### PR TITLE
docs: update "Add AWS Credential" instructions

### DIFF
--- a/docs/cloud-provider-credentials/add-cloud-provider-credential-aws.md
+++ b/docs/cloud-provider-credentials/add-cloud-provider-credential-aws.md
@@ -17,7 +17,7 @@ links:
 1. Type the user name for the new user
     > Tip: you might want to name the user as `devopness` to make it easier to track its activities
 1. Click `Next: Permissions`
-1. In the `Set Permissions` step click `Attach existing policies directly`
+1. In the `Set Permissions` step click `Attach policies directly`
 1. Search and select the policies `AmazonEC2FullAccess` and `IAMReadOnlyAccess`
 1. Follow the prompts then click `Create user`
 1. In the `Users` list, click the username link of the user recently created

--- a/docs/cloud-provider-credentials/add-cloud-provider-credential-aws.md
+++ b/docs/cloud-provider-credentials/add-cloud-provider-credential-aws.md
@@ -16,11 +16,14 @@ links:
 1. In the navigation pane on the left side, choose `Users` and then choose `Add users`
 1. Type the user name for the new user
     > Tip: you might want to name the user as `devopness` to make it easier to track its activities
-1. Check the option `Access key - Programmatic access`
-1. Uncheck the option `Password - AWS Management Console access`
 1. Click `Next: Permissions`
 1. In the `Set Permissions` step click `Attach existing policies directly`
 1. Search and select the policies `AmazonEC2FullAccess` and `IAMReadOnlyAccess`
 1. Follow the prompts then click `Create user`
+1. In the `Users` list, click the username link of the user recently created
+1. Click `Security credentials`
+1. In this page, search for `Access keys` section and click `Create access key`
+1. Choose `Other` and click `Next`
+1. Click `Create access key`
 1. Copy the values of `Access key ID` and `Secret access key`
 1. To add the copied credentials to Devopness see [Add a Cloud Provider Credential](../add-cloud-provider-credential)


### PR DESCRIPTION
Update instructions on how to generate security credentials

The current AWS IAM console doesn't have the options listed in the docs, as per the image below

![01](https://user-images.githubusercontent.com/33532177/221748037-0b663d93-6333-47e9-b943-8ebbd7f9290e.png)

So the new workflow to generate access keys using the IAM console is described in the [AWS IAM docs: Managing access keys (console)](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey), in the section "To create, modify, or delete the access keys of another IAM user (console)"