### PR TITLE
fix: adjust regex for 'sdk' label

### DIFF
--- a/.github/labeler-issue.yml
+++ b/.github/labeler-issue.yml
@@ -9,6 +9,6 @@ web-app:
 docs:
   - '(Documentation)'
 sdk:
-  - 'SDK'
+  - 'SDK-'
 sdk-javascript:
   - '(SDK-JS)'


### PR DESCRIPTION
## Description of change
The regex used to add the generic `sdk` label currently is matching other occurences of the string `'SDK'`  in the body of the issue. This PR adds a dash to the end of it (`SDK-`) to avoid false positive matches.

## Issues resolved by this PR
<!-- Check list box of JIRA issues (tasks, subtasks, bugs) completed by this PR -->

- [x] [DVN-13024]

## More info
<!-- More info to help validate your PR: links, images, videos, ... -->
Link of issue whose labels were added automatically: https://github.com/devopness/devopness/issues/815

[DVN-13024]: https://devopness.atlassian.net/browse/DVN-13024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ