### PR TITLE
fix: validate pr-title job name

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -9,11 +9,11 @@ on:
 
 jobs:
   validate_pr_title:
-    name: Validate PR Title
+    name: Validate PR title
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
-      - name: Validate PR Title
+      - name: Validate PR title
         uses: amannn/action-semantic-pull-request@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description of changes  
<!--  
Short description of how this PR makes the world a better place for Devopness users or team members:  
* Example: Clicking on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]  

If the PR is still in draft state, please add a **Why draft?** section clarifying what help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.  
-->  
- [x] Restore the CI job name 'Validate PR Title' that was changed in PR #1239  

## GitHub issues resolved by this PR  
<!--  
Check list box of GitHub issues completed by this PR.  
Use `N/A` if this PR is not fixing any existing issue.  
-->  

- N/A  

## Quality Assurance  

<!-- Please complete this checklist before requesting a review of your pull request. -->  

- Once the changes in this PR are merged and deployed, the success criteria is: the CI job 'Validate PR Title' runs correctly on PRs.  

## More info  
<!--  
More info to help repository maintainers when reviewing your PR: links, images, videos, ...  
-->  

#### Example of a PR with the CI job 'Validate PR Title' stuck in the status 'Expected — Waiting for status to be reported' - #1252 
![image](https://github.com/user-attachments/assets/40279348-da83-41fd-953d-05335a790f4d)
