### PR TITLE
docs: reword mention of button because of style change (#848)

### DIFF
--- a/docs/linked-resources/add-linked-resource.md
+++ b/docs/linked-resources/add-linked-resource.md
@@ -17,13 +17,14 @@ links:
 
 {% endnote %}
 
-1. On Devopness, navigate to a project then select an environment
-1. Find the `Applications` card
-1. Click `View` in the `Applications` card to see a list of existing `Applications`
-1. Click `DETAILS` on the application you want to link a server
-1. On the upper-right corner of the application details view, click `...`
-1. Use the drop-down menu to choose `Linked resources`
-1. On the upper-right corner of the `Linked resources` list, click `LINK TO`
-1. Use the drop-down menu to choose `Servers`
-1. Follow the prompts then click `Link`
-1. In the `Linked Resource` list, the recently linked server can be seen in the `DEPENDS ON` table
+1. On Devopness, navigate to a project then select an environment.
+2. Find the `Applications` card.
+3. Click `View` in the `Applications` card to see a list of existing `Applications`.
+4. Click `DETAILS` on the application you want to link a server.
+5. On the upper-right corner of the application details view, click on the settings button with the gear icon (⚙️).
+6. Use the drop-down menu to choose `Linked resources`.
+7. On the upper-right corner of the `Linked resources` list, click `LINK TO`.
+8. Use the drop-down menu to choose `Servers`.
+9. Follow the prompts then click `Link`.
+10. In the `Linked Resource` list, the recently linked server can be seen in the `DEPENDS ON` table.
+

--- a/docs/linked-resources/add-linked-resource.md
+++ b/docs/linked-resources/add-linked-resource.md
@@ -18,13 +18,12 @@ links:
 {% endnote %}
 
 1. On Devopness, navigate to a project then select an environment.
-2. Find the `Applications` card.
-3. Click `View` in the `Applications` card to see a list of existing `Applications`.
-4. Click `DETAILS` on the application you want to link a server.
-5. On the upper-right corner of the application details view, click on the settings button with the gear icon (⚙️).
-6. Use the drop-down menu to choose `Linked resources`.
-7. On the upper-right corner of the `Linked resources` list, click `LINK TO`.
-8. Use the drop-down menu to choose `Servers`.
-9. Follow the prompts then click `Link`.
-10. In the `Linked Resource` list, the recently linked server can be seen in the `DEPENDS ON` table.
-
+1. Find the `Applications` card.
+1. Click `View` in the `Applications` card to see a list of existing `Applications`.
+1. Click `DETAILS` on the application you want to link a server.
+1. On the upper-right corner of the application details view, click on the settings button with the gear icon (⚙️).
+1. Use the drop-down menu to choose `Linked resources`.
+1. On the upper-right corner of the `Linked resources` list, click `LINK TO`.
+1. Use the drop-down menu to choose `Servers`.
+1. Follow the prompts then click `Link`.
+1. In the `Linked Resource` list, the recently linked server can be seen in the `DEPENDS ON` table.


### PR DESCRIPTION
Closes #848 by updating the description of the settings button.

## Description of changes
In the docs for adding a linked resource (`/docs/linked-resources`), updated the description of the settings button from:

> click `...`

to:

> click the settings button with the gear icon (⚙️)

## GitHub issues resolved by this PR
- [ ] closes #848

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: 
The docs can be easily followed by a user not familiar with the previous UI.
