### PR TITLE
feat(design-system): update icons source from @react-icons/all-files to react-icons

### DIFF
--- a/.changeset/replace-react-icons-all-files.md
+++ b/.changeset/replace-react-icons-all-files.md
@@ -1,0 +1,9 @@
+---
+"@devopness/ui-react": minor
+---
+
+Update icons source from [@react-icons/all-files](https://www.npmjs.com/package/@react-icons/all-files) to [react-icons](https://www.npmjs.com/package/react-icons)
+
+Both libraries are from the same author, but all-files is a heavy dependency that needed to be installed from outside the npm registry
+
+Using [react-icons](https://www.npmjs.com/package/react-icons) is the recommended approach for this package's use case, according to their [docs](https://react-icons.github.io/react-icons/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3119,15 +3119,6 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@react-icons/all-files": {
-      "version": "5.2.1",
-      "resolved": "https://github.com/react-icons/react-icons/releases/download/v5.2.1/react-icons-all-files-5.2.1.tgz",
-      "integrity": "sha512-GWFOoiXrh/PE7El1qrHcdHkLay6kyvzxch6SLlSlIzfp574qfyrFgYOu3zPn8Rc/7mERKiClYEUMdUzdFwN9OQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
@@ -11389,6 +11380,15 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "dev": true,
@@ -14372,12 +14372,12 @@
       "dependencies": {
         "@mui/material": "^6.4.0",
         "@mui/styled-engine-sc": "^6.4.0",
-        "@react-icons/all-files": "https://github.com/react-icons/react-icons/releases/download/v5.2.1/react-icons-all-files-5.2.1.tgz",
         "framer-motion": "^11.18.0",
         "ldrs": "^1.0.2",
         "lodash": "^4.17.21",
         "material-ui-popup-state": "^5.3.3",
         "path-browserify": "^1.0.1",
+        "react-icons": "^5.4.0",
         "styled-components": "^6.1.14"
       },
       "devDependencies": {

--- a/packages/ui/react/.storybook/preview.ts
+++ b/packages/ui/react/.storybook/preview.ts
@@ -4,6 +4,7 @@ const preview: Preview = {
   parameters: {
     layout: 'centered',
     controls: {
+      sort: 'requiredFirst',
       matchers: {
         color: /(background|color)$/i,
         date: /Date$/i,

--- a/packages/ui/react/package.json
+++ b/packages/ui/react/package.json
@@ -59,12 +59,12 @@
   "dependencies": {
     "@mui/material": "^6.4.0",
     "@mui/styled-engine-sc": "^6.4.0",
-    "@react-icons/all-files": "https://github.com/react-icons/react-icons/releases/download/v5.2.1/react-icons-all-files-5.2.1.tgz",
     "framer-motion": "^11.18.0",
     "ldrs": "^1.0.2",
     "lodash": "^4.17.21",
     "material-ui-popup-state": "^5.3.3",
     "path-browserify": "^1.0.1",
+    "react-icons": "^5.4.0",
     "styled-components": "^6.1.14"
   },
   "devDependencies": {

--- a/packages/ui/react/src/components/Primitives/Icon/Icon.stories.tsx
+++ b/packages/ui/react/src/components/Primitives/Icon/Icon.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
   render: (props) => (
     <Icon
       {...props}
-      opacity={(props.opacity ?? 1) / 100}
+      opacity={(props.opacity ?? 100) / 100}
     />
   ),
 } satisfies Meta<typeof Icon>
@@ -30,9 +30,10 @@ type Story = StoryObj<typeof meta>
 const Primary: Story = {
   args: {
     name: 'help',
-    size: 40,
-    color: 'purple.800',
     ariaLabel: 'help',
+    color: 'purple.800',
+    opacity: 100,
+    size: 40,
   },
 }
 

--- a/packages/ui/react/src/components/Primitives/Label/Label.styled.ts
+++ b/packages/ui/react/src/components/Primitives/Label/Label.styled.ts
@@ -1,4 +1,4 @@
-import { BsQuestionCircleFill } from '@react-icons/all-files/bs/BsQuestionCircleFill'
+import { BsQuestionCircleFill } from 'react-icons/bs'
 import { styled } from 'styled-components'
 
 import { getColor } from 'src/colors'

--- a/packages/ui/react/src/components/Primitives/Label/Label.styled.ts
+++ b/packages/ui/react/src/components/Primitives/Label/Label.styled.ts
@@ -1,4 +1,5 @@
 import { BsQuestionCircleFill } from 'react-icons/bs'
+
 import { styled } from 'styled-components'
 
 import { getColor } from 'src/colors'

--- a/packages/ui/react/src/icons/iconLoader.tsx
+++ b/packages/ui/react/src/icons/iconLoader.tsx
@@ -1,76 +1,75 @@
-import { AiOutlineCheck } from '@react-icons/all-files/ai/AiOutlineCheck'
-import { AiOutlineCloudServer } from '@react-icons/all-files/ai/AiOutlineCloudServer'
-import { AiOutlineDeploymentUnit } from '@react-icons/all-files/ai/AiOutlineDeploymentUnit'
-import { AiOutlineDollarCircle } from '@react-icons/all-files/ai/AiOutlineDollarCircle'
-import { AiOutlineLink } from '@react-icons/all-files/ai/AiOutlineLink'
-import { AiOutlineSafety } from '@react-icons/all-files/ai/AiOutlineSafety'
-import { BiUnlink } from '@react-icons/all-files/bi/BiUnlink'
-import { BsFillGearFill } from '@react-icons/all-files/bs/BsFillGearFill'
-import { BsQuestionCircleFill } from '@react-icons/all-files/bs/BsQuestionCircleFill'
-import { BsTerminal } from '@react-icons/all-files/bs/BsTerminal'
-import { DiCodeBadge } from '@react-icons/all-files/di/DiCodeBadge'
-import { FaCog } from '@react-icons/all-files/fa/FaCog'
-import { FaCopy } from '@react-icons/all-files/fa/FaCopy'
-import { FaCubes } from '@react-icons/all-files/fa/FaCubes'
-import { FaDatabase } from '@react-icons/all-files/fa/FaDatabase'
-import { FaGlobe } from '@react-icons/all-files/fa/FaGlobe'
-import { FaLock } from '@react-icons/all-files/fa/FaLock'
-import { FaLockOpen } from '@react-icons/all-files/fa/FaLockOpen'
-import { FaPlus } from '@react-icons/all-files/fa/FaPlus'
-import { FaRegCopy } from '@react-icons/all-files/fa/FaRegCopy'
-import { FaServer } from '@react-icons/all-files/fa/FaServer'
-import { FaSort } from '@react-icons/all-files/fa/FaSort'
-import { FaUserCheck } from '@react-icons/all-files/fa/FaUserCheck'
-import { FaUserClock } from '@react-icons/all-files/fa/FaUserClock'
-import { FaUserTimes } from '@react-icons/all-files/fa/FaUserTimes'
-import { FiGitBranch } from '@react-icons/all-files/fi/FiGitBranch'
-import { FiLogOut } from '@react-icons/all-files/fi/FiLogOut'
-import { FiPlusCircle } from '@react-icons/all-files/fi/FiPlusCircle'
-import { FiServer } from '@react-icons/all-files/fi/FiServer'
-import { GoGitCommit } from '@react-icons/all-files/go/GoGitCommit'
-import { GoKey } from '@react-icons/all-files/go/GoKey'
-import { GoPasskeyFill } from '@react-icons/all-files/go/GoPasskeyFill'
-import { GoSkip } from '@react-icons/all-files/go/GoSkip'
-import { GrClose } from '@react-icons/all-files/gr/GrClose'
-import { GrConnect } from '@react-icons/all-files/gr/GrConnect'
-import { GrLaunch } from '@react-icons/all-files/gr/GrLaunch'
-import { ImTree } from '@react-icons/all-files/im/ImTree'
-import { IoMdEye } from '@react-icons/all-files/io/IoMdEye'
-import { IoMdEyeOff } from '@react-icons/all-files/io/IoMdEyeOff'
-import { LiaNetworkWiredSolid } from '@react-icons/all-files/lia/LiaNetworkWiredSolid'
-import { MdAdd } from '@react-icons/all-files/md/MdAdd'
-import { MdAlarmOn } from '@react-icons/all-files/md/MdAlarmOn'
-import { MdCheckCircle } from '@react-icons/all-files/md/MdCheckCircle'
-import { MdDelete } from '@react-icons/all-files/md/MdDelete'
-import { MdDevices } from '@react-icons/all-files/md/MdDevices'
-import { MdDragHandle } from '@react-icons/all-files/md/MdDragHandle'
-import { MdEdit } from '@react-icons/all-files/md/MdEdit'
-import { MdError } from '@react-icons/all-files/md/MdError'
-import { MdGroup } from '@react-icons/all-files/md/MdGroup'
-import { MdInfo } from '@react-icons/all-files/md/MdInfo'
-import { MdKeyboardArrowDown } from '@react-icons/all-files/md/MdKeyboardArrowDown'
-import { MdKeyboardArrowLeft } from '@react-icons/all-files/md/MdKeyboardArrowLeft'
-import { MdKeyboardArrowRight } from '@react-icons/all-files/md/MdKeyboardArrowRight'
-import { MdKeyboardArrowUp } from '@react-icons/all-files/md/MdKeyboardArrowUp'
-import { MdLens } from '@react-icons/all-files/md/MdLens'
-import { MdMoreHoriz } from '@react-icons/all-files/md/MdMoreHoriz'
-import { MdOutlineDescription } from '@react-icons/all-files/md/MdOutlineDescription'
-import { MdOutlineFolder } from '@react-icons/all-files/md/MdOutlineFolder'
-import { MdPending } from '@react-icons/all-files/md/MdPending'
-import { MdPersonOutline } from '@react-icons/all-files/md/MdPersonOutline'
-import { MdSecurity } from '@react-icons/all-files/md/MdSecurity'
-import { MdSettings } from '@react-icons/all-files/md/MdSettings'
-import { MdSnooze } from '@react-icons/all-files/md/MdSnooze'
-import { MdTimerOff } from '@react-icons/all-files/md/MdTimerOff'
-import { MdWarning } from '@react-icons/all-files/md/MdWarning'
-import { PiCloudWarningBold } from '@react-icons/all-files/pi/PiCloudWarningBold'
-import { PiTagDuotone } from '@react-icons/all-files/pi/PiTagDuotone'
-import { PiTreeView } from '@react-icons/all-files/pi/PiTreeView'
-import { RiEye2Line } from '@react-icons/all-files/ri/RiEye2Line'
-import { RiMapPinLine } from '@react-icons/all-files/ri/RiMapPinLine'
-import { RiShieldCheckFill } from '@react-icons/all-files/ri/RiShieldCheckFill'
-import { RiTeamLine } from '@react-icons/all-files/ri/RiTeamLine'
-import { RxOpenInNewWindow } from '@react-icons/all-files/rx/RxOpenInNewWindow'
+import {
+  AiOutlineCheck,
+  AiOutlineCloudServer,
+  AiOutlineDeploymentUnit,
+  AiOutlineDollarCircle,
+  AiOutlineLink,
+  AiOutlineSafety,
+} from 'react-icons/ai'
+import { BiUnlink } from 'react-icons/bi'
+import {
+  BsFillGearFill,
+  BsQuestionCircleFill,
+  BsTerminal,
+} from 'react-icons/bs'
+import { DiCodeBadge } from 'react-icons/di'
+import {
+  FaCog,
+  FaCopy,
+  FaCubes,
+  FaDatabase,
+  FaGlobe,
+  FaLock,
+  FaLockOpen,
+  FaPlus,
+  FaRegCopy,
+  FaServer,
+  FaSort,
+  FaUserCheck,
+  FaUserClock,
+  FaUserTimes,
+} from 'react-icons/fa'
+import { FiGitBranch, FiLogOut, FiPlusCircle, FiServer } from 'react-icons/fi'
+import { GoGitCommit, GoKey, GoPasskeyFill, GoSkip } from 'react-icons/go'
+import { GrClose, GrConnect, GrLaunch } from 'react-icons/gr'
+import { ImTree } from 'react-icons/im'
+import { IoMdEye, IoMdEyeOff } from 'react-icons/io'
+import { LiaNetworkWiredSolid } from 'react-icons/lia'
+import {
+  MdAdd,
+  MdAlarmOn,
+  MdCheckCircle,
+  MdDelete,
+  MdDevices,
+  MdDragHandle,
+  MdEdit,
+  MdError,
+  MdGroup,
+  MdInfo,
+  MdKeyboardArrowDown,
+  MdKeyboardArrowLeft,
+  MdKeyboardArrowRight,
+  MdKeyboardArrowUp,
+  MdLens,
+  MdMoreHoriz,
+  MdOutlineDescription,
+  MdOutlineFolder,
+  MdPending,
+  MdPersonOutline,
+  MdSecurity,
+  MdSettings,
+  MdSnooze,
+  MdTimerOff,
+  MdWarning,
+} from 'react-icons/md'
+import { PiCloudWarningBold, PiTagDuotone, PiTreeView } from 'react-icons/pi'
+import {
+  RiEye2Line,
+  RiMapPinLine,
+  RiShieldCheckFill,
+  RiTeamLine,
+} from 'react-icons/ri'
+import { RxOpenInNewWindow } from 'react-icons/rx'
 
 import { CircleBubble } from './CircleBubble'
 import { getImageAssetUrl } from './getImageAssetUrl'


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->

- Replace dependency `@react-icons/all-files` with `react-icons`
    - The `@react-icons/all-files` approach...
        - ...is not recommend "for standard modern project", according to [docs](https://react-icons.github.io/react-icons/)
        - ...is slower to install, compared to `react-icons`
        - ...needs to download a big file from outside npm registry
    - Due to those reasons, and aiming to reduce install times of this library, it's recommended to avoid `@react-icons/all-files`
- Fixes Icon story colors [1]
    - Sort Storybook Controls by showing required props first and sorting all alphabetically
        - See [Storybook Docs: Controls - Sorting Controls](https://storybook.js.org/docs/essentials/controls#sorting-controls)
    - Add default 100% opacity to story

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: Users can install @devopness/ui-react package without downloading all files from react-icons

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->

[1]

### BEFORE

![image](https://github.com/user-attachments/assets/52c44723-7011-431a-afde-9b796dda7ac8)


### AFTER

Icons are still available after updating the dependencies

![image](https://github.com/user-attachments/assets/76a1809c-cf2d-46cb-bbde-88699ecb62f3)

[DVN-17383]

[DVN-17383]: https://devopness.atlassian.net/browse/DVN-17383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ