### PR TITLE
docs: improved instructions to install xcode in macOS

### DIFF
--- a/packages/sdks/javascript/README.md
+++ b/packages/sdks/javascript/README.md
@@ -83,7 +83,11 @@ To build and test the SDK locally, [**fork this repository**](https://github.com
 #### Pre-requisites
 - [Docker](https://www.docker.com/products/docker-desktop/)
 - [make](https://www.gnu.org/software/make/)
-  - `make` is pre-installed in most Linux systems. In `macOS` it is included as part of the `Xcode` command line utils
+  - `make` is pre-installed in most Linux systems.
+  - In `macOS` it is included as part of the `Xcode` command line utils. It can be installed with the homebrew installation or the follow command:
+  ```
+  xcode-select --install
+  ```
 ### Setup and run in local environment
 #### 1. Build Docker Image
 ```

--- a/packages/sdks/javascript/README.md
+++ b/packages/sdks/javascript/README.md
@@ -84,7 +84,7 @@ To build and test the SDK locally, [**fork this repository**](https://github.com
 - [Docker](https://www.docker.com/products/docker-desktop/)
 - [make](https://www.gnu.org/software/make/)
   - `make` is pre-installed in most Linux systems.
-  - In `macOS` it is included as part of the `Xcode` command line utils. It can be installed with the homebrew installation or the follow command:
+  - In `macOS` it is included as part of the `Xcode` command line utils. It can be installed with the following command:
   ```
   xcode-select --install
   ```


### PR DESCRIPTION
A simple alteration to help macOS users to install Xcode command line.