### PR TITLE
feat: add deprecated to code template generator

### DIFF
--- a/packages/sdks/javascript/Makefile
+++ b/packages/sdks/javascript/Makefile
@@ -22,7 +22,7 @@ help: ## Show this help.
 
 npm-ci: ## Install project dependencies without updating `package-lock.json`
 	$(info NPM - Installing dependencies ...)
-	@docker run --rm -v $(PWD):/$(WORKDIR) --name npm_install $(IMAGE):$(TAG) npm ci
+	@docker run --rm -v $(PWD):/$(WORKDIR) --name npm_ci $(IMAGE):$(TAG) npm ci
 
 npm-install: ## Install project dependencies and update `package-lock.json`
 	$(info NPM - Installing dependencies ...)

--- a/packages/sdks/javascript/Makefile
+++ b/packages/sdks/javascript/Makefile
@@ -11,7 +11,7 @@ build-image: ## Build Docker Image
 	$(info Docker - Building Image ...)
 	@docker build -f Dockerfile-dev -t $(IMAGE):$(TAG) .
 
-build-sdk-js: ## Build Javascript SDK
+build-sdk-js: build-image npm-ci ## Build Javascript SDK
 	$(info Docker - Building Javascript SDK ...)
 	@docker run --rm -v $(PWD):/$(WORKDIR) --name sdk-js-build $(IMAGE):$(TAG) npm run build
 
@@ -20,7 +20,11 @@ help: ## Show this help.
 	@echo Devopness SDK - Javascript
 	@awk 'BEGIN {FS = ": .*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[$$()% 0-9a-zA-Z_-]+(\\:[$$()% 0-9a-zA-Z_-]+)*:.*?##/ { gsub(/\\:/,":", $$1); printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-npm-ci: ## Install project dependencies
+npm-ci: ## Install project dependencies without updating `package-lock.json`
+	$(info NPM - Installing dependencies ...)
+	@docker run --rm -v $(PWD):/$(WORKDIR) --name npm_install $(IMAGE):$(TAG) npm ci
+
+npm-install: ## Install project dependencies and update `package-lock.json`
 	$(info NPM - Installing dependencies ...)
 	@docker run --rm -v $(PWD):/$(WORKDIR) --name npm_install $(IMAGE):$(TAG) npm install
 

--- a/packages/sdks/javascript/package-lock.json
+++ b/packages/sdks/javascript/package-lock.json
@@ -14,7 +14,7 @@
         "parse-link-header": "^2.0.0"
       },
       "devDependencies": {
-        "@openapitools/openapi-generator-cli": "^2.0.2",
+        "@openapitools/openapi-generator-cli": "^2.7.0",
         "@types/jest": "^27.0.1",
         "@typescript-eslint/eslint-plugin": "^5.31.0",
         "axios-mock-adapter": "^1.18.1",

--- a/packages/sdks/javascript/package.json
+++ b/packages/sdks/javascript/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/devopness/devopness#readme",
   "devDependencies": {
-    "@openapitools/openapi-generator-cli": "^2.0.2",
+    "@openapitools/openapi-generator-cli": "^2.7.0",
     "@types/jest": "^27.0.1",
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "axios-mock-adapter": "^1.18.1",

--- a/packages/sdks/javascript/src/api/generated/apis/actions-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/actions-api.ts
@@ -32,7 +32,7 @@ export class ActionsApiService extends ApiBaseService {
         if (actionId === null || actionId === undefined) {
             throw new ArgumentNullException('actionId', 'getAction');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/actions/{action_id}' + (queryString? `?${queryString}` : '');
@@ -48,7 +48,7 @@ export class ActionsApiService extends ApiBaseService {
      * @param {number} [perPage] Number of items returned per page
      */
     public async listActions(page?: number, perPage?: number): Promise<ApiResponse<Array<ActionRelation>>> {
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {
@@ -80,7 +80,7 @@ export class ActionsApiService extends ApiBaseService {
         if (resourceType === null || resourceType === undefined) {
             throw new ArgumentNullException('resourceType', 'listActionsByResourceType');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {
@@ -112,7 +112,7 @@ export class ActionsApiService extends ApiBaseService {
         if (targetResourceType === null || targetResourceType === undefined) {
             throw new ArgumentNullException('targetResourceType', 'listActionsByTargetResourceType');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {
@@ -138,7 +138,7 @@ export class ActionsApiService extends ApiBaseService {
         if (actionId === null || actionId === undefined) {
             throw new ArgumentNullException('actionId', 'retryAction');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/actions/{action_id}/retry' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/actions-logs-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/actions-logs-api.ts
@@ -37,7 +37,7 @@ export class ActionsLogsApiService extends ApiBaseService {
         if (actionTargetId === null || actionTargetId === undefined) {
             throw new ArgumentNullException('actionTargetId', 'getActionLog');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/actions/{action_id}/targets/{action_target_id}/steps/{action_step_order}/logs' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/applications-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/applications-api.ts
@@ -31,7 +31,7 @@ export class ApplicationsApiService extends ApiBaseService {
         if (applicationId === null || applicationId === undefined) {
             throw new ArgumentNullException('applicationId', 'deleteApplication');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/applications/{application_id}' + (queryString? `?${queryString}` : '');
@@ -49,7 +49,7 @@ export class ApplicationsApiService extends ApiBaseService {
         if (applicationId === null || applicationId === undefined) {
             throw new ArgumentNullException('applicationId', 'getApplication');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/applications/{application_id}' + (queryString? `?${queryString}` : '');
@@ -71,7 +71,7 @@ export class ApplicationsApiService extends ApiBaseService {
         if (applicationUpdate === null || applicationUpdate === undefined) {
             throw new ArgumentNullException('applicationUpdate', 'updateApplication');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/applications/{application_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/applications-deployments-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/applications-deployments-api.ts
@@ -34,7 +34,7 @@ export class ApplicationsDeploymentsApiService extends ApiBaseService {
         if (deploymentApplicationCreate === null || deploymentApplicationCreate === undefined) {
             throw new ArgumentNullException('deploymentApplicationCreate', 'addApplicationDeployment');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/applications/{application_id}/deployments' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/applications-hooks-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/applications-hooks-api.ts
@@ -31,7 +31,7 @@ export class ApplicationsHooksApiService extends ApiBaseService {
         if (applicationId === null || applicationId === undefined) {
             throw new ArgumentNullException('applicationId', 'listApplicationHooks');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/applications-sslcertificates-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/applications-sslcertificates-api.ts
@@ -36,7 +36,7 @@ export class ApplicationsSSLCertificatesApiService extends ApiBaseService {
         if (sslCertificateApplicationCreate === null || sslCertificateApplicationCreate === undefined) {
             throw new ArgumentNullException('sslCertificateApplicationCreate', 'addApplicationSslCertificate');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/applications/{application_id}/ssl-certificates' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class ApplicationsSSLCertificatesApiService extends ApiBaseService {
         if (applicationId === null || applicationId === undefined) {
             throw new ArgumentNullException('applicationId', 'listApplicationSslCertificates');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/applications-variables-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/applications-variables-api.ts
@@ -25,6 +25,7 @@ import { VariableRelation } from '../../generated/models';
 export class ApplicationsVariablesApiService extends ApiBaseService {
     /**
      * 
+     * @deprecated
      * @summary Create a new variable linked to an application
      * @param {number} applicationId The ID of the application.
      * @param {VariableApplicationCreate} variableApplicationCreate A JSON object containing the resource data
@@ -36,7 +37,7 @@ export class ApplicationsVariablesApiService extends ApiBaseService {
         if (variableApplicationCreate === null || variableApplicationCreate === undefined) {
             throw new ArgumentNullException('variableApplicationCreate', 'addApplicationVariable');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/applications/{application_id}/variables' + (queryString? `?${queryString}` : '');
@@ -47,6 +48,7 @@ export class ApplicationsVariablesApiService extends ApiBaseService {
 
     /**
      * 
+     * @deprecated
      * @summary Return a list of variables belonging to an application
      * @param {number} applicationId The ID of the application.
      * @param {number} [page] Number of the page to be retrieved
@@ -56,7 +58,7 @@ export class ApplicationsVariablesApiService extends ApiBaseService {
         if (applicationId === null || applicationId === undefined) {
             throw new ArgumentNullException('applicationId', 'listApplicationVariables');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/cloud-providers-credentials-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/cloud-providers-credentials-api.ts
@@ -36,7 +36,7 @@ export class CloudProvidersCredentialsApiService extends ApiBaseService {
         if (credentialCloudProviderCreate === null || credentialCloudProviderCreate === undefined) {
             throw new ArgumentNullException('credentialCloudProviderCreate', 'addCloudProviderCredential');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/cloud-providers/{cloud_provider_code}/credentials' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class CloudProvidersCredentialsApiService extends ApiBaseService {
         if (cloudProviderCode === null || cloudProviderCode === undefined) {
             throw new ArgumentNullException('cloudProviderCode', 'listCloudProviderCredentialsByCloudProviderCode');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/credentials-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/credentials-api.ts
@@ -30,7 +30,7 @@ export class CredentialsApiService extends ApiBaseService {
         if (credentialId === null || credentialId === undefined) {
             throw new ArgumentNullException('credentialId', 'deleteCredential');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/credentials/{credential_id}' + (queryString? `?${queryString}` : '');
@@ -48,7 +48,7 @@ export class CredentialsApiService extends ApiBaseService {
         if (credentialId === null || credentialId === undefined) {
             throw new ArgumentNullException('credentialId', 'getCredential');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/credentials/{credential_id}' + (queryString? `?${queryString}` : '');
@@ -64,7 +64,7 @@ export class CredentialsApiService extends ApiBaseService {
      * @param {number} [perPage] Number of items returned per page
      */
     public async listCredentials(page?: number, perPage?: number): Promise<ApiResponse<Array<CredentialRelation>>> {
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/cron-jobs-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/cron-jobs-api.ts
@@ -31,7 +31,7 @@ export class CronJobsApiService extends ApiBaseService {
         if (cronJobId === null || cronJobId === undefined) {
             throw new ArgumentNullException('cronJobId', 'deleteCronJob');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/cron-jobs/{cron_job_id}' + (queryString? `?${queryString}` : '');
@@ -49,7 +49,7 @@ export class CronJobsApiService extends ApiBaseService {
         if (cronJobId === null || cronJobId === undefined) {
             throw new ArgumentNullException('cronJobId', 'getCronJob');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/cron-jobs/{cron_job_id}' + (queryString? `?${queryString}` : '');
@@ -71,7 +71,7 @@ export class CronJobsApiService extends ApiBaseService {
         if (cronJobUpdate === null || cronJobUpdate === undefined) {
             throw new ArgumentNullException('cronJobUpdate', 'updateCronJob');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/cron-jobs/{cron_job_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/daemons-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/daemons-api.ts
@@ -33,7 +33,7 @@ export class DaemonsApiService extends ApiBaseService {
         if (daemonId === null || daemonId === undefined) {
             throw new ArgumentNullException('daemonId', 'deleteDaemon');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/daemons/{daemon_id}' + (queryString? `?${queryString}` : '');
@@ -51,7 +51,7 @@ export class DaemonsApiService extends ApiBaseService {
         if (daemonId === null || daemonId === undefined) {
             throw new ArgumentNullException('daemonId', 'getDaemon');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/daemons/{daemon_id}' + (queryString? `?${queryString}` : '');
@@ -73,7 +73,7 @@ export class DaemonsApiService extends ApiBaseService {
         if (daemonGetStatus === null || daemonGetStatus === undefined) {
             throw new ArgumentNullException('daemonGetStatus', 'getStatusDaemon');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/daemons/{daemon_id}/get-status' + (queryString? `?${queryString}` : '');
@@ -95,7 +95,7 @@ export class DaemonsApiService extends ApiBaseService {
         if (daemonRestart === null || daemonRestart === undefined) {
             throw new ArgumentNullException('daemonRestart', 'restartDaemon');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/daemons/{daemon_id}/restart' + (queryString? `?${queryString}` : '');
@@ -117,7 +117,7 @@ export class DaemonsApiService extends ApiBaseService {
         if (daemonUpdate === null || daemonUpdate === undefined) {
             throw new ArgumentNullException('daemonUpdate', 'updateDaemon');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/daemons/{daemon_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/environments-actions-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-actions-api.ts
@@ -31,7 +31,7 @@ export class EnvironmentsActionsApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'listEnvironmentActions');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {
@@ -63,7 +63,7 @@ export class EnvironmentsActionsApiService extends ApiBaseService {
         if (resourceType === null || resourceType === undefined) {
             throw new ArgumentNullException('resourceType', 'listEnvironmentActionsByResourceType');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/environments-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-api.ts
@@ -31,7 +31,7 @@ export class EnvironmentsApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'archiveEnvironment');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/archive' + (queryString? `?${queryString}` : '');
@@ -49,7 +49,7 @@ export class EnvironmentsApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'getEnvironment');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}' + (queryString? `?${queryString}` : '');
@@ -67,7 +67,7 @@ export class EnvironmentsApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'unarchiveEnvironment');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/unarchive' + (queryString? `?${queryString}` : '');
@@ -89,7 +89,7 @@ export class EnvironmentsApiService extends ApiBaseService {
         if (environmentUpdate === null || environmentUpdate === undefined) {
             throw new ArgumentNullException('environmentUpdate', 'updateEnvironment');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/environments-applications-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-applications-api.ts
@@ -36,7 +36,7 @@ export class EnvironmentsApplicationsApiService extends ApiBaseService {
         if (applicationEnvironmentCreate === null || applicationEnvironmentCreate === undefined) {
             throw new ArgumentNullException('applicationEnvironmentCreate', 'addEnvironmentApplication');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/applications' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class EnvironmentsApplicationsApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'listEnvironmentApplications');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/environments-cron-jobs-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-cron-jobs-api.ts
@@ -36,7 +36,7 @@ export class EnvironmentsCronJobsApiService extends ApiBaseService {
         if (cronJobEnvironmentCreate === null || cronJobEnvironmentCreate === undefined) {
             throw new ArgumentNullException('cronJobEnvironmentCreate', 'addEnvironmentCronJob');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/cron-jobs' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class EnvironmentsCronJobsApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'listEnvironmentCronJobs');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/environments-daemons-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-daemons-api.ts
@@ -36,7 +36,7 @@ export class EnvironmentsDaemonsApiService extends ApiBaseService {
         if (daemonEnvironmentCreate === null || daemonEnvironmentCreate === undefined) {
             throw new ArgumentNullException('daemonEnvironmentCreate', 'addEnvironmentDaemon');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/daemons' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class EnvironmentsDaemonsApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'listEnvironmentDaemons');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/environments-network-rules-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-network-rules-api.ts
@@ -36,7 +36,7 @@ export class EnvironmentsNetworkRulesApiService extends ApiBaseService {
         if (networkRuleEnvironmentCreate === null || networkRuleEnvironmentCreate === undefined) {
             throw new ArgumentNullException('networkRuleEnvironmentCreate', 'addEnvironmentNetworkRule');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/network-rules' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class EnvironmentsNetworkRulesApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'listEnvironmentNetworkRules');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/environments-networks-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-networks-api.ts
@@ -36,7 +36,7 @@ export class EnvironmentsNetworksApiService extends ApiBaseService {
         if (networkEnvironmentCreate === null || networkEnvironmentCreate === undefined) {
             throw new ArgumentNullException('networkEnvironmentCreate', 'addEnvironmentNetwork');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/networks' + (queryString? `?${queryString}` : '');
@@ -59,7 +59,7 @@ export class EnvironmentsNetworksApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'listEnvironmentNetworks');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, include_default_network: includeDefaultNetwork, provider_name: providerName, region: region, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/environments-servers-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-servers-api.ts
@@ -36,7 +36,7 @@ export class EnvironmentsServersApiService extends ApiBaseService {
         if (serverEnvironmentCreate === null || serverEnvironmentCreate === undefined) {
             throw new ArgumentNullException('serverEnvironmentCreate', 'addEnvironmentServer');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/servers' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class EnvironmentsServersApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'listEnvironmentServers');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/environments-services-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-services-api.ts
@@ -36,7 +36,7 @@ export class EnvironmentsServicesApiService extends ApiBaseService {
         if (serviceEnvironmentCreate === null || serviceEnvironmentCreate === undefined) {
             throw new ArgumentNullException('serviceEnvironmentCreate', 'addEnvironmentService');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/services' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class EnvironmentsServicesApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'listEnvironmentServices');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/environments-sshkeys-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-sshkeys-api.ts
@@ -36,7 +36,7 @@ export class EnvironmentsSSHKeysApiService extends ApiBaseService {
         if (sshKeyEnvironmentCreate === null || sshKeyEnvironmentCreate === undefined) {
             throw new ArgumentNullException('sshKeyEnvironmentCreate', 'addEnvironmentSshKey');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/ssh-keys' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class EnvironmentsSSHKeysApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'listEnvironmentSshKeys');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/environments-team-memberships-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-team-memberships-api.ts
@@ -31,7 +31,7 @@ export class EnvironmentsTeamMembershipsApiService extends ApiBaseService {
         if (environmentId === null || environmentId === undefined) {
             throw new ArgumentNullException('environmentId', 'listEnvironmentTeamMemberships');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/environments-teams-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/environments-teams-api.ts
@@ -38,7 +38,7 @@ export class EnvironmentsTeamsApiService extends ApiBaseService {
         if (teamEnvironmentLink === null || teamEnvironmentLink === undefined) {
             throw new ArgumentNullException('teamEnvironmentLink', 'linkTeamToEnvironment');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/teams/{team_id}/link' + (queryString? `?${queryString}` : '');
@@ -60,7 +60,7 @@ export class EnvironmentsTeamsApiService extends ApiBaseService {
         if (teamId === null || teamId === undefined) {
             throw new ArgumentNullException('teamId', 'unlinkTeamFromEnvironment');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/environments/{environment_id}/teams/{team_id}/unlink' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/hook-requests-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/hook-requests-api.ts
@@ -30,7 +30,7 @@ export class HookRequestsApiService extends ApiBaseService {
         if (hookRequestId === null || hookRequestId === undefined) {
             throw new ArgumentNullException('hookRequestId', 'getHookRequest');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/hook-requests/{hook_request_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/hooks-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/hooks-api.ts
@@ -36,7 +36,7 @@ export class HooksApiService extends ApiBaseService {
         if (hookType === null || hookType === undefined) {
             throw new ArgumentNullException('hookType', 'deleteHook');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/hooks/{hook_type}/{hook_id}' + (queryString? `?${queryString}` : '');
@@ -58,7 +58,7 @@ export class HooksApiService extends ApiBaseService {
         if (hookType === null || hookType === undefined) {
             throw new ArgumentNullException('hookType', 'getHook');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/hooks/{hook_type}/{hook_id}' + (queryString? `?${queryString}` : '');
@@ -76,7 +76,7 @@ export class HooksApiService extends ApiBaseService {
         if (hookId === null || hookId === undefined) {
             throw new ArgumentNullException('hookId', 'triggerHook');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/hooks/{hook_id}/trigger' + (queryString? `?${queryString}` : '');
@@ -102,7 +102,7 @@ export class HooksApiService extends ApiBaseService {
         if (hookUpdate === null || hookUpdate === undefined) {
             throw new ArgumentNullException('hookUpdate', 'updateHook');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/hooks/{hook_type}/{hook_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/hooks-requests-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/hooks-requests-api.ts
@@ -35,7 +35,7 @@ export class HooksRequestsApiService extends ApiBaseService {
         if (hookType === null || hookType === undefined) {
             throw new ArgumentNullException('hookType', 'listHookRequestsByHookType');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/network-rules-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/network-rules-api.ts
@@ -31,7 +31,7 @@ export class NetworkRulesApiService extends ApiBaseService {
         if (networkRuleId === null || networkRuleId === undefined) {
             throw new ArgumentNullException('networkRuleId', 'deleteNetworkRule');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/network-rules/{network_rule_id}' + (queryString? `?${queryString}` : '');
@@ -49,7 +49,7 @@ export class NetworkRulesApiService extends ApiBaseService {
         if (networkRuleId === null || networkRuleId === undefined) {
             throw new ArgumentNullException('networkRuleId', 'getNetworkRule');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/network-rules/{network_rule_id}' + (queryString? `?${queryString}` : '');
@@ -71,7 +71,7 @@ export class NetworkRulesApiService extends ApiBaseService {
         if (networkRuleUpdate === null || networkRuleUpdate === undefined) {
             throw new ArgumentNullException('networkRuleUpdate', 'updateNetworkRule');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/network-rules/{network_rule_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/networks-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/networks-api.ts
@@ -30,7 +30,7 @@ export class NetworksApiService extends ApiBaseService {
         if (networkId === null || networkId === undefined) {
             throw new ArgumentNullException('networkId', 'deleteNetwork');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/networks/{network_id}' + (queryString? `?${queryString}` : '');
@@ -48,7 +48,7 @@ export class NetworksApiService extends ApiBaseService {
         if (networkId === null || networkId === undefined) {
             throw new ArgumentNullException('networkId', 'getNetwork');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/networks/{network_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/networks-subnets-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/networks-subnets-api.ts
@@ -36,7 +36,7 @@ export class NetworksSubnetsApiService extends ApiBaseService {
         if (subnetNetworkCreate === null || subnetNetworkCreate === undefined) {
             throw new ArgumentNullException('subnetNetworkCreate', 'addNetworkSubnet');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/networks/{network_id}/subnets' + (queryString? `?${queryString}` : '');
@@ -58,7 +58,7 @@ export class NetworksSubnetsApiService extends ApiBaseService {
         if (networkId === null || networkId === undefined) {
             throw new ArgumentNullException('networkId', 'listNetworkSubnets');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, region: region, zone: zone, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/pipelines-actions-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/pipelines-actions-api.ts
@@ -36,7 +36,7 @@ export class PipelinesActionsApiService extends ApiBaseService {
         if (actionPipelineCreate === null || actionPipelineCreate === undefined) {
             throw new ArgumentNullException('actionPipelineCreate', 'addPipelineAction');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/pipelines/{pipeline_id}/actions' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class PipelinesActionsApiService extends ApiBaseService {
         if (pipelineId === null || pipelineId === undefined) {
             throw new ArgumentNullException('pipelineId', 'listPipelineActions');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/pipelines-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/pipelines-api.ts
@@ -41,7 +41,7 @@ export class PipelinesApiService extends ApiBaseService {
         if (pipelineCreate === null || pipelineCreate === undefined) {
             throw new ArgumentNullException('pipelineCreate', 'addPipeline');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/pipelines/{resource_type}/{resource_id}' + (queryString? `?${queryString}` : '');
@@ -59,7 +59,7 @@ export class PipelinesApiService extends ApiBaseService {
         if (pipelineId === null || pipelineId === undefined) {
             throw new ArgumentNullException('pipelineId', 'deletePipeline');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/pipelines/{pipeline_id}' + (queryString? `?${queryString}` : '');
@@ -77,7 +77,7 @@ export class PipelinesApiService extends ApiBaseService {
         if (pipelineId === null || pipelineId === undefined) {
             throw new ArgumentNullException('pipelineId', 'getPipeline');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/pipelines/{pipeline_id}' + (queryString? `?${queryString}` : '');
@@ -101,7 +101,7 @@ export class PipelinesApiService extends ApiBaseService {
         if (resourceType === null || resourceType === undefined) {
             throw new ArgumentNullException('resourceType', 'listPipelinesByResourceType');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {
@@ -131,7 +131,7 @@ export class PipelinesApiService extends ApiBaseService {
         if (pipelineUpdate === null || pipelineUpdate === undefined) {
             throw new ArgumentNullException('pipelineUpdate', 'updatePipeline');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/pipelines/{pipeline_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/pipelines-hooks-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/pipelines-hooks-api.ts
@@ -40,7 +40,7 @@ export class PipelinesHooksApiService extends ApiBaseService {
         if (hookPipelineCreate === null || hookPipelineCreate === undefined) {
             throw new ArgumentNullException('hookPipelineCreate', 'addPipelineHook');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/pipelines/{pipeline_id}/hooks/{hook_type}' + (queryString? `?${queryString}` : '');
@@ -60,7 +60,7 @@ export class PipelinesHooksApiService extends ApiBaseService {
         if (pipelineId === null || pipelineId === undefined) {
             throw new ArgumentNullException('pipelineId', 'listPipelineHooks');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/pipelines-steps-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/pipelines-steps-api.ts
@@ -36,7 +36,7 @@ export class PipelinesStepsApiService extends ApiBaseService {
         if (stepPipelineCreate === null || stepPipelineCreate === undefined) {
             throw new ArgumentNullException('stepPipelineCreate', 'addPipelineStep');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/pipelines/{pipeline_id}/steps' + (queryString? `?${queryString}` : '');
@@ -58,7 +58,7 @@ export class PipelinesStepsApiService extends ApiBaseService {
         if (stepId === null || stepId === undefined) {
             throw new ArgumentNullException('stepId', 'linkStepToPipeline');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/pipelines/{pipeline_id}/steps/{step_id}/link' + (queryString? `?${queryString}` : '');
@@ -80,7 +80,7 @@ export class PipelinesStepsApiService extends ApiBaseService {
         if (stepId === null || stepId === undefined) {
             throw new ArgumentNullException('stepId', 'unlinkStepFromPipeline');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/pipelines/{pipeline_id}/steps/{step_id}/unlink' + (queryString? `?${queryString}` : '');
@@ -106,7 +106,7 @@ export class PipelinesStepsApiService extends ApiBaseService {
         if (stepPipelineUpdate === null || stepPipelineUpdate === undefined) {
             throw new ArgumentNullException('stepPipelineUpdate', 'updatePipelineStep');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/pipelines/{pipeline_id}/steps/{step_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/projects-actions-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/projects-actions-api.ts
@@ -35,7 +35,7 @@ export class ProjectsActionsApiService extends ApiBaseService {
         if (resourceType === null || resourceType === undefined) {
             throw new ArgumentNullException('resourceType', 'listProjectActionsByResourceType');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/projects-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/projects-api.ts
@@ -33,7 +33,7 @@ export class ProjectsApiService extends ApiBaseService {
         if (projectCreate === null || projectCreate === undefined) {
             throw new ArgumentNullException('projectCreate', 'addProject');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/projects' + (queryString? `?${queryString}` : '');
@@ -51,7 +51,7 @@ export class ProjectsApiService extends ApiBaseService {
         if (projectId === null || projectId === undefined) {
             throw new ArgumentNullException('projectId', 'getProject');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/projects/{project_id}' + (queryString? `?${queryString}` : '');
@@ -67,7 +67,7 @@ export class ProjectsApiService extends ApiBaseService {
      * @param {number} [perPage] Number of items returned per page
      */
     public async listProjects(page?: number, perPage?: number): Promise<ApiResponse<Array<ProjectRelation>>> {
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {
@@ -97,7 +97,7 @@ export class ProjectsApiService extends ApiBaseService {
         if (projectUpdate === null || projectUpdate === undefined) {
             throw new ArgumentNullException('projectUpdate', 'updateProject');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/projects/{project_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/projects-archived-environments-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/projects-archived-environments-api.ts
@@ -32,7 +32,7 @@ export class ProjectsArchivedEnvironmentsApiService extends ApiBaseService {
         if (projectId === null || projectId === undefined) {
             throw new ArgumentNullException('projectId', 'listProjectArchivedEnvironments');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/projects-environments-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/projects-environments-api.ts
@@ -36,7 +36,7 @@ export class ProjectsEnvironmentsApiService extends ApiBaseService {
         if (environmentProjectCreate === null || environmentProjectCreate === undefined) {
             throw new ArgumentNullException('environmentProjectCreate', 'addProjectEnvironment');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/projects/{project_id}/environments' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class ProjectsEnvironmentsApiService extends ApiBaseService {
         if (projectId === null || projectId === undefined) {
             throw new ArgumentNullException('projectId', 'listProjectEnvironments');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/projects-roles-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/projects-roles-api.ts
@@ -36,7 +36,7 @@ export class ProjectsRolesApiService extends ApiBaseService {
         if (roleProjectCreate === null || roleProjectCreate === undefined) {
             throw new ArgumentNullException('roleProjectCreate', 'addProjectRole');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/projects/{project_id}/roles' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class ProjectsRolesApiService extends ApiBaseService {
         if (projectId === null || projectId === undefined) {
             throw new ArgumentNullException('projectId', 'listProjectRoles');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/projects-teams-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/projects-teams-api.ts
@@ -36,7 +36,7 @@ export class ProjectsTeamsApiService extends ApiBaseService {
         if (teamProjectCreate === null || teamProjectCreate === undefined) {
             throw new ArgumentNullException('teamProjectCreate', 'addProjectTeam');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/projects/{project_id}/teams' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class ProjectsTeamsApiService extends ApiBaseService {
         if (projectId === null || projectId === undefined) {
             throw new ArgumentNullException('projectId', 'listProjectTeams');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/resource-events-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/resource-events-api.ts
@@ -35,7 +35,7 @@ export class ResourceEventsApiService extends ApiBaseService {
         if (resourceType === null || resourceType === undefined) {
             throw new ArgumentNullException('resourceType', 'addResourceEvent');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/events/{resource_type}/{resource_id}' + (queryString? `?${queryString}` : '');
@@ -59,7 +59,7 @@ export class ResourceEventsApiService extends ApiBaseService {
         if (resourceType === null || resourceType === undefined) {
             throw new ArgumentNullException('resourceType', 'listResourceEventsByResourceType');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/resource-links-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/resource-links-api.ts
@@ -42,7 +42,7 @@ export class ResourceLinksApiService extends ApiBaseService {
         if (resourceType === null || resourceType === undefined) {
             throw new ArgumentNullException('resourceType', 'linkResourceLinkToResourceLink');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/resource-links/{resource_type}/{resource_id}/{child_type}/{child_id}/link' + (queryString? `?${queryString}` : '');
@@ -66,7 +66,7 @@ export class ResourceLinksApiService extends ApiBaseService {
         if (resourceType === null || resourceType === undefined) {
             throw new ArgumentNullException('resourceType', 'listResourceLinksByResourceType');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {
@@ -102,7 +102,7 @@ export class ResourceLinksApiService extends ApiBaseService {
         if (resourceType === null || resourceType === undefined) {
             throw new ArgumentNullException('resourceType', 'listResourceLinksByResourceTypeAndLinkType');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {
@@ -140,7 +140,7 @@ export class ResourceLinksApiService extends ApiBaseService {
         if (resourceType === null || resourceType === undefined) {
             throw new ArgumentNullException('resourceType', 'unlinkResourceLinkFromResourceLink');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/resource-links/{resource_type}/{resource_id}/{child_type}/{child_id}/unlink' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/roles-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/roles-api.ts
@@ -31,7 +31,7 @@ export class RolesApiService extends ApiBaseService {
         if (roleId === null || roleId === undefined) {
             throw new ArgumentNullException('roleId', 'deleteRole');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/roles/{role_id}' + (queryString? `?${queryString}` : '');
@@ -49,7 +49,7 @@ export class RolesApiService extends ApiBaseService {
         if (roleId === null || roleId === undefined) {
             throw new ArgumentNullException('roleId', 'getRole');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/roles/{role_id}' + (queryString? `?${queryString}` : '');
@@ -71,7 +71,7 @@ export class RolesApiService extends ApiBaseService {
         if (roleUpdate === null || roleUpdate === undefined) {
             throw new ArgumentNullException('roleUpdate', 'updateRole');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/roles/{role_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/servers-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/servers-api.ts
@@ -36,7 +36,7 @@ export class ServersApiService extends ApiBaseService {
         if (serverId === null || serverId === undefined) {
             throw new ArgumentNullException('serverId', 'connectServer');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/servers/{server_id}/connect/{activation_token}' + (queryString? `?${queryString}` : '');
@@ -55,7 +55,7 @@ export class ServersApiService extends ApiBaseService {
         if (serverId === null || serverId === undefined) {
             throw new ArgumentNullException('serverId', 'deleteServer');
         }
-        
+
         let queryString = '';
         const queryParams = { destroy_server_disks: destroyServerDisks, } as { [key: string]: any };
         for (const key in queryParams) {
@@ -81,7 +81,7 @@ export class ServersApiService extends ApiBaseService {
         if (serverId === null || serverId === undefined) {
             throw new ArgumentNullException('serverId', 'getServer');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/servers/{server_id}' + (queryString? `?${queryString}` : '');
@@ -99,7 +99,7 @@ export class ServersApiService extends ApiBaseService {
         if (serverId === null || serverId === undefined) {
             throw new ArgumentNullException('serverId', 'getServerCommands');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/servers/{server_id}/commands' + (queryString? `?${queryString}` : '');
@@ -117,7 +117,7 @@ export class ServersApiService extends ApiBaseService {
         if (serverId === null || serverId === undefined) {
             throw new ArgumentNullException('serverId', 'getStatusServer');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/servers/{server_id}/get-status' + (queryString? `?${queryString}` : '');
@@ -135,7 +135,7 @@ export class ServersApiService extends ApiBaseService {
         if (serverId === null || serverId === undefined) {
             throw new ArgumentNullException('serverId', 'restartServer');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/servers/{server_id}/restart' + (queryString? `?${queryString}` : '');
@@ -153,7 +153,7 @@ export class ServersApiService extends ApiBaseService {
         if (serverId === null || serverId === undefined) {
             throw new ArgumentNullException('serverId', 'startServer');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/servers/{server_id}/start' + (queryString? `?${queryString}` : '');
@@ -171,7 +171,7 @@ export class ServersApiService extends ApiBaseService {
         if (serverId === null || serverId === undefined) {
             throw new ArgumentNullException('serverId', 'stopServer');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/servers/{server_id}/stop' + (queryString? `?${queryString}` : '');
@@ -193,7 +193,7 @@ export class ServersApiService extends ApiBaseService {
         if (serverUpdate === null || serverUpdate === undefined) {
             throw new ArgumentNullException('serverUpdate', 'updateServer');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/servers/{server_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/services-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/services-api.ts
@@ -36,7 +36,7 @@ export class ServicesApiService extends ApiBaseService {
         if (serviceId === null || serviceId === undefined) {
             throw new ArgumentNullException('serviceId', 'deleteService');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/services/{service_id}' + (queryString? `?${queryString}` : '');
@@ -54,7 +54,7 @@ export class ServicesApiService extends ApiBaseService {
         if (serviceId === null || serviceId === undefined) {
             throw new ArgumentNullException('serviceId', 'getService');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/services/{service_id}' + (queryString? `?${queryString}` : '');
@@ -76,7 +76,7 @@ export class ServicesApiService extends ApiBaseService {
         if (serviceReload === null || serviceReload === undefined) {
             throw new ArgumentNullException('serviceReload', 'reloadService');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/services/{service_id}/reload' + (queryString? `?${queryString}` : '');
@@ -98,7 +98,7 @@ export class ServicesApiService extends ApiBaseService {
         if (serviceRestart === null || serviceRestart === undefined) {
             throw new ArgumentNullException('serviceRestart', 'restartService');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/services/{service_id}/restart' + (queryString? `?${queryString}` : '');
@@ -120,7 +120,7 @@ export class ServicesApiService extends ApiBaseService {
         if (serviceStart === null || serviceStart === undefined) {
             throw new ArgumentNullException('serviceStart', 'startService');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/services/{service_id}/start' + (queryString? `?${queryString}` : '');
@@ -142,7 +142,7 @@ export class ServicesApiService extends ApiBaseService {
         if (serviceStop === null || serviceStop === undefined) {
             throw new ArgumentNullException('serviceStop', 'stopService');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/services/{service_id}/stop' + (queryString? `?${queryString}` : '');
@@ -164,7 +164,7 @@ export class ServicesApiService extends ApiBaseService {
         if (serviceUpdate === null || serviceUpdate === undefined) {
             throw new ArgumentNullException('serviceUpdate', 'updateService');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/services/{service_id}' + (queryString? `?${queryString}` : '');
@@ -186,7 +186,7 @@ export class ServicesApiService extends ApiBaseService {
         if (serviceUpdateStatus === null || serviceUpdateStatus === undefined) {
             throw new ArgumentNullException('serviceUpdateStatus', 'updateStatusService');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/services/{service_id}/update-status' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/services-variables-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/services-variables-api.ts
@@ -25,6 +25,7 @@ import { VariableServiceCreate } from '../../generated/models';
 export class ServicesVariablesApiService extends ApiBaseService {
     /**
      * 
+     * @deprecated
      * @summary Create a new variable linked to a service
      * @param {number} serviceId The ID of the service.
      * @param {VariableServiceCreate} variableServiceCreate A JSON object containing the resource data
@@ -36,7 +37,7 @@ export class ServicesVariablesApiService extends ApiBaseService {
         if (variableServiceCreate === null || variableServiceCreate === undefined) {
             throw new ArgumentNullException('variableServiceCreate', 'addServiceVariable');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/services/{service_id}/variables' + (queryString? `?${queryString}` : '');
@@ -47,6 +48,7 @@ export class ServicesVariablesApiService extends ApiBaseService {
 
     /**
      * 
+     * @deprecated
      * @summary Return a list of variables belonging to a service
      * @param {number} serviceId The ID of the service.
      * @param {number} [page] Number of the page to be retrieved
@@ -56,7 +58,7 @@ export class ServicesVariablesApiService extends ApiBaseService {
         if (serviceId === null || serviceId === undefined) {
             throw new ArgumentNullException('serviceId', 'listServiceVariables');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/social-accounts-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/social-accounts-api.ts
@@ -33,7 +33,7 @@ export class SocialAccountsApiService extends ApiBaseService {
         if (socialAccountCreate === null || socialAccountCreate === undefined) {
             throw new ArgumentNullException('socialAccountCreate', 'addSocialAccount');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/social-accounts' + (queryString? `?${queryString}` : '');
@@ -51,7 +51,7 @@ export class SocialAccountsApiService extends ApiBaseService {
         if (socialAccountId === null || socialAccountId === undefined) {
             throw new ArgumentNullException('socialAccountId', 'deleteSocialAccount');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/social-accounts/{social_account_id}' + (queryString? `?${queryString}` : '');
@@ -69,7 +69,7 @@ export class SocialAccountsApiService extends ApiBaseService {
         if (socialAccountProvider === null || socialAccountProvider === undefined) {
             throw new ArgumentNullException('socialAccountProvider', 'getSocialAccount');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/social-accounts/{social_account_provider}' + (queryString? `?${queryString}` : '');
@@ -87,7 +87,7 @@ export class SocialAccountsApiService extends ApiBaseService {
         if (socialAccountProvider === null || socialAccountProvider === undefined) {
             throw new ArgumentNullException('socialAccountProvider', 'getSocialAccountStatus');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/social-accounts/{social_account_provider}/status' + (queryString? `?${queryString}` : '');
@@ -103,7 +103,7 @@ export class SocialAccountsApiService extends ApiBaseService {
      * @param {number} [perPage] Number of items returned per page
      */
     public async listSocialAccounts(page?: number, perPage?: number): Promise<ApiResponse<Array<SocialAccountRelation>>> {
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/source-providers-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/source-providers-api.ts
@@ -32,7 +32,7 @@ export class SourceProvidersApiService extends ApiBaseService {
         if (sourceProviderCreate === null || sourceProviderCreate === undefined) {
             throw new ArgumentNullException('sourceProviderCreate', 'addSourceProvider');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/source-providers' + (queryString? `?${queryString}` : '');
@@ -50,7 +50,7 @@ export class SourceProvidersApiService extends ApiBaseService {
         if (sourceProviderId === null || sourceProviderId === undefined) {
             throw new ArgumentNullException('sourceProviderId', 'deleteSourceProvider');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/source-providers/{source_provider_id}' + (queryString? `?${queryString}` : '');
@@ -68,7 +68,7 @@ export class SourceProvidersApiService extends ApiBaseService {
         if (sourceProviderId === null || sourceProviderId === undefined) {
             throw new ArgumentNullException('sourceProviderId', 'getSourceProvider');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/source-providers/{source_provider_id}' + (queryString? `?${queryString}` : '');
@@ -84,7 +84,7 @@ export class SourceProvidersApiService extends ApiBaseService {
      * @param {number} [perPage] Number of items returned per page
      */
     public async listSourceProviders(page?: number, perPage?: number): Promise<ApiResponse<Array<SourceProviderRelation>>> {
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/source-providers-repositories-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/source-providers-repositories-api.ts
@@ -38,7 +38,7 @@ export class SourceProvidersRepositoriesApiService extends ApiBaseService {
         if (sourceProviderId === null || sourceProviderId === undefined) {
             throw new ArgumentNullException('sourceProviderId', 'getSourceProviderRepository');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/source-providers/{source_provider_id}/repositories/{repository_owner}/{repository_name}' + (queryString? `?${queryString}` : '');
@@ -58,7 +58,7 @@ export class SourceProvidersRepositoriesApiService extends ApiBaseService {
         if (sourceProviderId === null || sourceProviderId === undefined) {
             throw new ArgumentNullException('sourceProviderId', 'listSourceProviderRepositories');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/sshkeys-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/sshkeys-api.ts
@@ -31,7 +31,7 @@ export class SSHKeysApiService extends ApiBaseService {
         if (sshKeyId === null || sshKeyId === undefined) {
             throw new ArgumentNullException('sshKeyId', 'deleteSshKey');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/ssh-keys/{ssh_key_id}' + (queryString? `?${queryString}` : '');
@@ -49,7 +49,7 @@ export class SSHKeysApiService extends ApiBaseService {
         if (sshKeyId === null || sshKeyId === undefined) {
             throw new ArgumentNullException('sshKeyId', 'getSshKey');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/ssh-keys/{ssh_key_id}' + (queryString? `?${queryString}` : '');
@@ -71,7 +71,7 @@ export class SSHKeysApiService extends ApiBaseService {
         if (sshKeyUpdate === null || sshKeyUpdate === undefined) {
             throw new ArgumentNullException('sshKeyUpdate', 'updateSshKey');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/ssh-keys/{ssh_key_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/sslcertificates-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/sslcertificates-api.ts
@@ -30,7 +30,7 @@ export class SSLCertificatesApiService extends ApiBaseService {
         if (sslCertificateId === null || sslCertificateId === undefined) {
             throw new ArgumentNullException('sslCertificateId', 'deleteSslCertificate');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/ssl-certificates/{ssl_certificate_id}' + (queryString? `?${queryString}` : '');
@@ -48,7 +48,7 @@ export class SSLCertificatesApiService extends ApiBaseService {
         if (sslCertificateId === null || sslCertificateId === undefined) {
             throw new ArgumentNullException('sslCertificateId', 'getSslCertificate');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/ssl-certificates/{ssl_certificate_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/static-data-application-options-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/static-data-application-options-api.ts
@@ -25,7 +25,7 @@ export class StaticDataApplicationOptionsApiService extends ApiBaseService {
      * @summary List `Application` resource options
      */
     public async getStaticApplicationOptions(): Promise<ApiResponse<ApplicationOptions>> {
-        
+
         let queryString = '';
 
         const requestUrl = '/static/application-options' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/static-data-cloud-provider-options-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/static-data-cloud-provider-options-api.ts
@@ -27,7 +27,7 @@ export class StaticDataCloudProviderOptionsApiService extends ApiBaseService {
      * @param {number} [perPage] Number of items returned per page
      */
     public async listStaticCloudProviderOptions(page?: number, perPage?: number): Promise<ApiResponse<Array<CloudProviderOptionsRelation>>> {
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/static-data-cloud-provider-service-instances-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/static-data-cloud-provider-service-instances-api.ts
@@ -35,7 +35,7 @@ export class StaticDataCloudProviderServiceInstancesApiService extends ApiBaseSe
         if (regionCode === null || regionCode === undefined) {
             throw new ArgumentNullException('regionCode', 'listStaticCloudInstancesByCloudProviderServiceCodeAndRegionCode');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/static-data-cloud-provider-services-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/static-data-cloud-provider-services-api.ts
@@ -29,7 +29,7 @@ export class StaticDataCloudProviderServicesApiService extends ApiBaseService {
         if (cloudProviderServiceCode === null || cloudProviderServiceCode === undefined) {
             throw new ArgumentNullException('cloudProviderServiceCode', 'getStaticCloudProviderService');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/static/cloud-provider-service-options/{cloud_provider_service_code}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/static-data-cron-job-options-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/static-data-cron-job-options-api.ts
@@ -25,7 +25,7 @@ export class StaticDataCronJobOptionsApiService extends ApiBaseService {
      * @summary List `CronJob` resource options
      */
     public async getStaticCronJobOptions(): Promise<ApiResponse<CronJobOptions>> {
-        
+
         let queryString = '';
 
         const requestUrl = '/static/cronjob-options' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/static-data-environment-options-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/static-data-environment-options-api.ts
@@ -25,7 +25,7 @@ export class StaticDataEnvironmentOptionsApiService extends ApiBaseService {
      * @summary List `Environment` options
      */
     public async getStaticEnvironmentOptions(): Promise<ApiResponse<EnvironmentOptions>> {
-        
+
         let queryString = '';
 
         const requestUrl = '/static/environment-options' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/static-data-network-rule-options-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/static-data-network-rule-options-api.ts
@@ -25,7 +25,7 @@ export class StaticDataNetworkRuleOptionsApiService extends ApiBaseService {
      * @summary List `Network Rule` options
      */
     public async getStaticNetworkRuleOptions(): Promise<ApiResponse<NetworkRuleOptions>> {
-        
+
         let queryString = '';
 
         const requestUrl = '/static/network-rule-options' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/static-data-permissions-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/static-data-permissions-api.ts
@@ -27,7 +27,7 @@ export class StaticDataPermissionsApiService extends ApiBaseService {
      * @param {number} [perPage] Number of items returned per page
      */
     public async listStaticPermissions(page?: number, perPage?: number): Promise<ApiResponse<Array<PermissionRelation>>> {
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/static-data-resource-types-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/static-data-resource-types-api.ts
@@ -27,7 +27,7 @@ export class StaticDataResourceTypesApiService extends ApiBaseService {
      * @param {number} [perPage] Number of items returned per page
      */
     public async listStaticResourceTypes(page?: number, perPage?: number): Promise<ApiResponse<Array<ResourceTypeRelation>>> {
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/static-data-service-options-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/static-data-service-options-api.ts
@@ -25,7 +25,7 @@ export class StaticDataServiceOptionsApiService extends ApiBaseService {
      * @summary List `Service` resource options
      */
     public async getStaticServiceOptions(): Promise<ApiResponse<ServiceOptions>> {
-        
+
         let queryString = '';
 
         const requestUrl = '/static/service-options' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/static-data-user-profile-options-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/static-data-user-profile-options-api.ts
@@ -25,7 +25,7 @@ export class StaticDataUserProfileOptionsApiService extends ApiBaseService {
      * @summary List `User profile` options
      */
     public async getStaticUserProfileOptions(): Promise<ApiResponse<UserProfileOptions>> {
-        
+
         let queryString = '';
 
         const requestUrl = '/static/user-profile-options' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/subnets-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/subnets-api.ts
@@ -30,7 +30,7 @@ export class SubnetsApiService extends ApiBaseService {
         if (subnetId === null || subnetId === undefined) {
             throw new ArgumentNullException('subnetId', 'deleteSubnet');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/subnets/{subnet_id}' + (queryString? `?${queryString}` : '');
@@ -48,7 +48,7 @@ export class SubnetsApiService extends ApiBaseService {
         if (subnetId === null || subnetId === undefined) {
             throw new ArgumentNullException('subnetId', 'getSubnet');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/subnets/{subnet_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/team-invitations-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/team-invitations-api.ts
@@ -29,7 +29,7 @@ export class TeamInvitationsApiService extends ApiBaseService {
         if (teamInvitationId === null || teamInvitationId === undefined) {
             throw new ArgumentNullException('teamInvitationId', 'acceptTeamInvitation');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/team-invitations/{team_invitation_id}/accept' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/teams-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/teams-api.ts
@@ -31,7 +31,7 @@ export class TeamsApiService extends ApiBaseService {
         if (teamId === null || teamId === undefined) {
             throw new ArgumentNullException('teamId', 'deleteTeam');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/teams/{team_id}' + (queryString? `?${queryString}` : '');
@@ -49,7 +49,7 @@ export class TeamsApiService extends ApiBaseService {
         if (teamId === null || teamId === undefined) {
             throw new ArgumentNullException('teamId', 'getTeam');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/teams/{team_id}' + (queryString? `?${queryString}` : '');
@@ -71,7 +71,7 @@ export class TeamsApiService extends ApiBaseService {
         if (teamUpdate === null || teamUpdate === undefined) {
             throw new ArgumentNullException('teamUpdate', 'updateTeam');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/teams/{team_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/teams-invitations-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/teams-invitations-api.ts
@@ -36,7 +36,7 @@ export class TeamsInvitationsApiService extends ApiBaseService {
         if (invitationTeamCreate === null || invitationTeamCreate === undefined) {
             throw new ArgumentNullException('invitationTeamCreate', 'addTeamInvitation');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/teams/{team_id}/invitations' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class TeamsInvitationsApiService extends ApiBaseService {
         if (teamId === null || teamId === undefined) {
             throw new ArgumentNullException('teamId', 'listTeamInvitations');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/teams-members-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/teams-members-api.ts
@@ -34,7 +34,7 @@ export class TeamsMembersApiService extends ApiBaseService {
         if (userId === null || userId === undefined) {
             throw new ArgumentNullException('userId', 'deleteTeamMember');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/teams/{team_id}/members/{user_id}' + (queryString? `?${queryString}` : '');
@@ -56,7 +56,7 @@ export class TeamsMembersApiService extends ApiBaseService {
         if (userId === null || userId === undefined) {
             throw new ArgumentNullException('userId', 'getTeamMember');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/teams/{team_id}/members/{user_id}' + (queryString? `?${queryString}` : '');
@@ -76,7 +76,7 @@ export class TeamsMembersApiService extends ApiBaseService {
         if (teamId === null || teamId === undefined) {
             throw new ArgumentNullException('teamId', 'listTeamMembers');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/users-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/users-api.ts
@@ -42,7 +42,7 @@ export class UsersApiService extends ApiBaseService {
         if (userCreate === null || userCreate === undefined) {
             throw new ArgumentNullException('userCreate', 'addUser');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/users' + (queryString? `?${queryString}` : '');
@@ -60,7 +60,7 @@ export class UsersApiService extends ApiBaseService {
         if (userId === null || userId === undefined) {
             throw new ArgumentNullException('userId', 'getUser');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/users/{user_id}' + (queryString? `?${queryString}` : '');
@@ -78,7 +78,7 @@ export class UsersApiService extends ApiBaseService {
         if (userId === null || userId === undefined) {
             throw new ArgumentNullException('userId', 'getUserActivity');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/users/{user_id}/activity' + (queryString? `?${queryString}` : '');
@@ -92,7 +92,7 @@ export class UsersApiService extends ApiBaseService {
      * @summary Get current user\'s billing info for active subscription
      */
     public async getUserBilling(): Promise<ApiResponse<UserBilling>> {
-        
+
         let queryString = '';
 
         const requestUrl = '/users/billing' + (queryString? `?${queryString}` : '');
@@ -106,7 +106,7 @@ export class UsersApiService extends ApiBaseService {
      * @summary Logout/revoke an existing token
      */
     public async getUserLogout(): Promise<ApiResponse<void>> {
-        
+
         let queryString = '';
 
         const requestUrl = '/users/logout' + (queryString? `?${queryString}` : '');
@@ -120,7 +120,7 @@ export class UsersApiService extends ApiBaseService {
      * @summary Get details of the current user
      */
     public async getUserMe(): Promise<ApiResponse<UserMe>> {
-        
+
         let queryString = '';
 
         const requestUrl = '/users/me' + (queryString? `?${queryString}` : '');
@@ -134,7 +134,7 @@ export class UsersApiService extends ApiBaseService {
      * @summary Get the authenticated user\'s URLs
      */
     public async getUserUrls(): Promise<ApiResponse<UserUrl>> {
-        
+
         let queryString = '';
 
         const requestUrl = '/users/urls' + (queryString? `?${queryString}` : '');
@@ -152,7 +152,7 @@ export class UsersApiService extends ApiBaseService {
         if (userLogin === null || userLogin === undefined) {
             throw new ArgumentNullException('userLogin', 'loginUser');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/users/login' + (queryString? `?${queryString}` : '');
@@ -170,7 +170,7 @@ export class UsersApiService extends ApiBaseService {
         if (userRefreshToken === null || userRefreshToken === undefined) {
             throw new ArgumentNullException('userRefreshToken', 'refreshTokenUser');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/users/refresh-token' + (queryString? `?${queryString}` : '');
@@ -188,7 +188,7 @@ export class UsersApiService extends ApiBaseService {
         if (userResendVerification === null || userResendVerification === undefined) {
             throw new ArgumentNullException('userResendVerification', 'resendVerificationUser');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/users/account/resend-verification' + (queryString? `?${queryString}` : '');
@@ -210,7 +210,7 @@ export class UsersApiService extends ApiBaseService {
         if (userUpdate === null || userUpdate === undefined) {
             throw new ArgumentNullException('userUpdate', 'updateUser');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/users/{user_id}' + (queryString? `?${queryString}` : '');
@@ -228,7 +228,7 @@ export class UsersApiService extends ApiBaseService {
         if (userVerify === null || userVerify === undefined) {
             throw new ArgumentNullException('userVerify', 'verifyUser');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/users/account/verify' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/users-environments-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/users-environments-api.ts
@@ -33,7 +33,7 @@ export class UsersEnvironmentsApiService extends ApiBaseService {
         if (userId === null || userId === undefined) {
             throw new ArgumentNullException('userId', 'listUserEnvironments');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, subscription_id: subscriptionId, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/users-passwords-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/users-passwords-api.ts
@@ -32,7 +32,7 @@ export class UsersPasswordsApiService extends ApiBaseService {
         if (passwordUserReset === null || passwordUserReset === undefined) {
             throw new ArgumentNullException('passwordUserReset', 'resetUserPassword');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/users/password/reset' + (queryString? `?${queryString}` : '');
@@ -50,7 +50,7 @@ export class UsersPasswordsApiService extends ApiBaseService {
         if (passwordUserSendResetLink === null || passwordUserSendResetLink === undefined) {
             throw new ArgumentNullException('passwordUserSendResetLink', 'sendResetLinkUserPassword');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/users/password/send-reset-link' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generated/apis/users-projects-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/users-projects-api.ts
@@ -33,7 +33,7 @@ export class UsersProjectsApiService extends ApiBaseService {
         if (userId === null || userId === undefined) {
             throw new ArgumentNullException('userId', 'listUserProjects');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, subscription_id: subscriptionId, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/users-team-invitations-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/users-team-invitations-api.ts
@@ -27,7 +27,7 @@ export class UsersTeamInvitationsApiService extends ApiBaseService {
      * @param {number} [perPage] Number of items returned per page
      */
     public async listUserTeamInvitations(page?: number, perPage?: number): Promise<ApiResponse<Array<TeamInvitationRelation>>> {
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {

--- a/packages/sdks/javascript/src/api/generated/apis/variables-api.ts
+++ b/packages/sdks/javascript/src/api/generated/apis/variables-api.ts
@@ -41,7 +41,7 @@ export class VariablesApiService extends ApiBaseService {
         if (variableCreate === null || variableCreate === undefined) {
             throw new ArgumentNullException('variableCreate', 'addVariable');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/variables/{resource_type}/{resource_id}' + (queryString? `?${queryString}` : '');
@@ -59,7 +59,7 @@ export class VariablesApiService extends ApiBaseService {
         if (variableId === null || variableId === undefined) {
             throw new ArgumentNullException('variableId', 'deleteVariable');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/variables/{variable_id}' + (queryString? `?${queryString}` : '');
@@ -77,7 +77,7 @@ export class VariablesApiService extends ApiBaseService {
         if (variableId === null || variableId === undefined) {
             throw new ArgumentNullException('variableId', 'getVariable');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/variables/{variable_id}' + (queryString? `?${queryString}` : '');
@@ -101,7 +101,7 @@ export class VariablesApiService extends ApiBaseService {
         if (resourceType === null || resourceType === undefined) {
             throw new ArgumentNullException('resourceType', 'listVariablesByResourceType');
         }
-        
+
         let queryString = '';
         const queryParams = { page: page, per_page: perPage, } as { [key: string]: any };
         for (const key in queryParams) {
@@ -131,7 +131,7 @@ export class VariablesApiService extends ApiBaseService {
         if (variableUpdate === null || variableUpdate === undefined) {
             throw new ArgumentNullException('variableUpdate', 'updateVariable');
         }
-        
+
         let queryString = '';
 
         const requestUrl = '/variables/{variable_id}' + (queryString? `?${queryString}` : '');

--- a/packages/sdks/javascript/src/api/generator/templates/apiInner.mustache
+++ b/packages/sdks/javascript/src/api/generator/templates/apiInner.mustache
@@ -25,6 +25,9 @@ export class {{classname}}Service extends ApiBaseService {
     {{#operation}}
     /**
      * {{&notes}}
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
      {{#summary}}
      * @summary {{&summary}}
      {{/summary}}

--- a/packages/sdks/javascript/src/api/generator/templates/apiInner.mustache
+++ b/packages/sdks/javascript/src/api/generator/templates/apiInner.mustache
@@ -44,7 +44,7 @@ export class {{classname}}Service extends ApiBaseService {
     {{/required}}
     {{/isHeaderParam}}
     {{/allParams}}
-        
+
         let queryString = '';
     {{#hasQueryParams}}
         const queryParams = { {{#queryParams}}{{baseName}}: {{paramName}}, {{/queryParams}}} as { [key: string]: any };


### PR DESCRIPTION
## Description of change
This PR: 

1. Removes the whitespace found in `apiInner.mustache` on [line 47](https://github.com/devopness/devopness/blob/main/packages/sdks/javascript/src/api/generator/templates/apiInner.mustache#L47). 
2. Adds verification of whether an endpoint has been marked as deprecated in `spec.json` or not. If it is deprecated, the template will write to the method's JSDoc that it is now deprecated.


## Issues resolved by this PR
<!-- Check list box of JIRA issues (tasks, subtasks, bugs) completed by this PR -->

- [x] [DVN-12933](https://devopness.atlassian.net/browse/DVN-12933)

## More info
<!-- More info to help validate your PR: links, images, videos, ... -->


[DVN-12933]: https://devopness.atlassian.net/browse/DVN-12933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ