### PR TITLE
chore: Add comment on safe usage of pull_request_target

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -2,6 +2,9 @@ name: Labeler - PR
 
 on:
   pull_request_target:
+    # triggers on `pull_request_target` as this is a fork-based repository
+    # for security reasons, `npm` or other code execution jobs must not
+    # be executed on this workflow
     types:
       - opened
       - reopened

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -3,6 +3,8 @@ name: "Lint PR"
 on:
   pull_request_target:
     # triggers on `pull_request_target` as this is a fork-based repository
+    # for security reasons, `npm` or other code execution jobs must not
+    # be executed on this workflow
     types:
       - opened
       - edited


### PR DESCRIPTION
Add comments to advise on security concerns when triggering actions on `pull_request_target`.
Reference: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ 