### PR TITLE
docs: Fix typos in cloud provider instructions

### DIFF
--- a/docs/servers/add-gcp-server.md
+++ b/docs/servers/add-gcp-server.md
@@ -24,8 +24,8 @@ links:
 1. Review server information and settings. If everything is correct, click `CONFIRM`
     > Use the `PREVIOUS` button if you need to modify any server details
 1. Wait for the `server:provision` action to be completed
-1. After the server is successfully provisioned it will be visible on GCP console
-1. If you want to access the server on GCP console:
+1. After the server is successfully provisioned it will be visible on the GCP console
+1. If you want to access the server on the GCP console:
     - Access [GCP Console](https://console.cloud.google.com/)
     - On the Search box, enter “Compute Engine” and select it from search results
     - A `GCE` instance will be listed, with the name of the new `Server` you provisioned on Devopness


### PR DESCRIPTION
## Description of changes

This PR fixes a minor typo in the documentation for improved clarity and professionalism.  
- Updated wording from **“On GCP console”** to **“On the GCP console”** to reflect proper grammar and enhance readability.

- [x] Corrected documentation grammar in a GCP-related instruction.

## GitHub issues resolved by this PR

- [ ] closes #1496

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is:  
  The typo is corrected, and the documentation displays the improved sentence: **“On the GCP console…”**

## More info

Minor documentation fix, no functional changes. No additional dependencies or steps required.
