### PR TITLE
fix: stop unwanted props from propagating to DOM Element in Button

### DIFF
--- a/.changeset/shaggy-plums-smash.md
+++ b/.changeset/shaggy-plums-smash.md
@@ -1,0 +1,5 @@
+---
+"@devopness/ui-react": patch
+---
+
+Stop select props from propagating to DOM element because of styled-component in Button component

--- a/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
+++ b/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
@@ -11,11 +11,11 @@ type CustomButton = {
 }
 
 type StyledProps = {
-  noMargin?: boolean
-  noPadding?: boolean
-  size: NonNullable<ButtonProps['typeSize']>
-  variant?: string
-  custom?: CustomButton
+  $noMargin?: boolean
+  $noPadding?: boolean
+  $size: NonNullable<ButtonProps['typeSize']>
+  $variant?: string
+  $custom?: CustomButton
   icon?: boolean
   alignEnd?: boolean
   reversed: boolean
@@ -67,7 +67,7 @@ const getBorderColor = (buttonType?: string, custom?: CustomButton) => {
   }
 }
 
-const getBorderWidth = (typeSize: StyledProps['size']) => {
+const getBorderWidth = (typeSize: StyledProps['$size']) => {
   switch (typeSize) {
     case 'medium':
       return 1
@@ -76,7 +76,7 @@ const getBorderWidth = (typeSize: StyledProps['size']) => {
   }
 }
 
-const getTypeSize = (typeSize: StyledProps['size']) => {
+const getTypeSize = (typeSize: StyledProps['$size']) => {
   switch (typeSize) {
     case 'auto':
       return 'auto'
@@ -88,17 +88,17 @@ const getTypeSize = (typeSize: StyledProps['size']) => {
 }
 
 const ContentIcon = styled.div<
-  Pick<ButtonProps, 'noIconMargin'> & {
+  Pick<ButtonProps, '$noIconMargin'> & {
     reversed: ButtonProps['revertOrientation']
     size: Required<ButtonProps['iconSize']>
   }
 >`
-  ${({ noIconMargin, reversed: revertOrientation, size: iconSize }) => css`
+  ${({ $noIconMargin, reversed: revertOrientation, size: iconSize }) => css`
     display: flex;
     align-items: center;
     width: ${iconSize}px;
     height: ${iconSize}px;
-    ${noIconMargin
+    ${$noIconMargin
       ? ''
       : revertOrientation
         ? 'margin-left: 10px;'
@@ -121,13 +121,13 @@ const WrapperButtons = styled.div<StyledProps>`
 
 const BaseButton = styled.button<StyledProps>`
   ${({
-    size: typeSize,
-    variant: buttonType,
-    custom,
-    noMargin,
+    $size: typeSize,
+    $variant: buttonType,
+    $custom: custom,
+    $noPadding: noPadding,
+    $noMargin: noMargin,
     reversed: revertOrientation,
     noPointerEvents,
-    noPadding,
   }) => css`
     display: flex;
     justify-content: center;

--- a/packages/ui/react/src/components/Buttons/Button/Button.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.tsx
@@ -46,15 +46,15 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   /**
    * The button component has a 15px margin on its sides, to remove activate the "noMargin" property
    */
-  noMargin?: boolean
+  $noMargin?: boolean
   /**
    * The button component has a 10px margin on its sides, to remove activate the "noIconMargin" property
    */
-  noIconMargin?: boolean
+  $noIconMargin?: boolean
   /**
    * The button component has a 15px padding on its sides, to remove activate the "noPadding" property
    */
-  noPadding?: boolean
+  $noPadding?: boolean
   /**
    * It should be true if the button is wrapped in a tooltip
    */
@@ -94,8 +94,8 @@ const Button = ({
   icon,
   children,
   revertOrientation = false,
-  noMargin,
-  noIconMargin,
+  $noMargin: noMargin,
+  $noIconMargin,
   noPointerEvents,
   iconSize,
   iconColor,
@@ -110,7 +110,7 @@ const Button = ({
       <ContentIcon
         data-testid={isLoading ? 'loading' : 'icon'}
         reversed={revertOrientation}
-        noIconMargin={noIconMargin}
+        $noIconMargin={$noIconMargin}
         size={iconSize ?? DEFAULT_ICON_SIZE}
       >
         {iconLoader(
@@ -125,16 +125,16 @@ const Button = ({
   return (
     <BaseButton
       data-testid="button"
-      size={typeSize}
-      variant={buttonType}
+      $size={typeSize}
+      $variant={buttonType}
       reversed={revertOrientation}
       noPointerEvents={noPointerEvents}
-      custom={{
+      $custom={{
         color: color,
         backgroundColor: backgroundColor,
         borderColor: borderColor,
       }}
-      noMargin={noMargin}
+      $noMargin={noMargin}
       disabled={disabled}
       type={type}
       tabIndex={tabIndex}

--- a/packages/ui/react/src/components/Forms/Alert/Alert.tsx
+++ b/packages/ui/react/src/components/Forms/Alert/Alert.tsx
@@ -79,8 +79,8 @@ const Alert = (props: AlertProps) => (
               icon="close"
               buttonType="borderless"
               iconColor={getColor(alertTypeToIconColor[props.type])}
-              noPadding
-              noIconMargin
+              $noPadding
+              $noIconMargin
               onClick={props.onClose}
             />
           ) : (

--- a/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.tsx
+++ b/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.tsx
@@ -27,7 +27,7 @@ const DEFAULT_ICON_MARGIN = 10
 
 type DropdownOptionIcon = Unwrap<
   Partial<Pick<IconProps, 'name' | 'size'>> &
-    Pick<React.CSSProperties, 'backgroundColor' | 'color'>
+  Pick<React.CSSProperties, 'backgroundColor' | 'color'>
 > & { icon: true }
 
 type DropdownOptionLetter = Unwrap<
@@ -218,8 +218,8 @@ const ElementAnchor = ({
       wrapper={(children) => <Tooltip title={tooltip}>{children}</Tooltip>}
     >
       <Button
-        noMargin
-        noIconMargin={!!buttonProps?.icon}
+        $noMargin
+        $noIconMargin={!!buttonProps?.icon}
         typeSize="medium"
         {...buttonProps}
         icon={!props.hideDropdownIcon ? dropdownIcon : undefined}

--- a/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.tsx
+++ b/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.tsx
@@ -27,7 +27,7 @@ const DEFAULT_ICON_MARGIN = 10
 
 type DropdownOptionIcon = Unwrap<
   Partial<Pick<IconProps, 'name' | 'size'>> &
-  Pick<React.CSSProperties, 'backgroundColor' | 'color'>
+    Pick<React.CSSProperties, 'backgroundColor' | 'color'>
 > & { icon: true }
 
 type DropdownOptionLetter = Unwrap<

--- a/packages/ui/react/src/components/Primitives/Pagination/Pagination.tsx
+++ b/packages/ui/react/src/components/Primitives/Pagination/Pagination.tsx
@@ -53,7 +53,7 @@ const Pagination = ({
         type="button"
         buttonType={'outlinedAuxiliary'}
         typeSize="medium"
-        noMargin
+        $noMargin
         onClick={firstPaginateAction}
         disabled={disableAllActions || disablePreviousActions}
       >
@@ -64,7 +64,7 @@ const Pagination = ({
         buttonType={'outlinedSecondary'}
         typeSize="medium"
         icon="leftArrow"
-        noMargin
+        $noMargin
         onClick={previousPaginateAction}
         disabled={disableAllActions || disablePreviousActions}
       >
@@ -76,7 +76,7 @@ const Pagination = ({
         typeSize="medium"
         icon="rightArrow"
         revertOrientation
-        noMargin
+        $noMargin
         onClick={nextPaginateAction}
         disabled={disableAllActions || disableNextActions}
       >
@@ -86,7 +86,7 @@ const Pagination = ({
         type="button"
         buttonType={'outlinedAuxiliary'}
         typeSize="medium"
-        noMargin
+        $noMargin
         onClick={lastPaginateAction}
         disabled={disableAllActions || disableNextActions}
       >


### PR DESCRIPTION
## Description of changes
Fixes bug described in issue #1004, where unwanted props used only in internal styling logic are currently being propagated by Styled Components to the DOM.
- Updated prop name in typing for BaseButton styled component, prefixing "$" to old prop name.

## GitHub issues resolved by this PR
- [x] closes #1004

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: 
  - looking at the resulting `<button />` DOM element from a `Button` component and noting that there are no props there that are invalid attributes.
  -  looking at the dev console and noting that there are no related warnings from react or styled-components regarding the button props.

## More info
This was solved as suggested in the issue description, by using the prop name to signal to Styled Components that the prop in question is a [transient prop](https://styled-components.com/docs/api#transient-props).

I changed the name of all Button props that gave warnings/errors in the dev console in storybook or in the tests, as well as other similarly named props that stood out to me (e.g.: i changed noPadding even though there was no warning because there was one for noMargin).

I considered using the [`shouldForwardProp` feature](https://styled-components.com/docs/api#shouldforwardprop) of styled-components instead of transient props, but ultimately decided against it because of a possible issue with over-engineering for the problem + maybe a significant impact on performance (i imagined that something like a $`O(p*P*c)`$ algorithm validating for all $p$ existing props in a component against all $P$ valid props for that DOM Element for all $c$ components might be significant).

I haven't spent too long looking into it, but i believe there are some libraries or in-built options that we could slot into the styled components config that do all of this checking and filtering. It doesn't seem necessary to delve into it right now, but i believe it's going to be a useful and worthwhile refactor in the future as a kind of automation.