### PR TITLE
chore: change amount of days until stale and until close

### DIFF
--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: true
           days-before-pr-stale: -1 # This option is to keep the action workflow from meddling with Pull Requests for now
           days-before-pr-close: -1 # This option is to keep the action workflow from meddling with Pull Requests for now
           days-before-issue-stale: 21

--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -15,8 +15,8 @@ jobs:
           debug-only: true
           days-before-pr-stale: -1 # This option is to keep the action workflow from meddling with Pull Requests for now
           days-before-pr-close: -1 # This option is to keep the action workflow from meddling with Pull Requests for now
-          days-before-issue-stale: 1
-          days-before-issue-close: 1
+          days-before-issue-stale: 21
+          days-before-issue-close: 14
           stale-issue-label: "no-issue-activity"
           labels-to-remove-when-unstale: "no-issue-activity"
           stale-issue-message: |


### PR DESCRIPTION
## Description of change
The actions were testes in debug mode and, according to their logs, worked as expected. This PR removes the `debug-only` option and changes the days before stale to 21 and the days before closed to 14.

## Issues resolved by this PR
<!-- Check list box of JIRA issues (tasks, subtasks, bugs) completed by this PR -->

- [x] [DVN-13029]

## More info
<!-- More info to help validate your PR: links, images, videos, ... -->
