### PR TITLE
ci: fix packages sdk-js and ui-react sharing version numbers

### DIFF
--- a/.github/workflows/sdk-javascript-release.yml
+++ b/.github/workflows/sdk-javascript-release.yml
@@ -17,12 +17,12 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
       - run: npm ci --ignore-scripts
-      - run: npx semantic-release@22.0.12
+      - run: npx semantic-release@24.1.2 --tag-format="sdk-js-\${version}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ui-react-release.yml
+++ b/.github/workflows/ui-react-release.yml
@@ -17,12 +17,12 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
       - run: npm ci --ignore-scripts
-      - run: npx semantic-release@22.0.12
+      - run: npx semantic-release@24.1.2 --tag-format="ui-react-\${version}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/ui/react/README.md
+++ b/packages/ui/react/README.md
@@ -1,5 +1,7 @@
 # Devopness UI - React
 
+[![NPM](https://nodei.co/npm/@devopness/ui-react.png?downloads=true&stars=true)](https://nodei.co/npm/@devopness/ui-react/)
+
 The official Devopness UI components for React
 
 <!-- TODO: enable this section once package is available in npm registry


### PR DESCRIPTION
## ⚠️ WARNING

⚠️ This PR should not be merged before tags in updated format are available on main branch
⚠️ If not found, semantic-release will attempt publishing a version without following the previous release's semantic versioning
⚠️ This can affect SDK and UI release publishing workflows

## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->

### The problem

- Releases of package [@devopness/ui-react](https://www.npmjs.com/package/@devopness/ui-react?activeTab=versions) have been sharing version tags with [@devopness/sdk-js](https://www.npmjs.com/package/@devopness/sdk-js?activeTab=versions)
    - The repository tags are used by [semantic-release](https://semantic-release.gitbook.io/semantic-release) to calculate the next release version number
    - Current tag format is [semantic-release's default](https://semantic-release.gitbook.io/semantic-release/usage/configuration#tagformat) `v${version}`
        - This tag format does not include which package was published
        - This format can lead to confusion and unexplained version gaps in both packages
        - Example: the first release of @devopness/ui-react was numbered 2.145.0, because sdk-js latest release at the time was 2.144.0, see [1]

### The proposed solution (step-by-step)

1. Create new tag for @devopness/sdk-js latest published version ("sdk-js-2.144.0") and push to main [2]
1. Create new tag for @devopness/ui-react latest published version ("ui-react-2.146.0") and push to main [2]
    - This allows semantic-release action to calculate the next release number using 2.144.0/2.146.0 as base, instead of starting from 1.0.0
1. Merge this PR to update semantic-release config to use separate version tag formats for each package, avoiding conflicts in future releases
     - Example:
         - Current: v2.143.0, v2.144.0, v2.145.0, 2.145.1
         - Proposed solution: sdk-js-2.143.0, sdk-js-2.144.0, ui-react-2.145.0, ui-react-2.145.1

### Other minor changes included in this PR

1. Update release workflow action versions:
     - actions/{checkout, setup-node} v4
     - semantic-release@24.1.2
1. Add npm badge to devopness/packages/ui/react/README.md
     - Allow users to access package homepage on npm from README file

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: A new version released of package @devopness/sdk-js should not affect versioning for the next version of package @devopness/ui-react

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->

[1] 

![image](https://github.com/user-attachments/assets/3c01dc45-de7e-4d61-8c65-c6b51391993e)

[2] 

```bash
git switch main
git tag sdk-js-2.144.0 v2.144.0
git tag ui-react-2.146.0 v2.146.0
git push --tags
```