### PR TITLE
fix: update PR validation to exclude 'github-actions' user from checks

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -21,7 +21,7 @@ jobs:
   validate_pr_description:
     name: Validate PR Description
     runs-on: ubuntu-latest
-    if: ${{ !contains('dependabot[bot],devopness-automations', github.event.pull_request.user.login) }}
+    if: ${{ !contains('dependabot[bot],devopness-automations,github-actions', github.event.pull_request.user.login) }}
     steps:
       - name: Convert PR Description Markdown to JSON
         uses: kkurno/action-markdown-reader@v0.1.0


### PR DESCRIPTION
## Description of changes  
<!--  
Short description of how this PR makes the world a better place for Devopness users or team members:  
* Example: Clicking on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]  

If the PR is still in draft state, please add a **Why draft?** section clarifying what help or feedback you need or mention what needs to be done before the PR is ready to be reviewed.  
-->  
- [x] Ignore PRs from the user [github-actions](https://github.com/apps/github-actions) in the `PR Lint` CI check  

## GitHub issues resolved by this PR  
<!--  
Check list box of GitHub issues completed by this PR.  
Use `N/A` if this PR is not fixing any existing issue.  
-->  

- N/A  

## Quality Assurance  
<!-- Please complete this checklist before requesting a review of your pull request. -->  

- Once the changes in this PR are merged and deployed, the success criteria is: PRs from the user [github-actions](https://github.com/apps/github-actions) will no longer be checked by the `PR Lint` CI.  

## More info  
<!--  
More info to help repository maintainers when reviewing your PR: links, images, videos, ...  
-->  

- PR from [github-actions](https://github.com/apps/github-actions) blocked by the `PR Lint` CI - [#1257](https://github.com/devopness/devopness/actions/runs/13040682748/job/36381621847?pr=1257)