### PR TITLE
fix: include created by user in pipeline type

### DIFF
--- a/packages/sdks/javascript/src/api/generated/models/pipeline.ts
+++ b/packages/sdks/javascript/src/api/generated/models/pipeline.ts
@@ -13,6 +13,7 @@
 
 
 import { PipelineStep } from './pipeline-step';
+import { UserRelation } from './user-relation'
 
 /**
  * 
@@ -51,11 +52,11 @@ export interface Pipeline {
      */
     project_id: number;
     /**
-     * id of the user responsible for creating the pipeline
-     * @type {number}
-     * @memberof Pipeline
+     * 
+     * @type {UserRelation}
+     * @memberof Environment
      */
-    created_by: number;
+    created_by_user: UserRelation;
     /**
      * 
      * @type {Array<PipelineStep>}


### PR DESCRIPTION
After the API update, the Pipeline typing no longer agrees with the values returned by the API. So I suggest this fix, changing `created_by` to `created_by_user` in Pipeline typing.