### PR TITLE
Feat/input error focus

### DIFF
--- a/packages/ui/react/src/components/Forms/Input/Input.stories.tsx
+++ b/packages/ui/react/src/components/Forms/Input/Input.stories.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { Input } from './Input'
@@ -6,7 +8,22 @@ import { Container } from './Input.styled'
 const meta = {
   title: 'Form/Input',
   component: Input,
-  parameters: { docs: { source: { type: 'code' } } },
+  parameters: {
+    docs: {
+      source: { type: 'code' },
+      description: {
+        component: `
+A flexible input component that supports:
+- Various input types (text, number, etc.)
+- Error states with automatic focus
+- Custom styling
+- Label and help text
+
+When an error state is applied, the input will automatically receive focus to draw the user's attention.
+    `,
+      },
+    },
+  },
   render: (args) => (
     <Container>
       <Input {...args} />
@@ -65,6 +82,34 @@ const Error: Story = {
         'publicStyle',
       ],
     },
+  },
+  render: (args) => {
+    const [
+      hasError,
+      setHasError,
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+    ] = useState(false)
+
+    return (
+      <div>
+        <Input
+          {...args}
+          error={hasError ? { message: 'This field has an error!' } : undefined}
+        />
+        <button
+          onClick={() => {
+            setHasError((prev) => !prev)
+          }}
+          style={{ marginTop: '1rem' }}
+        >
+          Toggle Error
+        </button>
+        <p style={{ marginTop: '0.5rem', fontSize: '0.875rem', color: '#666' }}>
+          Click the button to toggle error state. The input will automatically
+          focus when the error appears.
+        </p>
+      </div>
+    )
   },
 }
 

--- a/packages/ui/react/src/components/Forms/Input/Input.test.tsx
+++ b/packages/ui/react/src/components/Forms/Input/Input.test.tsx
@@ -53,7 +53,7 @@ describe('Input', () => {
       expect(input).toHaveFocus()
     })
 
-    it('should maintain focus behavior with external ref', () => {
+    it('should maintain focus behavior when using a custom ref', () => {
       const ref = { current: null }
       render(
         <Input

--- a/packages/ui/react/src/components/Forms/Input/Input.test.tsx
+++ b/packages/ui/react/src/components/Forms/Input/Input.test.tsx
@@ -1,0 +1,72 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Input } from './Input'
+
+describe('Input', () => {
+  describe('focus behavior on error', () => {
+    it('should focus input when error prop is present', () => {
+      render(
+        <Input
+          type="text"
+          error={{ message: 'Test error' }}
+          data-testid="test-input"
+        />
+      )
+
+      const input = screen.getByTestId('test-input')
+      expect(input).toHaveFocus()
+    })
+
+    it('should not focus input when no error is present', () => {
+      render(
+        <Input
+          type="text"
+          data-testid="test-input"
+        />
+      )
+
+      const input = screen.getByTestId('test-input')
+      expect(input).not.toHaveFocus()
+    })
+
+    it('should focus when error prop changes', () => {
+      const { rerender } = render(
+        <Input
+          type="text"
+          data-testid="test-input"
+        />
+      )
+
+      const input = screen.getByTestId('test-input')
+      expect(input).not.toHaveFocus()
+
+      rerender(
+        <Input
+          type="text"
+          error={{ message: 'New error' }}
+          data-testid="test-input"
+        />
+      )
+
+      expect(input).toHaveFocus()
+    })
+
+    it('should maintain focus behavior with external ref', () => {
+      const ref = { current: null }
+      render(
+        <Input
+          type="text"
+          ref={ref}
+          error={{ message: 'Test error' }}
+          data-testid="test-input"
+        />
+      )
+
+      const input = screen.getByTestId('test-input')
+      expect(input).toHaveFocus()
+      expect(ref.current).toBe(input)
+    })
+  })
+})

--- a/packages/ui/react/src/components/Forms/Input/Input.tsx
+++ b/packages/ui/react/src/components/Forms/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import { forwardRef, useEffect, useRef } from 'react'
 
 import { Container, InputText } from './Input.styled'
 import type { ErrorMessageProps } from 'src/components/Primitives/ErrorMessage'
@@ -59,19 +59,34 @@ type InputProps =
  * />
  * ```
  */
-const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => (
-  <Container>
-    {props.labelProps && <Label {...props.labelProps} />}
-    <InputText
-      className="translate"
-      ref={ref}
-      hasError={Boolean(props.error)}
-      {...props}
-      {...props.inputProps}
-    />
-    {Boolean(props.error) && <ErrorMessage error={props.error} />}
-  </Container>
-))
+const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+  const internalRef = useRef<HTMLInputElement>(null)
+  const inputRef =
+    (ref as React.RefObject<HTMLInputElement> | undefined) ?? internalRef
+
+  useEffect(() => {
+    if (props.error && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [
+    props.error,
+    inputRef,
+  ])
+
+  return (
+    <Container>
+      {props.labelProps && <Label {...props.labelProps} />}
+      <InputText
+        className="translate"
+        ref={inputRef}
+        hasError={Boolean(props.error)}
+        {...props}
+        {...props.inputProps}
+      />
+      {Boolean(props.error) && <ErrorMessage error={props.error} />}
+    </Container>
+  )
+})
 
 /**
  * Explicitly sets component display name for debugging in React DevTools when using forwardRef.


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->
- [ ] The input component by default enters on focus when there is an error
- [ ] Added tests for the new behaviour
- [ ] Modified storybook page to showcase the new behaviour 

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [ ] closes #1157

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: Whenever there is an error in a form, the focus should go to the input where there is the error

