### PR TITLE
docs: fix article "Link an SSH Key to a Server" to guide the user to click resource name and to use the tabs

### DIFF
--- a/docs/ssh-keys/link-ssh-key.md
+++ b/docs/ssh-keys/link-ssh-key.md
@@ -14,10 +14,8 @@ links:
 1. On Devopness, navigate to a project then select an environment
 1. Find the `SSH Keys` card
 1. Click `View` in the `SSH Keys` card to see a list of existing `SSH Keys`
-1. Click `DETAILS` on the SSH key you want to link to a server
-1. On the upper-right corner of the SSH key details view, click `SETTINGS`
-1. Use the drop-down menu to choose `Linked resources`
-1. On the upper-right corner of the `Linked resources` list, click `LINK TO`
-1. Use the drop-down menu to choose `Servers`
-1. Follow the prompts then click `Link`
-1. In the `Linked Resource` list, the recently linked server can be seen in the `DEPENDS ON` table
+1. In the list of SSH keys, find the SSH key you want to link to a server and click the `NAME` of the SSH key
+1. Click the `Servers` tab
+1. On the upper-right corner of the servers tab click `MANAGE`
+1. Follow the prompts, then click `Link`
+1. In the `Servers` list, the recently linked server can be seen


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->
- [ ] Fixed the excerpts "Click DETAILS on the SSH key you want to link to a server" that was replaced by a more descriptive text explaining how to enter in the SSH key details view.

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [ ] This PR resolves #879 

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: Update the article https://www.devopness.com/docs/ssh-keys/link-ssh-key/

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
