### PR TITLE
docs: create "add a linked ssh key", "deploy ssh key" articles and modify "link ssh key"

### DIFF
--- a/docs/ssh-keys/add-ssh-key.md
+++ b/docs/ssh-keys/add-ssh-key.md
@@ -7,7 +7,7 @@ links:
     previous:
         - /docs/ssh-keys/create-ssh-key-pair
     next:
-        - /docs/servers/ssh-into-server
+        - /docs/ssh-keys/link-ssh-key
     guides:
     related:
         - /docs/ssh-keys/create-ssh-key-pair

--- a/docs/ssh-keys/deploy-ssh-key.md
+++ b/docs/ssh-keys/deploy-ssh-key.md
@@ -12,7 +12,7 @@ links:
     related:
     featured:
 required_permissions:
-    - application:pipeline_run
+    - application:deploy
 ---
 
 1. On Devopness, navigate to a project then select an environment

--- a/docs/ssh-keys/deploy-ssh-key.md
+++ b/docs/ssh-keys/deploy-ssh-key.md
@@ -20,6 +20,6 @@ required_permissions:
 1. Click `View` in the `SSH Keys` card to see a list of existing `SSH Keys`
 1. Click `DETAILS` on the SSH key you want to deploy
 1. On the upper-right corner of the SSH key details view, click `DEPLOY`
-1. Choose the pipeline to be deployed, then click `Next`
+1. Choose a deploy pipeline to be run, then click `Next`
 1. Review deploy information then click `DEPLOY`
 1. Wait for the `Ssh-key:Deploy` action to be completed

--- a/docs/ssh-keys/deploy-ssh-key.md
+++ b/docs/ssh-keys/deploy-ssh-key.md
@@ -21,5 +21,4 @@ required_permissions:
 1. Click `DEPLOY` on the SSH Key you want to deploy
 1. Choose the pipeline to be deployed, then click `Next`
 1. Review deploy information then click `Confirm`
-   > A notification popup will be displayed, confirming that the deployment has been triggered
 1. Wait for the `Ssh-key:Deploy` action to be completed

--- a/docs/ssh-keys/deploy-ssh-key.md
+++ b/docs/ssh-keys/deploy-ssh-key.md
@@ -1,0 +1,25 @@
+---
+title: Deploy SSH Key
+intro: Deploy your SSH Keys to each of the servers you want the keys on.
+links:
+    overview:
+    quickstart:
+    previous:
+        - /docs/ssh-keys/link-ssh-key
+    next:
+        - /docs/servers/ssh-into-server
+    guides:
+    related:
+    featured:
+required_permissions:
+    - application:pipeline_run
+---
+
+1. On Devopness, navigate to a project then select an environment
+1. Find the `SSH Keys` card
+1. Click `View` in the `SSH Keys` card to see a list of existing `SSH Keys`
+1. Click `DEPLOY` on the SSH Key you want to deploy
+1. Choose the branch and the pipeline to be deployed, then click `Next`
+1. Review deploy information then click `Confirm`
+   > A notification popup will be displayed, confirming that the deployment has been triggered
+1. Wait for the `Ssh-key:Deploy` action to be completed

--- a/docs/ssh-keys/deploy-ssh-key.md
+++ b/docs/ssh-keys/deploy-ssh-key.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy SSH Key
-intro: Deploy your SSH Keys to each of the servers you want the keys on.
+intro: Deploy your SSH Keys to each of the servers you want to give access to using those keys.
 links:
     overview:
     quickstart:

--- a/docs/ssh-keys/deploy-ssh-key.md
+++ b/docs/ssh-keys/deploy-ssh-key.md
@@ -18,7 +18,8 @@ required_permissions:
 1. On Devopness, navigate to a project then select an environment
 1. Find the `SSH Keys` card
 1. Click `View` in the `SSH Keys` card to see a list of existing `SSH Keys`
-1. Click `DEPLOY` on the SSH Key you want to deploy
+1. Click `DETAILS` on the SSH key you want to deploy
+1. On the upper-right corner of the SSH key details view, click `DEPLOY`
 1. Choose the pipeline to be deployed, then click `Next`
 1. Review deploy information then click `DEPLOY`
 1. Wait for the `Ssh-key:Deploy` action to be completed

--- a/docs/ssh-keys/deploy-ssh-key.md
+++ b/docs/ssh-keys/deploy-ssh-key.md
@@ -19,7 +19,7 @@ required_permissions:
 1. Find the `SSH Keys` card
 1. Click `View` in the `SSH Keys` card to see a list of existing `SSH Keys`
 1. Click `DEPLOY` on the SSH Key you want to deploy
-1. Choose the branch and the pipeline to be deployed, then click `Next`
+1. Choose the pipeline to be deployed, then click `Next`
 1. Review deploy information then click `Confirm`
    > A notification popup will be displayed, confirming that the deployment has been triggered
 1. Wait for the `Ssh-key:Deploy` action to be completed

--- a/docs/ssh-keys/deploy-ssh-key.md
+++ b/docs/ssh-keys/deploy-ssh-key.md
@@ -12,7 +12,7 @@ links:
     related:
     featured:
 required_permissions:
-    - application:deploy
+    - ssh-key:deploy
 ---
 
 1. On Devopness, navigate to a project then select an environment

--- a/docs/ssh-keys/deploy-ssh-key.md
+++ b/docs/ssh-keys/deploy-ssh-key.md
@@ -20,5 +20,5 @@ required_permissions:
 1. Click `View` in the `SSH Keys` card to see a list of existing `SSH Keys`
 1. Click `DEPLOY` on the SSH Key you want to deploy
 1. Choose the pipeline to be deployed, then click `Next`
-1. Review deploy information then click `Confirm`
+1. Review deploy information then click `DEPLOY`
 1. Wait for the `Ssh-key:Deploy` action to be completed

--- a/docs/ssh-keys/link-ssh-key.md
+++ b/docs/ssh-keys/link-ssh-key.md
@@ -1,5 +1,5 @@
 ---
-title: Add a Linked SSH Key
+title: Link an SSH Key to a Server
 intro: Link an SSH Key to a server to select which SSH keys a server can have deployed.
 links:
     overview:

--- a/docs/ssh-keys/link-ssh-key.md
+++ b/docs/ssh-keys/link-ssh-key.md
@@ -16,8 +16,8 @@ links:
 1. On Devopness, navigate to a project then select an environment
 1. Find the `SSH Keys` card
 1. Click `View` in the `SSH Keys` card to see a list of existing `SSH Keys`
-1. Click `DETAILS` on the SSH Key you want to link to a server
-1. On the upper-right corner of the application details view, click `...`
+1. Click `DETAILS` on the SSH key you want to link to a server
+1. On the upper-right corner of the SSH key details view, click `...`
 1. Use the drop-down menu to choose `Linked resources`
 1. On the upper-right corner of the `Linked resources` list, click `LINK TO`. On the drop-down menu, click on `Servers`
 1. Follow the prompts then click `Link`

--- a/docs/ssh-keys/link-ssh-key.md
+++ b/docs/ssh-keys/link-ssh-key.md
@@ -19,6 +19,7 @@ links:
 1. Click `DETAILS` on the SSH key you want to link to a server
 1. On the upper-right corner of the SSH key details view, click `...`
 1. Use the drop-down menu to choose `Linked resources`
-1. On the upper-right corner of the `Linked resources` list, click `LINK TO`. On the drop-down menu, click on `Servers`
+1. On the upper-right corner of the `Linked resources` list, click `LINK TO`
+1. Use the drop-down menu to choose `Servers`
 1. Follow the prompts then click `Link`
 1. In the `Linked Resource` list, the recently linked server can be seen in the `DEPENDS ON` table

--- a/docs/ssh-keys/link-ssh-key.md
+++ b/docs/ssh-keys/link-ssh-key.md
@@ -1,0 +1,24 @@
+---
+title: Add a Linked SSH Key
+intro: Link an SSH Key to a server to select which SSH keys a server can have deployed.
+links:
+    overview:
+    quickstart:
+    previous:
+        - /docs/ssh-keys/add-ssh-key
+    next:
+        - /docs/ssh-keys/deploy-ssh-key
+    guides:
+    related:
+    featured:
+---
+
+1. On Devopness, navigate to a project then select an environment
+1. Find the `SSH Keys` card
+1. Click `View` in the `SSH Keys` card to see a list of existing `SSH Keys`
+1. Click `DETAILS` on the SSH Key you want to link to a server
+1. On the upper-right corner of the application details view, click `...`
+1. Use the drop-down menu to choose `Linked resources`
+1. On the upper-right corner of the `Linked resources` list, click `LINK TO`. On the drop-down menu, click on `Servers`
+1. Follow the prompts then click `Link`
+1. In the `Linked Resource` list, the recently linked server can be seen in the `DEPENDS ON` table


### PR DESCRIPTION
## Description of change
Creates two new articles: "Link SSH Key" and "Deploy SSH Key". Modifies "next" link of "Add an SSH Key" to point to new "Link SSH Key" article. The goal is to clarify that after the creation of an SSH Key, it has to be deployed to a server. But first, the server must be linked to the key.
