### PR TITLE
feat: Define onTokenExpired event

### DIFF
--- a/packages/sdks/javascript/README.md
+++ b/packages/sdks/javascript/README.md
@@ -40,9 +40,7 @@ To authenticate, just invoke the `login` method on the `users` service:
 
 ```javascript
 async function authenticate(email, pass) {
-  const userTokens = await devopnessApi.users.loginUser({ email: email, password: pass });
-  // The `accessToken` must be set every time a token is obtained or refreshed.
-  devopnessApi.accessToken = userTokens.data.access_token;
+  await devopnessApi.users.loginUser({ email: email, password: pass });
 }
 
 // invoke the authentication method

--- a/packages/sdks/javascript/README.md
+++ b/packages/sdks/javascript/README.md
@@ -26,7 +26,12 @@ Here is a generic simple example that can be used from `Node.js`, `TypeScript` o
 
 ```javascript
 import { DevopnessApiClient } from '@devopness/sdk-js'
-const devopnessApi = new DevopnessApiClient();
+// a callback for when the accessToken expires can be defined. Whenever a refresh
+// needs to be done this function will be called.
+const configuration = {
+  callbacks: { onTokenExpired: refreshToken => console.log("Doing something with refreshToken") }
+}
+const devopnessApi = new DevopnessApiClient(configuration);
 ```
 
 The instance of `DevopnessApiClient` has properties to all services provided by the API.

--- a/packages/sdks/javascript/src/DevopnessApiClient.ts
+++ b/packages/sdks/javascript/src/DevopnessApiClient.ts
@@ -90,23 +90,4 @@ export class DevopnessApiClient {
     this.users = new UserService();
     this.variables = new VariableService();
   }
-
-  public get accessToken(): string {
-    return ApiBaseService.accessToken;
-  }
-
-  public set accessToken(accessToken: string) {
-    const MIN_TOKEN_LENGHT = 100;
-
-    /**
-     * As a complete access token validation rule might be too much to be implemented here, we
-     * at least check for min length and return a substring of it to help users identify the
-     * issue when first initializing this SDK from their apps
-     */
-    if (accessToken && accessToken.length < MIN_TOKEN_LENGHT) {
-      throw new Error(`"${accessToken.substring(0, 10)} ..." doesn't seem to be a valid access token issued by Devopness API.`);
-    }
-
-    ApiBaseService.accessToken = accessToken;
-  }
 }

--- a/packages/sdks/javascript/src/services/ApiBaseService.ts
+++ b/packages/sdks/javascript/src/services/ApiBaseService.ts
@@ -134,7 +134,7 @@ export class ApiBaseService {
             : ApiBaseService._accessTokenExpiresAt;
     }
 
-    private isTokenExpired(response: any): boolean {
+    private isTokenExpired(response: AxiosResponse | undefined): boolean {
         return response?.status === 401 && Date.now() > ApiBaseService._accessTokenExpiresAt;
     }
 

--- a/packages/sdks/javascript/tests/Exceptions.spec.ts
+++ b/packages/sdks/javascript/tests/Exceptions.spec.ts
@@ -3,9 +3,11 @@ import MockAdapter from 'axios-mock-adapter';
 
 import { DevopnessApiClient } from '../src/DevopnessApiClient'
 import { ApiError, NetworkError } from '../src/common/Exceptions';
+import { ConfigurationOptions } from '../src/services/ApiBaseService';
 
 const reqMock = new MockAdapter(axios)
-const apiClient = new DevopnessApiClient();
+const options = { callbacks: { onTokenExpired: (data: any) => console.log(data) } } as unknown as ConfigurationOptions
+const apiClient = new DevopnessApiClient(options);
 
 test("200 response shouldn't reject", async () => {
   expect.assertions(0);


### PR DESCRIPTION
## Description of change
Hello there,

In this PR, two main changes are introduced:
1) A callback handler for expired access token is incorporated into the client. 
2) The need for a client to manually set the `accessToken` is removed and is instead now done inside the code, together with the setting of `refreshToken` and `expiresAt`

**NOTE: This PR is still in draft because I am unsure of the approach to set the `accessToken`, `refreshToken` and `expiresAt`. I think this is internal knowledge of the SDK and should be handle there, however, the previous method to set the `accessToken` by the client existed, therefore I am a bit confused as to which approach to follow. Also, by removing the getter and setter of `accessToken`, a breaking change would be introduced.**

## Issues resolved by this PR

This PR solves #25 
