### PR TITLE
docs: some errors in docs have been fixed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you want to submit a bug fix or new feature, make sure that all tests are pas
 
 - Keep git commit messages clear and appropriate. Ideally, follow commit conventions described below.
 - Push your changes to your topic branch in your fork of the repo.
-- Submit a pull request from your topic branch to the master branch in the `@devponess/sdk-js` repository.
+- Submit a pull request from your topic branch to the main branch in the `@devponess/sdk-js` repository.
 - Be sure to tag any issues your pull request is taking care of / contributing to. \* Adding "Closes #123" to a pull request description will auto close the issue once the pull request is merged in.
 - Ensure the pull request passes all `checks`. If not, please fix the code until you get a green check mark on the PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you want to submit a bug fix or new feature, make sure that all tests are pas
 
 - Keep git commit messages clear and appropriate. Ideally, follow commit conventions described below.
 - Push your changes to your topic branch in your fork of the repo.
-- Submit a pull request from your topic branch to the main branch in the `@devponess/sdk-js` repository.
+- Submit a pull request from your topic branch to the main branch in the `@devopness/devopness` repository.
 - Be sure to tag any issues your pull request is taking care of / contributing to. \* Adding "Closes #123" to a pull request description will auto close the issue once the pull request is merged in.
 - Ensure the pull request passes all `checks`. If not, please fix the code until you get a green check mark on the PR.
 

--- a/packages/sdks/javascript/README.md
+++ b/packages/sdks/javascript/README.md
@@ -20,7 +20,7 @@ yarn add @devopness/sdk-js
 
 ### Initializing
 
-To initialize the usage of Devopness SDK just import it and create a new instance of `DevopnessApiClient` class.
+To initialize the usage of Devopness SDK, just import it and create a new instance of `DevopnessApiClient` class.
 
 Here is a generic simple example that can be used from `Node.js`, `TypeScript` or `Javascript` applications:
 
@@ -30,8 +30,8 @@ const devopnessApi = new DevopnessApiClient();
 ```
 
 The instance of `DevopnessApiClient` has properties to all services provided by the API.
-The name of the methods at services is the same as operation name in the documentation of the
-Devopness API. You can consult the URL of a endpoint to see the operation name. For instance
+The name of the methods at services is the same as the operation name in the documentation of the
+Devopness API. You can consult the URL of an endpoint to see the operation name. For instance,
 the URL to endpoint `POST /users/login` in the documentation is: `/#operation/login`
 
 ### Authenticating
@@ -49,7 +49,7 @@ async function authenticate(email, pass) {
 authenticate('user@email.com', 'secret-password');
 ```
 
-In the example above, `userTokens` is a instance of `ApiResponse` and the `data` property has the data requested from the API. See [ApiResponse.ts](https://github.com/devopness/devopness/blob/master/src/common/ApiResponse.ts) for reference.
+In the example above, `userTokens` is an instance of `ApiResponse` and the `data` property has the data requested from the API. See [ApiResponse.ts](https://github.com/devopness/devopness/blob/master/src/common/ApiResponse.ts) for reference.
 
 ### Invoking authentication protected endpoints
 Once an authentication token is set, any protected endpoint can be invoked.
@@ -74,7 +74,7 @@ getUserProfile();
 This package includes TypeScript declarations for every method.
 TypeScript versions `>= 3.8` are supported.
 
-Some methods in `Devopness SDK JavaScript` accept and return objects from the Devopness API. The type declarations for these objects will always track the latest version of the API. Therefore, if you'e using the latest version of this package you can rely on the Devopness API documentation for checking the input and return types of each API endpoint.
+Some methods in `Devopness SDK JavaScript` accept and return objects from the Devopness API. The type declarations for these objects will always track the latest version of the API. Therefore, if you'e using the latest version of this package, you can rely on the Devopness API documentation for checking the input and return types of each API endpoint.
 
 ## Building and testing
 To build and test the SDK locally, follow these steps:


### PR DESCRIPTION
This PR fixes:
- Some spelling errors that were found in the README.md file
- The use of the term `master`. GitHub currently use `main`