### PR TITLE
docs: fix article "Remove a Network" to guide the user to click resource name

### DIFF
--- a/docs/networks/remove-network.md
+++ b/docs/networks/remove-network.md
@@ -16,7 +16,7 @@ required_permissions:
 1. On Devopness, navigate to a project then select an environment
 1. Find the `Networks` card
 1. Click `View` in the `Networks` card, to see a list of existing `Networks`
-1. In the list of networks, find the network you want to remove and click `DETAILS`
-1. On the upper-right corner of the network details view, click `REMOVE`
-1. Follow the prompts then click `REMOVE NETWORK`
-1. In the `Networks` list, the recently removed `Network` will be gone
+2. In the list of networks, find the network you want to remove and click the `NAME` of the network
+3. On the upper-right corner of the network details view, click `REMOVE`
+4. Follow the prompts then click `REMOVE NETWORK`
+5. In the `Networks` list, the recently removed `Network` will be gone


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->
- [ ] Fixed the excerpt "In the list of networks, find the network you want to remove and click DETAILS" that was replaced by a more descriptive text explaining how to enter in the netowork details view.

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [ ] This PR resolves #865 

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: Update the article https://www.devopness.com/docs/networks/remove-network/

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
