### PR TITLE
fix: define version used in semantic release

### DIFF
--- a/.github/workflows/sdk-javascript-release.yml
+++ b/.github/workflows/sdk-javascript-release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: '18.x'
       - run: npm ci
-      - run: npx semantic-release
+      - run: npx semantic-release@22.0.12
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description of changes
The "npx semantic-release" command used by one of the workflows is failing due to incompatibility between the version of NodeJS used and the version required by "semantic-release". This PR updates the command so that it uses a specific version that is compatible with the NodeJS version currently used.

## GitHub issues resolved by this PR
N/A

## Quality Assurance
GitHub action responsible for updating and generating a new version of the JS SDK must work using the informed version.

## More info
N/A