### PR TITLE
ci: avoid building packages sdk-js and ui-react 2 times per action

### DIFF
--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node }}
           registry-url: https://registry.npmjs.org
       - name: install
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: build
         run: npm run build-api-models

--- a/.github/workflows/sdk-javascript-release.yml
+++ b/.github/workflows/sdk-javascript-release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "20.x"
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npx semantic-release@22.0.12
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ui-react-ci.yml
+++ b/.github/workflows/ui-react-ci.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node }}
           registry-url: https://registry.npmjs.org
       - name: install
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: build
         run: npm run build

--- a/.github/workflows/ui-react-release.yml
+++ b/.github/workflows/ui-react-release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "20.x"
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npx semantic-release@22.0.12
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->

- Fixes building packages twice per action [1]

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: All package related workflows should run prepare/build scripts only once

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->

[1]

### Why does it happens?

`prepare` script is called during `npm ci` unless adding `--ignore-scripts` flag

https://docs.npmjs.com/cli/v8/using-npm/scripts#npm-ci
https://docs.npmjs.com/cli/v8/commands/npm-ci#ignore-scripts

### Release Workflows Evidence

- SDK JavaScript https://github.com/devopness/devopness/actions/runs/11041350259/job/30671424291
- UI React https://github.com/devopness/devopness/actions/runs/11244451650/job/31262550259

`npm ci`

![image](https://github.com/user-attachments/assets/8b781a01-bb37-412a-9659-88668e5364d6)

`npx semantic-release@22.0.12`
![image](https://github.com/user-attachments/assets/335bca58-15ef-4d0a-8f92-cb47de7cdb30)

### CI Workflows Evidence

- SDK JavaScript https://github.com/devopness/devopness/actions/runs/11224903987/job/31202571452
- UI React https://github.com/devopness/devopness/actions/runs/11244458565/job/31262573767
