### PR TITLE
fix: Fix `GET /applications/{id}/hooks` summary

### DIFF
--- a/packages/sdks/javascript/src/api/spec.json
+++ b/packages/sdks/javascript/src/api/spec.json
@@ -493,7 +493,7 @@
     },
     "/applications/{application_id}/hooks": {
       "get": {
-        "summary": "Returns a list of all incoming hooks belonging to an application",
+        "summary": "Returns a list of all hooks belonging to an application",
         "operationId": "listApplicationHooks",
         "tags": [
           "Applications - Hooks"


### PR DESCRIPTION
This endpoint actually returns all hooks, both incoming and outgoing.