### PR TITLE
refactor: 'Reproduction link' field should not be required

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,7 +49,7 @@ body:
       description: |
         If you're having issues consuming one of our SDKs, a link to real code in jsfiddle.net, codesandbox.io etc is very helpful to speed up bug reproduction and resolution
     validations:
-      required: true
+      required: false
   - type: textarea
     attributes:
       label: Steps to reproduce


### PR DESCRIPTION
## Description of change
The 'Reproduction link' field should not be required, since not all bugs will have a reproduction link.

## Issues resolved by this PR
<!-- Check list box of JIRA issues (tasks, subtasks, bugs) completed by this PR -->

- [x] [DVN-13018]

## More info
<!-- More info to help validate your PR: links, images, videos, ... -->


[DVN-13018]: https://devopness.atlassian.net/browse/DVN-13018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ