### PR TITLE
docs: Add an existing Server

### DIFF
--- a/.github/labeler-pr.yml
+++ b/.github/labeler-pr.yml
@@ -7,6 +7,9 @@ ci:
 applications:
   - applications/**/*
 
+docs:
+  - docs/**/*
+
 packages:
   - packages/**/*
 

--- a/docs/servers/add-existing-server.md
+++ b/docs/servers/add-existing-server.md
@@ -29,4 +29,4 @@ links:
 12. Log into your server as the `root` user
 13. Paste the command that has been copied to the clipboard and run it
 14. A message will be displayed in the terminal window when the server is connected to Devopness
-15. Get back to Devopness and start managing your server! :)
+15. On Devopness, once the server is displayed as `Connected`, it's been added to the selected environment

--- a/docs/servers/add-existing-server.md
+++ b/docs/servers/add-existing-server.md
@@ -1,0 +1,32 @@
+---
+title: Add an existing Server
+intro: If you have servers provisioned manually or by other processes you can still connect them to your Devopness account and take the most of the Devopness infrastructure management features.
+links:
+    overview:
+    quickstart:
+    previous:
+    next:
+    guides:
+    related:
+    featured:
+---
+
+# Add an existing Server
+1. On Devopness, navigate to a project then select an environment
+2. If there's no other server in the selected environment, just click `Add Server`
+3. If a list of resource cards is displayed, find the `Servers` card
+4. Click `View` in the `Servers` card to see a list of existing `Servers`
+5. On the upper-right corner of the list click `ADD SERVER`
+6. On the `Cloud Provider` drop-down menu choose `VPS/Self Hosted`
+7. Provide the `Public IP address` of your existing server
+6. Enter the `SSH Port` to be used to connect to the server
+7. Click `NEXT`
+8. Follow the prompts to complete the configuration of the new `Server`
+9. Click `CONFIRM`
+    - If you see a message saying `Error establishing a SSH connection to server`, please verify if the IP address and SSH port used are correct and if external SSH connections are allowed on this server
+10. After the `Server` is added you will be redirected to the `Connect` page
+11. Find the `Command to connect` field and click `Copy to clipboard`
+12. Log into your server as the `root` user
+13. Paste the command that has been copied to the clipboard and run it
+14. A message will be displayed in the terminal window when the server is connected to Devopness
+15. Get back to Devopness and start managing your server! :)

--- a/docs/servers/add-existing-server.md
+++ b/docs/servers/add-existing-server.md
@@ -20,6 +20,7 @@ links:
 6. On the `Cloud Provider` drop-down menu choose `VPS/Self Hosted`
 7. Provide the `Public IP address` of your existing server
 6. Enter the `SSH Port` to be used to connect to the server
+> Note: we do not recommend connecting servers that are already being used in production. Server's existing configuration will be lost and replaced by Devopness during the server setup process
 7. Click `NEXT`
 8. Follow the prompts to complete the configuration of the new `Server`
 9. Click `CONFIRM`

--- a/docs/servers/add-existing-server.md
+++ b/docs/servers/add-existing-server.md
@@ -1,6 +1,6 @@
 ---
 title: Add an existing Server
-intro: If you have servers provisioned manually or by other processes you can still connect them to your Devopness account and take the most of the Devopness infrastructure management features.
+intro: If you have servers provisioned outside of your desired environment on Devopness, you can still connect them to your Devopness account and take the most of the Devopness infrastructure management features.
 links:
     overview:
     quickstart:

--- a/docs/servers/add-existing-server.md
+++ b/docs/servers/add-existing-server.md
@@ -28,5 +28,5 @@ links:
 11. Find the `Command to connect` field and click `Copy to clipboard`
 12. Log into your server as the `root` user
 13. Paste the command that has been copied to the clipboard and run it
-14. A message will be displayed in the terminal window when the server is connected to Devopness
+14. A message will be displayed in the terminal window when the server connect command is successfully completed
 15. On Devopness, once the server is displayed as `Connected`, it's been added to the selected environment

--- a/docs/servers/index.md
+++ b/docs/servers/index.md
@@ -1,0 +1,12 @@
+---
+title: Servers
+intro: Learn how to provision servers on multiple cloud providers and also how to connect existing servers to Devopness.
+links:
+    overview:
+    quickstart:
+    previous:
+    next:
+    guides:
+    related:
+    featured:
+---

--- a/docs/ssh-keys/add-ssh-key.md
+++ b/docs/ssh-keys/add-ssh-key.md
@@ -15,7 +15,7 @@ links:
 # Add an SSH key
 1. On Devopness, navigate to a project then select an environment
 2. Find the `SSH Keys` card
-3. Click `View` in the `SSH Keys` card to see a list of existing SSH Keys
+3. Click `View` in the `SSH Keys` card to see a list of existing `SSH Keys`
 4. On the upper-right corner of the list click `ADD SSH KEY`
 5. Provide a name to the `SSH Key` being added. For example, "Company Laptop"
 6. Paste in your public key

--- a/docs/ssh-keys/remove-ssh-key.md
+++ b/docs/ssh-keys/remove-ssh-key.md
@@ -15,7 +15,7 @@ links:
 # Remove an SSH key
 1. On Devopness, navigate to a project then select an environment
 2. Find the `SSH Keys` card
-3. Click the `View` in the `SSH Keys` card to see a list of existing SSH Keys
+3. Click the `View` in the `SSH Keys` card to see a list of existing `SSH Keys`
 4. In the list of keys find the key you want to remove and click `DETAILS`
 5. On the upper-right corner of the key details view click `REMOVE`
 6. Follow the instructions in the delete form then click `DELETE`


### PR DESCRIPTION
- [x] Add instructions on how to `Add an existing Server`
- [x] Add landing page for `Server` resource docs
- [x] Fix `SSH keys` docs, to ensure resource name is always highlighted
- [x] ci: Auto add `docs` label on documentation changes