### PR TITLE
fix: change use of word 'directory' to 'section'

### DIFF
--- a/docs/legal/index.md
+++ b/docs/legal/index.md
@@ -1,6 +1,6 @@
 ---
 title: Legal
-intro: This directory contains all legal agreements for our services, including terms of service and privacy policy. By using our services, you agree to these terms.
+intro: This section contains all legal agreements for our services, including terms of service and privacy policy. By using our services, you agree to these terms.
 links:
     overview:
     quickstart:

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -1,6 +1,6 @@
 ---
 title: Security
-intro: This directory contains all documentation related to the product's security topics.
+intro: This section contains all documentation related to the product's security topics.
 links:
     overview:
     quickstart:


### PR DESCRIPTION
## Description of change
This PR fixes the incorrect use of "directory" to refer to what is actually a section of the documentation by changing the wording to "section".

## Issues resolved by this PR
<!-- Check list box of JIRA issues (tasks, subtasks, bugs) completed by this PR -->

- [x] [DVN-13246]

## More info
<!-- More info to help validate your PR: links, images, videos, ... -->


[DVN-13246]: https://devopness.atlassian.net/browse/DVN-13246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ