### PR TITLE
Feat: increase ApiBaseService timeout

### DIFF
--- a/packages/sdks/javascript/src/services/ApiBaseService.ts
+++ b/packages/sdks/javascript/src/services/ApiBaseService.ts
@@ -29,7 +29,7 @@ export class ApiBaseService {
     private static SDK_VERSION = '0.0.0-development';
 
     private defaultAxiosSettings: AxiosRequestConfig = {
-        timeout: 30000,
+        timeout: 300000,
         responseType: 'json',
         headers: {
             common: {


### PR DESCRIPTION
This is a simple modification increasing the timeout of the ApiBaseService.

The current timeout of 30s might generate some issues with low-speed connections as the content received by some requests can be pretty large, often exceeding the 30 seconds limit and cancelling the download of the content and generating an unexpected behaviour in the application.

So, as a solution, I am proposing to increase this time to 5 minutes to give enough time to download this large content.