### PR TITLE
fix: change paths on release workflow that should trigger a new release

### DIFF
--- a/.github/workflows/sdk-javascript-release.yml
+++ b/.github/workflows/sdk-javascript-release.yml
@@ -2,7 +2,8 @@ name: SDK JavaScript - Release
 on:
   push:
     paths:
-      - packages/sdks/javascript/**
+      - packages/sdks/javascript/dist
+      - packages/sdks/javascript/package.json
     branches:
       - main
       - '*.x' # maintenance releases


### PR DESCRIPTION
## Description of change
This PR adjusts the path of files that should be included on the list of files whose change should trigger the release of a new SDK version.

## Issues resolved by this PR
<!-- Check list box of JIRA issues (tasks, subtasks, bugs) completed by this PR -->

- [x] [DVN-13106]

## More info
<!-- More info to help validate your PR: links, images, videos, ... -->
