### PR TITLE
ci: Set main branch and default dir in workflows

### DIFF
--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -3,7 +3,7 @@ on: # rebuild any PRs and main branch changes
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 defaults:
   run:

--- a/.github/workflows/sdk-javascript-release.yml
+++ b/.github/workflows/sdk-javascript-release.yml
@@ -2,8 +2,12 @@ name: SDK JavaScript - Release
 on:
   push:
     branches:
-      - master
+      - main
       - "*.x" # maintenance releases
+
+defaults:
+  run:
+    working-directory: packages/sdks/javascript
 
 jobs:
   release:


### PR DESCRIPTION
- [x] Set default directory in `SDK release` workflow
- [x] Use `main` branch in `Release` workflow
- [x] Use `main` branch in `CI` workflow