### PR TITLE
fix: Rename release branch to use `main`

### DIFF
--- a/packages/sdks/javascript/package.json
+++ b/packages/sdks/javascript/package.json
@@ -37,7 +37,7 @@
   "license": "MIT",
   "release": {
     "branches": [
-      "master"
+      "main"
     ]
   },
   "bugs": {


### PR DESCRIPTION
Update release branch after repo main branch being switched from `master` to `main`.