### PR TITLE
feat: add issue labeler

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug Report
 description: Report a bug/issue on Devopness platform, website, SDKs or documentation
 title: '[Bug]: '
-labels: [bug]
+labels: [bug, needs-triage]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest an idea for this project
 title: '[Feature request]: '
-labels: [enhancement]
+labels: [enhancement, needs-triage]
 body:
   - type: textarea
     attributes:

--- a/.github/labeler-issue.yml
+++ b/.github/labeler-issue.yml
@@ -1,0 +1,12 @@
+api:
+  - '(Devopness API)'
+website:
+  - '(Devopness website)'
+web-app:
+  - '(Devopness web app)'
+docs:
+  - '(Documentation)'
+sdk-js:
+  - '(SDK-JS)'
+other:
+  - "(Don't know / other)"

--- a/.github/workflows/label-issue.yml
+++ b/.github/workflows/label-issue.yml
@@ -1,0 +1,19 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.3 #May not be the latest version
+      with:
+        configuration-path: .github/labeler-issue.yml
+        not-before: 2023-11-25T00:00:00Z
+        enable-versioned-regex: 0
+        repo-token: ${{ github.token }}


### PR DESCRIPTION
## Description of change
This PR adds a new workflow to label issues according to the Devopness module which the issue mentions and modifies the issue form templates to add a new `needs-triage` label on issue creation.

## Issues resolved by this PR
<!-- Check list box of JIRA issues (tasks, subtasks, bugs) completed by this PR -->

- [x] [DVN-13024]

## More info
<!-- More info to help validate your PR: links, images, videos, ... -->
