### PR TITLE
docs: fix article "Delete a Server provisioned by Devopness" to guide the user to click resource name

### DIFF
--- a/docs/servers/delete-cloudprovider-server.md
+++ b/docs/servers/delete-cloudprovider-server.md
@@ -22,7 +22,7 @@ required_permissions:
 1. On Devopness, navigate to a project then select an environment
 1. Find the `Servers` card
 1. Click the `View` in the `Servers` card, to see a list of existing `Servers`
-1. In the list of servers, find the server you want to delete and click `DETAILS`
+1. In the list of servers, find the server you want to delete and click the `NAME` of the server
 1. On the upper-right corner of the server details view, click `REMOVE`
 1. Follow the prompts then click `REMOVE`
 1. Wait for the `server:remove` action to be completed


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->
- [x] Fixed the excerpts "In the list of servers, find the server you want to delete and click DETAILS" that were replaced by a more descriptive text explaining how to enter in the server details view.


## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [x] This PR resolves #872 

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: Update the article https://www.devopness.com/docs/servers/delete-cloudprovider-server/

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
