### PR TITLE
ci: Auto remove labels when PR no longer changes a file

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -21,3 +21,4 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler-pr.yml
+          sync-label: true


### PR DESCRIPTION
Sometimes a PR modifies a file and is correctly labeled according to the changed files.
After feedback and review some files might no longer be part of the PR changes, so we'd better off removing the previously added labels.