### PR TITLE
Revert "build(deps): bump axios from 0.21.4 to 0.23.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1706,11 +1706,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
-      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.0"
       }
     },
     "axios-mock-adapter": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@types/parse-link-header": "^1.0.0",
-    "axios": "^0.23.0",
+    "axios": "^0.21.4",
     "parse-link-header": "^1.0.1"
   }
 }


### PR DESCRIPTION
Reverts devopness/devopness-sdk-js#440
Axios 0.23 introduce breaking changes on type definitions. Let's stick to 0.21 for now and wait for upcoming Axios versions to see if new changes are coming before updating our code base do meet the new type definitions.