### PR TITLE
docs: add help documentation for listing projects #1203

### DIFF
--- a/docs/projects/list-projects.md
+++ b/docs/projects/list-projects.md
@@ -1,0 +1,21 @@
+---
+title: List a project
+intro: How to view and manage your existing projects in Devopness.
+links:
+    overview:
+    quickstart:
+    previous: index
+    next: projects/view-project
+    guides:
+    related:
+    featured:
+---
+
+1. Click the Devopness logo in the upper-left corner of the page to navigate to the Projects section.
+1. The list of existing projects will be displayed, including their names and owners.
+1. Click on a project name to view its details.
+  - To add a new project, click the `ADD PROJECT` button in the upper-right corner.
+  - To manage an existing project, select it from the list and navigate through its resources, environments, teams, and roles.
+  - You can edit or remove projects as needed (future functionality may apply).
+  - The Help Documentation button `?` in the upper-right corner provides more details on managing projects.
+  - If a project you created is missing from the list, try refreshing the page.


### PR DESCRIPTION
## Description of changes  
This PR introduces new documentation for the "List Projects" page in Devopness. With this addition, users will have a clear and structured guide on how to view, manage, and navigate their existing projects. 

* [x] Added docs/projects/list-projects.md
* [x] Described steps for users to list projects in Devopness
* [x] Linked to "View Project" documentation as the next step

## GitHub issues resolved by this PR  
* [ ] closes #1203

## Quality Assurance  
* Once the changes in this PR are merged and deployed, success criteria is:  
* Users will be able to find documentation on how to list existing projects in Devopness.  

## More info  
* Documentation was written following the structure of existing project pages.
* Ensures consistency across help resources for a better user experience.