### PR TITLE
feat: add action to handle notification and closure of stale issues

### DIFF
--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -1,0 +1,22 @@
+name: "Stale issues handler"
+
+on:
+  workflow_dispatch: # allows workflow to be manually triggered from GitHub UI
+  schedule:
+    - cron: "0 5 * * *" # runs at 5am UTC
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          debug-only: true
+          days-before-issue-stale: 1
+          days-before-issue-close: 1
+          stale-issue-label: "no-issue-activity"
+          labels-to-remove-when-unstale: "no-issue-activity"
+          stale-issue-message: |
+            This issue is stale because it has been open 1 day with no activity.
+            Please comment or this issue will be automatically closed in 1 day.

--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -18,5 +18,12 @@ jobs:
           stale-issue-label: "no-issue-activity"
           labels-to-remove-when-unstale: "no-issue-activity"
           stale-issue-message: |
-            This issue is stale because it has been open 1 day with no activity.
-            Please comment or this issue will be automatically closed in 1 day.
+            👋 Hi there!
+            This issue has been automatically marked as stale because there wasn't any activity in the past
+            3 weeks.
+            * Please check if it is still relevant in the latest version of Devopness
+            * If so, please update the issue with new details
+            If this issue remains without activity for another week (completing a month without activity), it'll be automatically closed.
+          close-issue-message: |
+            ❌ This issue was closed because it has been open and inactive for a month.
+            If you feel this is still a high-priority issue, or are interested in contributing, please open a new issue or pull request linking to this one, for context.


### PR DESCRIPTION
## Description of change
This PR adds a new Action which will mark issues as stale after 21 days since being opened and notify the issue creator that the issue will be closed after 14 days. Initially, this Action will be tested in debug mode with the issue being marked as stale after 1 day and deleted after 1 more day (since it's in debug mode, the notification and deletion will be a dry-run).

## Issues resolved by this PR
<!-- Check list box of JIRA issues (tasks, subtasks, bugs) completed by this PR -->

- [x] [DVN-13029]

## More info
<!-- More info to help validate your PR: links, images, videos, ... -->


[DVN-13029]: https://devopness.atlassian.net/browse/DVN-13029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ