### PR TITLE
fix(design-system): revert #1179 breaking changes and refactor implementation to improve legibility

### DIFF
--- a/.changeset/fix-button-props.md
+++ b/.changeset/fix-button-props.md
@@ -1,0 +1,27 @@
+---
+"@devopness/ui-react": patch
+---
+
+Revert Button breaking changes
+
+The following changes were made in 2.153.1
+
+```
+-  noMargin?: boolean
++  $noMargin?: boolean
+  /**
+   * The button component has a 10px margin on its sides, to remove activate the "noIconMargin" property
+   */
+-  noIconMargin?: boolean
++  $noIconMargin?: boolean
+  /**
+   * The button component has a 15px padding on its sides, to remove activate the "noPadding" property
+   */
+-  noPadding?: boolean
++  $noPadding?: boolean
+```
+
+This version reverts the diff above
+
+The ButtonProps will be compatible with 2.153.0, and any changes to props will not be released as a patch version in the future
+

--- a/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
+++ b/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
@@ -167,7 +167,7 @@ const BaseButton = styled.button<
     border-color: ${getBorderColor($buttonType, $borderColor)};
     border-radius: 25px;
     border-style: ${getBorderStyle($buttonType)};
-    border-width: ${getBorderWidth($typeSize)};
+    border-width: ${getBorderWidth($typeSize)}px;
 
     &:hover:enabled {
       filter: brightness(75%);

--- a/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
+++ b/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
@@ -99,15 +99,18 @@ const ContentIcon = styled.div<
   Pick<StyledProps, '$iconSize' | '$noIconMargin' | '$revertOrientation'>
 >`
   ${({ $iconSize, $noIconMargin, $revertOrientation }) => css`
+    /** Base */
     display: flex;
-    align-items: center;
-    width: ${$iconSize}px;
     height: ${$iconSize}px;
     ${$noIconMargin
       ? ''
       : $revertOrientation
         ? 'margin-left: 10px;'
         : 'margin-right: 10px;'}
+    width: ${$iconSize}px;
+
+    /** Flex Layout */
+    align-items: center;
   `}
 `
 
@@ -138,38 +141,43 @@ const BaseButton = styled.button<
     $revertOrientation,
     $typeSize,
   }) => css`
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    /** Base */
     cursor: pointer;
-    border: 1px;
-    border-radius: 25px;
-    font-family: ${getFont('roboto')};
-    text-transform: uppercase;
-    padding: ${$noPadding ? '0' : '5px 15px'};
-    margin: ${$noMargin ? '0' : '0 15px'};
-    font-size: 13px;
-    flex-direction: ${$revertOrientation ? 'row-reverse' : 'row'};
-    border-width: ${getBorderWidth($typeSize)};
-    border-style: ${getBorderStyle($buttonType)};
-    border-color: ${getBorderColor($buttonType, $borderColor)};
-    color: ${getTextColor($buttonType, $color)};
+    display: flex;
     background-color: ${getBackgroundColor($buttonType, $backgroundColor)};
     height: ${getHeight($typeSize)};
+    margin: ${$noMargin ? '0' : '0 15px'};
+    padding: ${$noPadding ? '0' : '5px 15px'};
+    user-select: none;
+
+    /** Flex Layout */
+    align-items: center;
+    flex-direction: ${$revertOrientation ? 'row-reverse' : 'row'};
+    justify-content: center;
+
+    /** Text */
+    color: ${getTextColor($buttonType, $color)};
+    font-family: ${getFont('roboto')};
+    font-size: 13px;
     line-height: 1;
+    text-transform: uppercase;
     transition: filter 0.3s;
+
+    /** Border */
+    border-color: ${getBorderColor($buttonType, $borderColor)};
+    border-radius: 25px;
+    border-style: ${getBorderStyle($buttonType)};
+    border-width: ${getBorderWidth($typeSize)};
 
     &:hover:enabled {
       filter: brightness(75%);
     }
 
     &:disabled {
-      pointer-events: ${$noPointerEvents ? 'none' : 'auto'};
-      opacity: 0.5;
       cursor: not-allowed;
+      opacity: 0.5;
+      pointer-events: ${$noPointerEvents ? 'none' : 'auto'};
     }
-
-    user-select: none;
   `}
 `
 

--- a/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
+++ b/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
@@ -104,17 +104,14 @@ const getHeight = (typeSize: StyledProps['$typeSize']) => {
 }
 
 const ContentIcon = styled.div<
-  Pick<StyledProps, '$iconSize' | '$noIconMargin' | '$revertOrientation'>
+  Pick<StyledProps, '$iconSize' | '$noIconMargin'>
 >`
-  ${({ $iconSize, $noIconMargin, $revertOrientation }) => css`
+  ${({ $iconSize, $noIconMargin }) => css`
     /** Base */
     display: flex;
     height: ${$iconSize}px;
-    ${$noIconMargin
-      ? ''
-      : $revertOrientation
-        ? 'margin-left: 10px;'
-        : 'margin-right: 10px;'}
+    /** Use margin-inline to automatically handle direction based on flex-direction */
+    margin-inline: ${$noIconMargin ? '0' : '0 10px'};
     width: ${$iconSize}px;
 
     /** Flex Layout */

--- a/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
+++ b/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
@@ -4,48 +4,53 @@ import type { ButtonProps } from '.'
 import { getColor } from 'src/colors'
 import { getFont } from 'src/fonts'
 
-type CustomButton = {
-  backgroundColor?: string
-  color?: string
-  borderColor?: string
-}
-
 type StyledProps = {
-  $noMargin?: boolean
-  $noPadding?: boolean
-  $size: NonNullable<ButtonProps['typeSize']>
-  $variant?: string
-  $custom?: CustomButton
-  icon?: boolean
-  alignEnd?: boolean
-  reversed: boolean
-  noPointerEvents?: boolean
+  [Key in keyof Pick<
+    ButtonProps,
+    | 'backgroundColor'
+    | 'borderColor'
+    | 'buttonType'
+    | 'color'
+    | 'iconSize'
+    | 'noIconMargin'
+    | 'noMargin'
+    | 'noPadding'
+    | 'noPointerEvents'
+    | 'revertOrientation'
+    | 'typeSize'
+  > as `$${Key}`]: ButtonProps[Key]
 }
 
-const backgroundColor = (buttonType?: string, custom?: CustomButton) => {
+const getBackgroundColor = (
+  buttonType: StyledProps['$buttonType'],
+  backgroundColor: StyledProps['$backgroundColor']
+) => {
   switch (buttonType) {
     case 'borderless':
       return 'transparent'
     case 'outlinedSecondary':
     case 'outlinedAuxiliary':
-      return custom?.backgroundColor ?? getColor('white')
+      return backgroundColor ?? getColor('white')
     default:
-      return custom?.backgroundColor ?? getColor('purple.800')
+      return backgroundColor ?? getColor('purple.800')
   }
 }
 
-const getTextColor = (buttonType?: string, custom?: CustomButton) => {
+const getTextColor = (
+  buttonType: StyledProps['$buttonType'],
+  color: StyledProps['$color']
+) => {
   switch (buttonType) {
     case 'borderless':
     case 'outlinedSecondary':
     case 'outlinedAuxiliary':
-      return custom?.color ?? getColor('purple.800')
+      return color ?? getColor('purple.800')
     default:
-      return custom?.color ?? getColor('white')
+      return color ?? getColor('white')
   }
 }
 
-const getBorderStyle = (buttonType?: string) => {
+const getBorderStyle = (buttonType: StyledProps['$buttonType']) => {
   switch (buttonType) {
     case 'borderless':
       return 'none'
@@ -54,20 +59,23 @@ const getBorderStyle = (buttonType?: string) => {
   }
 }
 
-const getBorderColor = (buttonType?: string, custom?: CustomButton) => {
+const getBorderColor = (
+  buttonType: StyledProps['$buttonType'],
+  borderColor: StyledProps['$borderColor']
+) => {
   switch (buttonType) {
     case 'borderless':
       return ''
     case 'outlinedSecondary':
-      return custom?.borderColor ?? getColor('purple.800')
+      return borderColor ?? getColor('purple.800')
     case 'outlinedAuxiliary':
-      return custom?.borderColor ?? getColor('gray.800')
+      return borderColor ?? getColor('gray.800')
     default:
-      return custom?.borderColor ?? getColor('purple.800')
+      return borderColor ?? getColor('purple.800')
   }
 }
 
-const getBorderWidth = (typeSize: StyledProps['$size']) => {
+const getBorderWidth = (typeSize: StyledProps['$typeSize']) => {
   switch (typeSize) {
     case 'medium':
       return 1
@@ -76,7 +84,7 @@ const getBorderWidth = (typeSize: StyledProps['$size']) => {
   }
 }
 
-const getTypeSize = (typeSize: StyledProps['$size']) => {
+const getHeight = (typeSize: StyledProps['$typeSize']) => {
   switch (typeSize) {
     case 'auto':
       return 'auto'
@@ -88,19 +96,16 @@ const getTypeSize = (typeSize: StyledProps['$size']) => {
 }
 
 const ContentIcon = styled.div<
-  Pick<ButtonProps, '$noIconMargin'> & {
-    reversed: ButtonProps['revertOrientation']
-    size: Required<ButtonProps['iconSize']>
-  }
+  Pick<StyledProps, '$iconSize' | '$noIconMargin' | '$revertOrientation'>
 >`
-  ${({ $noIconMargin, reversed: revertOrientation, size: iconSize }) => css`
+  ${({ $iconSize, $noIconMargin, $revertOrientation }) => css`
     display: flex;
     align-items: center;
-    width: ${iconSize}px;
-    height: ${iconSize}px;
+    width: ${$iconSize}px;
+    height: ${$iconSize}px;
     ${$noIconMargin
       ? ''
-      : revertOrientation
+      : $revertOrientation
         ? 'margin-left: 10px;'
         : 'margin-right: 10px;'}
   `}
@@ -108,26 +113,30 @@ const ContentIcon = styled.div<
 
 const Label = styled.span``
 
-const WrapperButtons = styled.div<StyledProps>`
-  ${({ alignEnd }) => css`
-    display: flex;
-    justify-content: ${alignEnd && 'flex-end'};
-    align-items: center;
-
-    width: 100%;
-    height: 126px;
-  `}
-`
-
-const BaseButton = styled.button<StyledProps>`
+const BaseButton = styled.button<
+  Pick<
+    StyledProps,
+    | '$backgroundColor'
+    | '$borderColor'
+    | '$buttonType'
+    | '$color'
+    | '$noMargin'
+    | '$noPadding'
+    | '$noPointerEvents'
+    | '$revertOrientation'
+    | '$typeSize'
+  >
+>`
   ${({
-    $size: typeSize,
-    $variant: buttonType,
-    $custom: custom,
-    $noPadding: noPadding,
-    $noMargin: noMargin,
-    reversed: revertOrientation,
-    noPointerEvents,
+    $backgroundColor,
+    $borderColor,
+    $buttonType,
+    $color,
+    $noMargin,
+    $noPadding,
+    $noPointerEvents,
+    $revertOrientation,
+    $typeSize,
   }) => css`
     display: flex;
     justify-content: center;
@@ -137,16 +146,16 @@ const BaseButton = styled.button<StyledProps>`
     border-radius: 25px;
     font-family: ${getFont('roboto')};
     text-transform: uppercase;
-    padding: ${noPadding ? '0' : '5px 15px'};
-    nomargin: ${noMargin ? '0' : '0 15px'};
+    padding: ${$noPadding ? '0' : '5px 15px'};
+    margin: ${$noMargin ? '0' : '0 15px'};
     font-size: 13px;
-    flex-direction: ${revertOrientation ? 'row-reverse' : 'row'};
-    border-width: ${getBorderWidth(typeSize)};
-    border-style: ${getBorderStyle(buttonType)};
-    border-color: ${getBorderColor(buttonType, custom)};
-    color: ${getTextColor(buttonType, custom)};
-    background-color: ${backgroundColor(buttonType, custom)};
-    height: ${getTypeSize(typeSize)};
+    flex-direction: ${$revertOrientation ? 'row-reverse' : 'row'};
+    border-width: ${getBorderWidth($typeSize)};
+    border-style: ${getBorderStyle($buttonType)};
+    border-color: ${getBorderColor($buttonType, $borderColor)};
+    color: ${getTextColor($buttonType, $color)};
+    background-color: ${getBackgroundColor($buttonType, $backgroundColor)};
+    height: ${getHeight($typeSize)};
     line-height: 1;
     transition: filter 0.3s;
 
@@ -155,7 +164,7 @@ const BaseButton = styled.button<StyledProps>`
     }
 
     &:disabled {
-      pointer-events: ${noPointerEvents ? 'none' : 'auto'};
+      pointer-events: ${$noPointerEvents ? 'none' : 'auto'};
       opacity: 0.5;
       cursor: not-allowed;
     }
@@ -164,12 +173,4 @@ const BaseButton = styled.button<StyledProps>`
   `}
 `
 
-const SmallWrapper = styled.div<StyledProps>`
-  ${({ icon }) => css`
-    width: 16px;
-    height: 16px;
-    margin-right: ${icon ? '9px' : '10px'};
-  `}
-`
-
-export { ContentIcon, Label, WrapperButtons, BaseButton, SmallWrapper }
+export { BaseButton, ContentIcon, Label }

--- a/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
+++ b/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
@@ -103,15 +103,11 @@ const getHeight = (typeSize: StyledProps['$typeSize']) => {
   }
 }
 
-const ContentIcon = styled.div<
-  Pick<StyledProps, '$iconSize' | '$noIconMargin'>
->`
-  ${({ $iconSize, $noIconMargin }) => css`
+const ContentIcon = styled.div<Pick<StyledProps, '$iconSize'>>`
+  ${({ $iconSize }) => css`
     /** Base */
     display: flex;
     height: ${$iconSize}px;
-    /** Use margin-inline to automatically handle direction based on flex-direction */
-    margin-inline: ${$noIconMargin ? '0' : '0 10px'};
     width: ${$iconSize}px;
 
     /** Flex Layout */
@@ -128,6 +124,7 @@ const BaseButton = styled.button<
     | '$borderColor'
     | '$buttonType'
     | '$color'
+    | '$noIconMargin'
     | '$noMargin'
     | '$noPadding'
     | '$noPointerEvents'
@@ -140,6 +137,7 @@ const BaseButton = styled.button<
     $borderColor,
     $buttonType,
     $color,
+    $noIconMargin,
     $noMargin,
     $noPadding,
     $noPointerEvents,
@@ -156,6 +154,7 @@ const BaseButton = styled.button<
     user-select: none;
 
     /** Flex Layout */
+    gap: ${$noIconMargin ? '0' : '10px'};
     align-items: center;
     flex-direction: ${$revertOrientation ? 'row-reverse' : 'row'};
     justify-content: center;

--- a/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
+++ b/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
@@ -5,6 +5,14 @@ import { getColor } from 'src/colors'
 import { getFont } from 'src/fonts'
 
 type StyledProps = {
+  /**
+   * Button props related to styling
+   *
+   * Adds a `$` prefix to the prop name to prevent it from being passed to the
+   * underlying React node or rendered to the DOM element
+   *
+   * @see {@link https://styled-components.com/docs/api#transient-props | Styled Components - Transient props}
+   */
   [Key in keyof Pick<
     ButtonProps,
     | 'backgroundColor'

--- a/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
@@ -100,8 +100,8 @@ describe('Button', () => {
     it('applies correct icon margins', () => {
       render(<Button icon="html">Button with Icon</Button>)
 
-      const iconContainer = screen.getByTestId('button-icon')
-      expect(iconContainer).toHaveStyle({ 'margin-inline': '0 10px' })
+      const iconContainer = screen.getByTestId('button')
+      expect(iconContainer).toHaveStyle({ gap: '10px' })
     })
 
     it('applies no icon margin when noIconMargin is true', () => {
@@ -114,8 +114,8 @@ describe('Button', () => {
         </Button>
       )
 
-      const iconContainer = screen.getByTestId('button-icon')
-      expect(iconContainer).toHaveStyle({ marginInline: '0' })
+      const iconContainer = screen.getByTestId('button')
+      expect(iconContainer).toHaveStyle({ gap: '0' })
     })
 
     it('with reversed orientation', () => {
@@ -129,10 +129,7 @@ describe('Button', () => {
       )
 
       const button = screen.getByTestId('button')
-      const iconContainer = screen.getByTestId('button-icon')
-
       expect(button).toHaveStyle({ flexDirection: 'row-reverse' })
-      expect(iconContainer).toHaveStyle({ 'margin-inline': '0 10px' })
     })
 
     it('with noPadding prop removes padding', () => {

--- a/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
@@ -8,19 +8,25 @@ describe('Button', () => {
   describe('renders correctly', () => {
     it('with default props', () => {
       render(<Button>Click me!</Button>)
-      
+
       const button = screen.getByTestId('button')
       expect(button).toBeInTheDocument()
       expect(button).toHaveTextContent('Click me!')
+      expect(button).toHaveStyle({
+        backgroundColor: getColor('purple.800'),
+        color: getColor('white'),
+        height: '34px',
+        borderStyle: 'solid',
+      })
     })
 
     it('with custom styles', () => {
       const customColor = '#FF0000'
       const customBgColor = '#00FF00'
       const customBorderColor = '#0000FF'
-      
+
       render(
-        <Button 
+        <Button
           color={customColor}
           backgroundColor={customBgColor}
           borderColor={customBorderColor}
@@ -28,49 +34,97 @@ describe('Button', () => {
           Custom Button
         </Button>
       )
-      
+
       const button = screen.getByTestId('button')
       expect(button).toHaveStyle({
         color: customColor,
         backgroundColor: customBgColor,
-        borderColor: customBorderColor
+        borderColor: customBorderColor,
       })
+    })
+
+    it('with margin controls', () => {
+      render(
+        <Button
+          noMargin
+          noIconMargin
+        >
+          No Margin Button
+        </Button>
+      )
+
+      const button = screen.getByTestId('button')
+      expect(button).toHaveStyle({ margin: '0' })
     })
 
     it('with disabled state', () => {
       render(<Button disabled>Disabled Button</Button>)
-      
+
       const button = screen.getByTestId('button')
       expect(button).toBeDisabled()
+      expect(button).toHaveStyle({ opacity: '0.5', cursor: 'not-allowed' })
     })
 
     it('with loading state', () => {
       render(<Button loading>Loading Button</Button>)
-      
+
       const loadingIcon = screen.getByTestId('loading')
       expect(loadingIcon).toBeInTheDocument()
+      expect(loadingIcon.firstChild).toHaveAttribute('color', getColor('white'))
     })
 
-    it('with custom icon', () => {
+    it('with loading state and different buttonType', () => {
       render(
-        <Button icon="html" iconColor={getColor('purple.800')} iconSize={24}>
+        <Button
+          loading
+          buttonType="borderless"
+        >
+          Loading Button
+        </Button>
+      )
+
+      const loadingIcon = screen.getByTestId('loading')
+      expect(loadingIcon).toBeInTheDocument()
+      expect(loadingIcon.firstChild).toHaveAttribute(
+        'color',
+        getColor('purple.800')
+      )
+    })
+
+    it('with custom icon and properties', () => {
+      const iconColor = getColor('purple.800')
+      const iconSize = 24
+
+      render(
+        <Button
+          icon="html"
+          iconColor={iconColor}
+          iconSize={iconSize}
+        >
           Icon Button
         </Button>
       )
-      
-      const icon = screen.getByTestId('icon')
-      expect(icon).toBeInTheDocument()
+
+      const iconContainer = screen.getByTestId('icon')
+      expect(iconContainer).toBeInTheDocument()
+      expect(iconContainer).toHaveStyle({
+        width: `${iconSize}px`,
+        height: `${iconSize}px`,
+      })
     })
 
     it('with reversed orientation', () => {
       render(
-        <Button icon="html" revertOrientation>
+        <Button
+          icon="html"
+          revertOrientation
+        >
           Reversed Button
         </Button>
       )
-      
+
       const button = screen.getByTestId('button')
-      expect(button).toHaveAttribute('$revertOrientation', 'true')
+      expect(button).toHaveStyle({ flexDirection: 'row-reverse' })
     })
   })
 
@@ -78,44 +132,92 @@ describe('Button', () => {
     it('handles click events', () => {
       const handleClick = vi.fn()
       render(<Button onClick={handleClick}>Clickable Button</Button>)
-      
+
       const button = screen.getByTestId('button')
       fireEvent.click(button)
       expect(handleClick).toHaveBeenCalledTimes(1)
     })
 
     it('prevents interaction when noPointerEvents is true', () => {
-      const handleClick = vi.fn()
       render(
-        <Button noPointerEvents onClick={handleClick}>
+        <Button
+          noPointerEvents
+          disabled
+        >
           No Pointer Events Button
         </Button>
       )
-      
+
       const button = screen.getByTestId('button')
-      expect(button).toHaveStyle({ pointerEvents: 'none' })
+      expect(button).toHaveStyle({ 'pointer-events': 'none' })
     })
   })
 
   describe('button types', () => {
-    const buttonTypes = ['borderless', 'outlinedSecondary', 'outlinedAuxiliary'] as const
-    
-    it.each(buttonTypes)('renders %s button type correctly', (buttonType) => {
-      render(<Button buttonType={buttonType}>Button</Button>)
-      
+    it('renders borderless button type correctly', () => {
+      render(<Button buttonType="borderless">Button</Button>)
+
       const button = screen.getByTestId('button')
-      expect(button).toHaveAttribute('$buttonType', buttonType)
+      expect(button).toHaveStyle({
+        backgroundColor: 'rgba(0, 0, 0, 0)',
+        color: getColor('purple.800'),
+        borderStyle: 'none',
+      })
+    })
+
+    it('renders outlinedSecondary button type correctly', () => {
+      render(<Button buttonType="outlinedSecondary">Button</Button>)
+
+      const button = screen.getByTestId('button')
+      expect(button).toHaveStyle({
+        backgroundColor: getColor('white'),
+        color: getColor('purple.800'),
+        borderColor: getColor('purple.800'),
+        borderStyle: 'solid',
+      })
+    })
+
+    it('renders outlinedAuxiliary button type correctly', () => {
+      render(<Button buttonType="outlinedAuxiliary">Button</Button>)
+
+      const button = screen.getByTestId('button')
+      expect(button).toHaveStyle({
+        backgroundColor: getColor('white'),
+        color: getColor('purple.800'),
+        borderColor: getColor('gray.800'),
+        borderStyle: 'solid',
+      })
     })
   })
 
   describe('size variations', () => {
-    const sizes = ['default', 'medium', 'auto'] as const
-    
-    it.each(sizes)('renders %s size correctly', (typeSize) => {
-      render(<Button typeSize={typeSize}>Button</Button>)
-      
+    it('renders default size correctly', () => {
+      render(<Button typeSize="default">Button</Button>)
+
       const button = screen.getByTestId('button')
-      expect(button).toHaveAttribute('$typeSize', typeSize)
+      expect(button).toHaveStyle({
+        height: '34px',
+        borderWidth: '2px',
+      })
+    })
+
+    it('renders medium size correctly', () => {
+      render(<Button typeSize="medium">Button</Button>)
+
+      const button = screen.getByTestId('button')
+      expect(button).toHaveStyle({
+        height: '27px',
+        borderWidth: '1px',
+      })
+    })
+
+    it('renders auto size correctly', () => {
+      render(<Button typeSize="auto">Button</Button>)
+
+      const button = screen.getByTestId('button')
+      expect(button).toHaveStyle({
+        height: 'auto',
+      })
     })
   })
 })

--- a/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
@@ -1,190 +1,121 @@
 import '@testing-library/jest-dom'
-
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
-
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { getColor } from 'src/colors'
 import { Button } from '.'
-
-const styleButtonFactory = ({
-  color = 'rgb(255, 255, 255)',
-  backgroundColor = 'rgb(120, 110, 253)',
-  border = '1px',
-  borderColor = '#786efd',
-  borderRadius = '25px',
-  height = '34px',
-  borderStyle = 'solid',
-}) => `
-      color: ${color};
-      background-color: ${backgroundColor};
-      border: ${border};
-      border-color: ${borderColor};
-      border-style: ${borderStyle};
-      border-radius: ${borderRadius};
-      height: ${height};
-      `
 
 describe('Button', () => {
   describe('renders correctly', () => {
-    const typeSizes = [
-      { typeSize: 'default', height: '34px' },
-      { typeSize: 'medium', height: '27px' },
-    ] as const
+    it('with default props', () => {
+      render(<Button>Click me!</Button>)
+      
+      const button = screen.getByTestId('button')
+      expect(button).toBeInTheDocument()
+      expect(button).toHaveTextContent('Click me!')
+    })
 
-    it.each(typeSizes)(
-      'with primary type (typeSize: $typeSize)',
-      ({ typeSize, height }) => {
-        render(
-          <Button
-            type="button"
-            typeSize={typeSize}
-          >
-            Click me!
-          </Button>
-        )
+    it('with custom styles', () => {
+      const customColor = '#FF0000'
+      const customBgColor = '#00FF00'
+      const customBorderColor = '#0000FF'
+      
+      render(
+        <Button 
+          color={customColor}
+          backgroundColor={customBgColor}
+          borderColor={customBorderColor}
+        >
+          Custom Button
+        </Button>
+      )
+      
+      const button = screen.getByTestId('button')
+      expect(button).toHaveStyle({
+        color: customColor,
+        backgroundColor: customBgColor,
+        borderColor: customBorderColor
+      })
+    })
 
-        const expectedButton = screen.getByTestId('button')
-        const expectedStyles = styleButtonFactory({ height })
+    it('with disabled state', () => {
+      render(<Button disabled>Disabled Button</Button>)
+      
+      const button = screen.getByTestId('button')
+      expect(button).toBeDisabled()
+    })
 
-        expect(expectedButton).toBeInTheDocument()
-        expect(expectedButton).toHaveTextContent('Click me!')
-        expect(expectedButton).toHaveStyle(expectedStyles)
-        expect(expectedButton).toHaveAttribute('type', 'button')
-      }
-    )
+    it('with loading state', () => {
+      render(<Button loading>Loading Button</Button>)
+      
+      const loadingIcon = screen.getByTestId('loading')
+      expect(loadingIcon).toBeInTheDocument()
+    })
 
-    it.each(typeSizes)(
-      'with secondary type (typeSize: $typeSize)',
-      ({ typeSize, height }) => {
-        render(
-          <Button
-            type="button"
-            typeSize={typeSize}
-            buttonType="outlinedSecondary"
-          >
-            Click me!
-          </Button>
-        )
+    it('with custom icon', () => {
+      render(
+        <Button icon="html" iconColor={getColor('purple.800')} iconSize={24}>
+          Icon Button
+        </Button>
+      )
+      
+      const icon = screen.getByTestId('icon')
+      expect(icon).toBeInTheDocument()
+    })
 
-        const expectedButton = screen.getByTestId('button')
-        const expectedStyles = styleButtonFactory({
-          color: 'rgb(120, 110, 253)',
-          backgroundColor: 'rgb(255, 255, 255)',
-          height,
-        })
+    it('with reversed orientation', () => {
+      render(
+        <Button icon="html" revertOrientation>
+          Reversed Button
+        </Button>
+      )
+      
+      const button = screen.getByTestId('button')
+      expect(button).toHaveAttribute('$revertOrientation', 'true')
+    })
+  })
 
-        expect(expectedButton).toBeInTheDocument()
-        expect(expectedButton).toHaveTextContent('Click me!')
-        expect(expectedButton).toHaveStyle(expectedStyles)
-        expect(expectedButton).toHaveAttribute('type', 'button')
-      }
-    )
+  describe('interactions', () => {
+    it('handles click events', () => {
+      const handleClick = vi.fn()
+      render(<Button onClick={handleClick}>Clickable Button</Button>)
+      
+      const button = screen.getByTestId('button')
+      fireEvent.click(button)
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
 
-    it.each(typeSizes)(
-      'with borderless type (typeSize: $typeSize)',
-      ({ typeSize, height }) => {
-        render(
-          <Button
-            type="button"
-            typeSize={typeSize}
-            buttonType="borderless"
-          >
-            Click me!
-          </Button>
-        )
+    it('prevents interaction when noPointerEvents is true', () => {
+      const handleClick = vi.fn()
+      render(
+        <Button noPointerEvents onClick={handleClick}>
+          No Pointer Events Button
+        </Button>
+      )
+      
+      const button = screen.getByTestId('button')
+      expect(button).toHaveStyle({ pointerEvents: 'none' })
+    })
+  })
 
-        const expectedButton = screen.getByTestId('button')
-        const expectedStyles = styleButtonFactory({
-          color: 'rgb(120, 110, 253)',
-          backgroundColor: 'rgba(0, 0, 0, 0)',
-          border: '1px',
-          borderColor: '',
-          height,
-          borderStyle: 'none',
-        })
+  describe('button types', () => {
+    const buttonTypes = ['borderless', 'outlinedSecondary', 'outlinedAuxiliary'] as const
+    
+    it.each(buttonTypes)('renders %s button type correctly', (buttonType) => {
+      render(<Button buttonType={buttonType}>Button</Button>)
+      
+      const button = screen.getByTestId('button')
+      expect(button).toHaveAttribute('$buttonType', buttonType)
+    })
+  })
 
-        expect(expectedButton).toBeInTheDocument()
-        expect(expectedButton).toHaveTextContent('Click me!')
-        expect(expectedButton).toHaveStyle(expectedStyles)
-        expect(expectedButton).toHaveAttribute('type', 'button')
-      }
-    )
-
-    it.each(typeSizes)(
-      'with outlined auxiliary type (typeSize: $typeSize)',
-      ({ typeSize, height }) => {
-        render(
-          <Button
-            type="button"
-            typeSize={typeSize}
-            buttonType="outlinedAuxiliary"
-          >
-            Click me!
-          </Button>
-        )
-
-        const expectedButton = screen.getByTestId('button')
-        const expectedStyles = styleButtonFactory({
-          color: 'rgb(120, 110, 253)',
-          backgroundColor: 'rgb(255, 255, 255)',
-          height,
-          borderColor: '#828795',
-        })
-
-        expect(expectedButton).toBeInTheDocument()
-        expect(expectedButton).toHaveTextContent('Click me!')
-        expect(expectedButton).toHaveStyle(expectedStyles)
-        expect(expectedButton).toHaveAttribute('type', 'button')
-      }
-    )
-
-    it.each(typeSizes)(
-      'with loading (typeSize: $typeSize)',
-      ({ typeSize, height }) => {
-        render(
-          <Button
-            type="button"
-            typeSize={typeSize}
-            loading
-          >
-            Click me!
-          </Button>
-        )
-
-        const expectedButton = screen.getByTestId('button')
-        const expectedStyles = styleButtonFactory({ height })
-        const expectedLoading = screen.getByTestId('loading')
-
-        expect(expectedButton).toBeInTheDocument()
-        expect(expectedButton).toHaveTextContent('Click me!')
-        expect(expectedButton).toHaveStyle(expectedStyles)
-        expect(expectedButton).toHaveAttribute('type', 'button')
-        expect(expectedLoading).toBeInTheDocument()
-      }
-    )
-
-    it.each(typeSizes)(
-      'with icon (typeSize: $typeSize)',
-      ({ typeSize, height }) => {
-        render(
-          <Button
-            type="button"
-            typeSize={typeSize}
-            icon="html"
-          >
-            Click me!
-          </Button>
-        )
-
-        const expectedButton = screen.getByTestId('button')
-        const expectedStyles = styleButtonFactory({ height })
-        const expectedIcon = screen.getByTestId('icon')
-
-        expect(expectedButton).toBeInTheDocument()
-        expect(expectedButton).toHaveTextContent('Click me!')
-        expect(expectedButton).toHaveStyle(expectedStyles)
-        expect(expectedButton).toHaveAttribute('type', 'button')
-        expect(expectedIcon).toBeInTheDocument()
-      }
-    )
+  describe('size variations', () => {
+    const sizes = ['default', 'medium', 'auto'] as const
+    
+    it.each(sizes)('renders %s size correctly', (typeSize) => {
+      render(<Button typeSize={typeSize}>Button</Button>)
+      
+      const button = screen.getByTestId('button')
+      expect(button).toHaveAttribute('$typeSize', typeSize)
+    })
   })
 })

--- a/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
@@ -1,8 +1,9 @@
 import '@testing-library/jest-dom'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { getColor } from 'src/colors'
+
 import { Button } from '.'
+import { getColor } from 'src/colors'
 
 describe('Button', () => {
   describe('renders correctly', () => {
@@ -111,8 +112,8 @@ describe('Button', () => {
       expect(iconContainer).toBeInTheDocument()
       expect(iconContainer).toHaveAttribute('aria-label', 'html icon')
       expect(iconContainer).toHaveStyle({
-        width: `${iconSize}px`,
-        height: `${iconSize}px`,
+        width: `${iconSize.toString()}px`,
+        height: `${iconSize.toString()}px`,
       })
     })
 

--- a/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
@@ -68,8 +68,9 @@ describe('Button', () => {
     it('with loading state', () => {
       render(<Button loading>Loading Button</Button>)
 
-      const loadingIcon = screen.getByTestId('loading')
+      const loadingIcon = screen.getByTestId('button-icon')
       expect(loadingIcon).toBeInTheDocument()
+      expect(loadingIcon).toHaveAttribute('aria-label', 'loading')
       expect(loadingIcon.firstChild).toHaveAttribute('color', getColor('white'))
     })
 
@@ -83,8 +84,9 @@ describe('Button', () => {
         </Button>
       )
 
-      const loadingIcon = screen.getByTestId('loading')
+      const loadingIcon = screen.getByTestId('button-icon')
       expect(loadingIcon).toBeInTheDocument()
+      expect(loadingIcon).toHaveAttribute('aria-label', 'loading')
       expect(loadingIcon.firstChild).toHaveAttribute(
         'color',
         getColor('purple.800')
@@ -105,8 +107,9 @@ describe('Button', () => {
         </Button>
       )
 
-      const iconContainer = screen.getByTestId('icon')
+      const iconContainer = screen.getByTestId('button-icon')
       expect(iconContainer).toBeInTheDocument()
+      expect(iconContainer).toHaveAttribute('aria-label', 'html icon')
       expect(iconContainer).toHaveStyle({
         width: `${iconSize}px`,
         height: `${iconSize}px`,

--- a/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
@@ -56,6 +56,9 @@ describe('Button', () => {
 
       const button = screen.getByTestId('button')
       expect(button).toHaveStyle({ margin: '0' })
+
+      const iconContainer = screen.queryByTestId('button-icon')
+      expect(iconContainer).not.toBeInTheDocument()
     })
 
     it('with disabled state', () => {
@@ -94,27 +97,25 @@ describe('Button', () => {
       )
     })
 
-    it('with custom icon and properties', () => {
-      const iconColor = getColor('purple.800')
-      const iconSize = 24
+    it('applies correct icon margins', () => {
+      render(<Button icon="html">Button with Icon</Button>)
 
+      const iconContainer = screen.getByTestId('button-icon')
+      expect(iconContainer).toHaveStyle({ 'margin-inline': '0 10px' })
+    })
+
+    it('applies no icon margin when noIconMargin is true', () => {
       render(
         <Button
           icon="html"
-          iconColor={iconColor}
-          iconSize={iconSize}
+          noIconMargin
         >
-          Icon Button
+          Button with Icon
         </Button>
       )
 
       const iconContainer = screen.getByTestId('button-icon')
-      expect(iconContainer).toBeInTheDocument()
-      expect(iconContainer).toHaveAttribute('aria-label', 'html icon')
-      expect(iconContainer).toHaveStyle({
-        width: `${iconSize.toString()}px`,
-        height: `${iconSize.toString()}px`,
-      })
+      expect(iconContainer).toHaveStyle({ marginInline: '0' })
     })
 
     it('with reversed orientation', () => {
@@ -128,7 +129,48 @@ describe('Button', () => {
       )
 
       const button = screen.getByTestId('button')
+      const iconContainer = screen.getByTestId('button-icon')
+
       expect(button).toHaveStyle({ flexDirection: 'row-reverse' })
+      expect(iconContainer).toHaveStyle({ 'margin-inline': '0 10px' })
+    })
+
+    it('with noPadding prop removes padding', () => {
+      render(<Button noPadding>No Padding Button</Button>)
+
+      const button = screen.getByTestId('button')
+      expect(button).toHaveStyle({
+        padding: '0',
+      })
+    })
+
+    it('loading state should override icon prop', () => {
+      render(
+        <Button
+          loading
+          icon="html"
+        >
+          Button
+        </Button>
+      )
+
+      const iconContainer = screen.getByTestId('button-icon')
+      expect(iconContainer).toHaveAttribute('aria-label', 'loading')
+      expect(iconContainer).not.toHaveAttribute('aria-label', 'html icon')
+    })
+
+    it('should not render icon container when no icon or loading props provided', () => {
+      render(<Button>Button</Button>)
+
+      const iconContainer = screen.queryByTestId('button-icon')
+      expect(iconContainer).not.toBeInTheDocument()
+    })
+
+    it('should not render label when no children provided', () => {
+      render(<Button icon="html" />)
+
+      const label = screen.queryByTestId('button-label')
+      expect(label).not.toBeInTheDocument()
     })
   })
 

--- a/packages/ui/react/src/components/Buttons/Button/Button.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.tsx
@@ -25,7 +25,7 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   color?: string
   /** Icon name */
   icon?: Icon
-  /** 
+  /**
    * By default the icon color is primary, use this prop to customize "iconColor"
    */
   iconColor?: ReturnType<typeof getColor>

--- a/packages/ui/react/src/components/Buttons/Button/Button.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.tsx
@@ -103,9 +103,9 @@ const Button = ({
     return (
       <ContentIcon
         data-testid={isLoading ? 'loading' : 'icon'}
-        $revertOrientation={revertOrientation}
-        $noIconMargin={noIconMargin}
         $iconSize={iconSize ?? DEFAULT_ICON_SIZE}
+        $noIconMargin={noIconMargin}
+        $revertOrientation={revertOrientation}
       >
         {iconLoader(
           isLoading ? 'loading' : icon,
@@ -119,17 +119,17 @@ const Button = ({
   return (
     <BaseButton
       data-testid="button"
-      $typeSize={typeSize}
-      $buttonType={buttonType}
-      $revertOrientation={revertOrientation}
-      $noPointerEvents={noPointerEvents}
-      $color={color}
       $backgroundColor={backgroundColor}
       $borderColor={borderColor}
+      $buttonType={buttonType}
+      $color={color}
       $noMargin={noMargin}
+      $noPointerEvents={noPointerEvents}
+      $revertOrientation={revertOrientation}
+      $typeSize={typeSize}
       disabled={disabled}
-      type={type}
       tabIndex={tabIndex}
+      type={type}
       {...props}
     >
       <Icon />

--- a/packages/ui/react/src/components/Buttons/Button/Button.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.tsx
@@ -102,10 +102,11 @@ const Button = ({
 
     return (
       <ContentIcon
-        data-testid={isLoading ? 'loading' : 'icon'}
+        data-testid="button-icon"
         $iconSize={iconSize ?? DEFAULT_ICON_SIZE}
         $noIconMargin={noIconMargin}
         $revertOrientation={revertOrientation}
+        aria-label={isLoading ? 'loading' : `${icon} icon`}
       >
         {iconLoader(
           isLoading ? 'loading' : icon,
@@ -133,7 +134,14 @@ const Button = ({
       {...props}
     >
       <Icon />
-      {children && <Label className="translate">{children}</Label>}
+      {children && (
+        <Label
+          data-testid="button-label"
+          className="translate"
+        >
+          {children}
+        </Label>
+      )}
     </BaseButton>
   )
 }

--- a/packages/ui/react/src/components/Buttons/Button/Button.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.tsx
@@ -8,20 +8,10 @@ import { iconLoader } from 'src/icons'
 const DEFAULT_ICON_SIZE = 16
 
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  /**
-   * By default the button component is 34px high, the "typeSize" property contains
-   * the "medium" variation that changes to 27px
-   */
-  typeSize?: 'default' | 'medium' | 'auto'
-  /** Icon name */
-  icon?: Icon
-  /** Enable button loading animation */
-  loading?: boolean
-  /**
-   * With the property "revertOrientation" it is possible to change the positioning of
-   * the elements inside the button as "icon" or "loading"
-   */
-  revertOrientation?: boolean
+  /** Customize background color */
+  backgroundColor?: string
+  /** Customize border color */
+  borderColor?: string
   /** Predefined style variations for the button */
   buttonType?:
     | 'borderless'
@@ -33,40 +23,44 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
    * Customize elements color
    */
   color?: string
-  /** `Warning`: This property overrides the style defined by the `buttonType` property!
-   *
-   * Customize background color
+  /** Icon name */
+  icon?: Icon
+  /** 
+   * By default the icon color is primary, use this prop to customize "iconColor"
    */
-  backgroundColor?: string
-  /** `Warning`: This property overrides the style defined by the `buttonType` property!
-   *
-   * Customize border color
+  iconColor?: ReturnType<typeof getColor>
+  /**
+   * By default the icon component is 16px high, use this prop to customize "iconSize"
    */
-  borderColor?: string
+  iconSize?: number
+  /** Enable button loading animation */
+  loading?: boolean
   /**
    * The button component has a 15px margin on its sides, to remove activate the "noMargin" property
    */
-  $noMargin?: boolean
+  noMargin?: boolean
   /**
    * The button component has a 10px margin on its sides, to remove activate the "noIconMargin" property
    */
-  $noIconMargin?: boolean
+  noIconMargin?: boolean
   /**
    * The button component has a 15px padding on its sides, to remove activate the "noPadding" property
    */
-  $noPadding?: boolean
+  noPadding?: boolean
   /**
    * It should be true if the button is wrapped in a tooltip
    */
   noPointerEvents?: boolean
   /**
-   * By default the icon component is 16px high, use this prop to customize "iconSize"
+   * With the property "revertOrientation" it is possible to change the positioning of
+   * the elements inside the button as "icon" or "loading"
    */
-  iconSize?: number
+  revertOrientation?: boolean
   /**
-   * By default the icon color is primary, use this prop to customize "iconColor"
+   * By default the button component is 34px high, the "typeSize" property contains
+   * the "medium" variation that changes to 27px
    */
-  iconColor?: ReturnType<typeof getColor>
+  typeSize?: 'default' | 'medium' | 'auto'
 }
 
 const getLoadingColor = (buttonType?: string) => {
@@ -82,23 +76,23 @@ const getLoadingColor = (buttonType?: string) => {
 
 /** Primary UI component for user interaction */
 const Button = ({
-  type,
-  typeSize = 'default',
-  buttonType,
-  color,
   backgroundColor,
   borderColor,
-  disabled,
-  tabIndex,
-  loading: isLoading,
-  icon,
+  buttonType,
   children,
-  revertOrientation = false,
-  $noMargin: noMargin,
-  $noIconMargin,
-  noPointerEvents,
-  iconSize,
+  color,
+  disabled,
+  icon,
   iconColor,
+  iconSize,
+  loading: isLoading,
+  noIconMargin,
+  noMargin,
+  noPointerEvents,
+  revertOrientation = false,
+  tabIndex,
+  type,
+  typeSize = 'default',
   ...props
 }: ButtonProps) => {
   const Icon = () => {
@@ -109,9 +103,9 @@ const Button = ({
     return (
       <ContentIcon
         data-testid={isLoading ? 'loading' : 'icon'}
-        reversed={revertOrientation}
-        $noIconMargin={$noIconMargin}
-        size={iconSize ?? DEFAULT_ICON_SIZE}
+        $revertOrientation={revertOrientation}
+        $noIconMargin={noIconMargin}
+        $iconSize={iconSize ?? DEFAULT_ICON_SIZE}
       >
         {iconLoader(
           isLoading ? 'loading' : icon,
@@ -125,15 +119,13 @@ const Button = ({
   return (
     <BaseButton
       data-testid="button"
-      $size={typeSize}
-      $variant={buttonType}
-      reversed={revertOrientation}
-      noPointerEvents={noPointerEvents}
-      $custom={{
-        color: color,
-        backgroundColor: backgroundColor,
-        borderColor: borderColor,
-      }}
+      $typeSize={typeSize}
+      $buttonType={buttonType}
+      $revertOrientation={revertOrientation}
+      $noPointerEvents={noPointerEvents}
+      $color={color}
+      $backgroundColor={backgroundColor}
+      $borderColor={borderColor}
       $noMargin={noMargin}
       disabled={disabled}
       type={type}

--- a/packages/ui/react/src/components/Buttons/Button/Button.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.tsx
@@ -106,7 +106,7 @@ const Button = ({
         $iconSize={iconSize ?? DEFAULT_ICON_SIZE}
         $noIconMargin={noIconMargin}
         $revertOrientation={revertOrientation}
-        aria-label={isLoading ? 'loading' : `${icon} icon`}
+        aria-label={isLoading ? 'loading' : icon ? `${icon} icon` : undefined}
       >
         {iconLoader(
           isLoading ? 'loading' : icon,

--- a/packages/ui/react/src/components/Buttons/Button/Button.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.tsx
@@ -104,7 +104,6 @@ const Button = ({
       <ContentIcon
         data-testid="button-icon"
         $iconSize={iconSize ?? DEFAULT_ICON_SIZE}
-        $noIconMargin={noIconMargin}
         /**
          * Icon is safe to use non-null assertion because this component only renders
          * when either isLoading or icon prop is defined, as checked by noDefinedIcons
@@ -128,6 +127,7 @@ const Button = ({
       $borderColor={borderColor}
       $buttonType={buttonType}
       $color={color}
+      $noIconMargin={noIconMargin}
       $noMargin={noMargin}
       $noPadding={noPadding}
       $noPointerEvents={noPointerEvents}

--- a/packages/ui/react/src/components/Buttons/Button/Button.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.tsx
@@ -88,6 +88,7 @@ const Button = ({
   loading: isLoading,
   noIconMargin,
   noMargin,
+  noPadding,
   noPointerEvents,
   revertOrientation = false,
   tabIndex,
@@ -96,17 +97,20 @@ const Button = ({
   ...props
 }: ButtonProps) => {
   const Icon = () => {
-    const noDefinedIcons = isLoading === undefined && icon === undefined
-    const noVisibleIcons = !isLoading && icon === undefined
-    if (noDefinedIcons || noVisibleIcons) return <></>
+    const noDefinedIcons = !isLoading && !icon
+    if (noDefinedIcons) return <></>
 
     return (
       <ContentIcon
         data-testid="button-icon"
         $iconSize={iconSize ?? DEFAULT_ICON_SIZE}
         $noIconMargin={noIconMargin}
-        $revertOrientation={revertOrientation}
-        aria-label={isLoading ? 'loading' : icon ? `${icon} icon` : undefined}
+        /**
+         * Icon is safe to use non-null assertion because this component only renders
+         * when either isLoading or icon prop is defined, as checked by noDefinedIcons
+         */
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        aria-label={isLoading ? 'loading' : `${icon!} icon`}
       >
         {iconLoader(
           isLoading ? 'loading' : icon,
@@ -125,6 +129,7 @@ const Button = ({
       $buttonType={buttonType}
       $color={color}
       $noMargin={noMargin}
+      $noPadding={noPadding}
       $noPointerEvents={noPointerEvents}
       $revertOrientation={revertOrientation}
       $typeSize={typeSize}

--- a/packages/ui/react/src/components/Forms/Alert/Alert.tsx
+++ b/packages/ui/react/src/components/Forms/Alert/Alert.tsx
@@ -79,8 +79,8 @@ const Alert = (props: AlertProps) => (
               icon="close"
               buttonType="borderless"
               iconColor={getColor(alertTypeToIconColor[props.type])}
-              $noPadding
-              $noIconMargin
+              noPadding
+              noIconMargin
               onClick={props.onClose}
             />
           ) : (

--- a/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.tsx
+++ b/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.tsx
@@ -218,8 +218,8 @@ const ElementAnchor = ({
       wrapper={(children) => <Tooltip title={tooltip}>{children}</Tooltip>}
     >
       <Button
-        $noMargin
-        $noIconMargin={!!buttonProps?.icon}
+        noMargin
+        noIconMargin={!!buttonProps?.icon}
         typeSize="medium"
         {...buttonProps}
         icon={!props.hideDropdownIcon ? dropdownIcon : undefined}

--- a/packages/ui/react/src/components/Primitives/Pagination/Pagination.tsx
+++ b/packages/ui/react/src/components/Primitives/Pagination/Pagination.tsx
@@ -53,7 +53,7 @@ const Pagination = ({
         type="button"
         buttonType={'outlinedAuxiliary'}
         typeSize="medium"
-        $noMargin
+        noMargin
         onClick={firstPaginateAction}
         disabled={disableAllActions || disablePreviousActions}
       >
@@ -64,7 +64,7 @@ const Pagination = ({
         buttonType={'outlinedSecondary'}
         typeSize="medium"
         icon="leftArrow"
-        $noMargin
+        noMargin
         onClick={previousPaginateAction}
         disabled={disableAllActions || disablePreviousActions}
       >
@@ -76,7 +76,7 @@ const Pagination = ({
         typeSize="medium"
         icon="rightArrow"
         revertOrientation
-        $noMargin
+        noMargin
         onClick={nextPaginateAction}
         disabled={disableAllActions || disableNextActions}
       >
@@ -86,7 +86,7 @@ const Pagination = ({
         type="button"
         buttonType={'outlinedAuxiliary'}
         typeSize="medium"
-        $noMargin
+        noMargin
         onClick={lastPaginateAction}
         disabled={disableAllActions || disableNextActions}
       >


### PR DESCRIPTION
## Description of changes
<!--
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]
If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->
- Fix breaking changes in Button [1]
    - Reverted changes made directly to ButtonProps in #1179 [1]
    - Update Button test suite
        - The updated test suite has a higher code coverage [2]
        - This change aims to help detect future breaking changes in props
    - Removed unused styles declared in Button.styled.ts
    - Sorted and commented style code, to improve legibility
 
## GitHub issues resolved by this PR
<!--
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->
N/A
## Quality Assurance
<!-- Please complete this checklist before requesting a review of your pull request. -->
- Once the changes in this PR are merged and deployed, success criteria is: The updated Button should be compatible with v2.153.0 version, enabling users to update the dependency without needing to update props
## More info
<!--
More info to help repository maintainers when reviewing your PR: links, images, videos, ...
-->
[1]
Revert the changes below to ButtonProps, that added the prefix "$", from styled component transient props
```
  $noMargin?: boolean
  /**
   * The button component has a 10px margin on its sides, to remove activate the "noIconMargin" property
   */
  $noIconMargin?: boolean
  /**
   * The button component has a 15px padding on its sides, to remove activate the "noPadding" property
   */
  $noPadding?: boolean
```
[2]

Coverage data was collected locally using the command

```bash
npm run test -- run --coverage src/components/Buttons/Button/Button.test.tsx
```

### BEFORE

```
----------------------------------------|---------|----------|---------|---------|--------------------
File                                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------------------------|---------|----------|---------|---------|--------------------
 src/components/Buttons/Button          |   85.64 |    81.13 |     100 |   85.64 |
  Button.stories.ts                     |       0 |      100 |     100 |       0 | 2-30
  Button.styled.ts                      |   95.32 |    78.78 |     100 |   95.32 | 82,102,104,114,171
  Button.tsx                            |   98.59 |    84.21 |     100 |   98.59 | 77
  index.ts                              |     100 |      100 |     100 |     100 |
```
### AFTER
```
----------------------------------------|---------|----------|---------|---------|--------------------
File                                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------------------------|---------|----------|---------|---------|--------------------
src/components/Buttons/Button           |   88.61 |      100 |     100 |   88.61 |
  Button.stories.ts                     |       0 |      100 |     100 |       0 | 2-30
  Button.styled.ts                      |     100 |      100 |     100 |     100 |
  Button.tsx                            |     100 |      100 |     100 |     100 |
  index.ts                              |     100 |      100 |     100 |     100 |
```