### PR TITLE
docs: update PR template to link GitHub issues instead of internal issue ID

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,19 @@
 ## Description of changes
 <!-- 
-Short text describing how the changes on this PR make a world a better place for Devopness users.
-If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need or just mentioning what needs to be done before the PR is ready for being reviewed.
+Short description of how this PR's makes the world a better place for Devopness users or team members:
+* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]
+
+If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
 -->
 - [ ] <add one check list item here for each meaningful change on this PR>
 
+## Quality Assurance
+
+<!-- Please complete this checklist before requesting a review of your pull request. -->
+
+- Once the changes in this PR are merged and deployed, success criteria is: 
+
 ## More info
-<!-- More info to help the reviewers validate your PR: links, images, videos, ... -->
+<!-- 
+More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,9 @@
-## Description of change
-<!--Short text describing what the changes on this PR do. If it's a draft PR, please clarify what's the help or feedback you expect from the team that justifies opening this PR as a draft instead of only opening the PR when your changes are ready to be merged and deployed to production -->
-
-## Issues resolved by this PR
-<!-- Check list box of JIRA issues (tasks, subtasks, bugs) completed by this PR -->
-
-- [ ] [DVN-<task or subtask number here>]
+## Description of changes
+<!-- 
+Short text describing how the changes on this PR make a world a better place for Devopness users.
+If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need or just mentioning what needs to be done before the PR is ready for being reviewed.
+-->
+- [ ] <add one check list item here for each meaningful change on this PR>
 
 ## More info
-<!-- More info to help validate your PR: links, images, videos, ... -->
+<!-- More info to help the reviewers validate your PR: links, images, videos, ... -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,14 @@ If the PR is still in draft state, please add a **Why draft?** section clarifyin
 -->
 - [ ] <add one check list item here for each meaningful change on this PR>
 
+## GitHub issues resolved by this PR
+<!-- 
+Check list box of GitHub issues completed by this PR.
+Use `N/A` if this PR is not fixing any existing issue.
+-->
+
+- [ ] closes #ISSUE-NUMBER
+
 ## Quality Assurance
 
 <!-- Please complete this checklist before requesting a review of your pull request. -->


### PR DESCRIPTION
## Description of change
- [x] Update PR template to link `GitHub issues` instead of internal issue ID
- [x] Add `Quality Assurance` section to PR template

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [x] fix #818 

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once this change is deployed, success criteria is: template for new PRs will no longer show fields related to internal issue IDs

## More info
<!-- More info to help validate your PR: links, images, videos, ... -->

N/A