### PR TITLE
feat(design-system): add `borderBottomColor` prop to customize Card header

### DIFF
--- a/.changeset/add-card-header-prop.md
+++ b/.changeset/add-card-header-prop.md
@@ -1,0 +1,25 @@
+---
+"@devopness/ui-react": minor
+---
+
+Add `borderBottomColor` prop to Card component header
+
+### What Changed
+
+- Added new `borderBottomColor` prop to Card's `headerProps` for customizing the bottom border color
+- Updated tests to verify border color styling behavior
+- Maintains backward compatibility with existing header styling options
+
+### Example Usage
+
+```tsx
+<Card
+  title="Example Card"
+  headerProps={{
+    backgroundColor: "blue.100",
+    borderBottomColor: "purple.500" // New prop
+  }}
+/>
+```
+
+This enhancement provides more flexibility in styling Card headers by allowing separate control of the border color, independent of the background color. 

--- a/packages/ui/react/src/components/Templates/Card/Card.styled.ts
+++ b/packages/ui/react/src/components/Templates/Card/Card.styled.ts
@@ -82,8 +82,10 @@ const StyledHeader = styled.div<StyledHeaderProps>`
   align-items: center;
   background-color: ${({ $backgroundColor }) =>
     getColor($backgroundColor ?? 'transparent')};
-  border-bottom: ${({ $hideBorder }) =>
-    $hideBorder ? 'none' : `1px solid ${getColor('slate.300')}`};
+  border-bottom: ${({ $borderBottomColor, $hideBorder }) =>
+    $hideBorder
+      ? 'none'
+      : `1px solid ${getColor($borderBottomColor ?? 'slate.300')}`};
   box-sizing: border-box;
   color: ${getColor('gray.615')};
   display: grid;

--- a/packages/ui/react/src/components/Templates/Card/Card.test.tsx
+++ b/packages/ui/react/src/components/Templates/Card/Card.test.tsx
@@ -123,7 +123,6 @@ describe('Card', () => {
 
       const header = screen.getByTestId('card-header')
       expect(header).toBeInTheDocument()
-      console.log(window.getComputedStyle(header as Element))
       expect(header).toHaveStyle({
         'border-bottom-color': 'rgb(220, 236, 255)',
       })

--- a/packages/ui/react/src/components/Templates/Card/Card.test.tsx
+++ b/packages/ui/react/src/components/Templates/Card/Card.test.tsx
@@ -80,20 +80,78 @@ describe('Card', () => {
       expect(screen.getByText('+99')).toBeInTheDocument()
     })
 
-    it('with custom header colors', () => {
+    it('with custom header background color', () => {
       render(
         <Card
           {...defaultProps}
           headerProps={{
             backgroundColor: 'blue.100',
           }}
+          // Without any footer, the border will be hidden
+          footer={[
+            {
+              label: 'Settings',
+              url: '/settings',
+            },
+          ]}
         />
       )
 
       const header = screen.getByTestId('card-header')
       expect(header).toBeInTheDocument()
       expect(header).toHaveStyle({
-        backgroundColor: 'rgb(220, 236, 255)',
+        'background-color': 'rgb(220, 236, 255)',
+      })
+    })
+
+    it('with custom header border bottom color', () => {
+      render(
+        <Card
+          {...defaultProps}
+          headerProps={{
+            borderBottomColor: 'blue.100',
+          }}
+          // Without any footer, the border will be hidden
+          footer={[
+            {
+              label: 'Settings',
+              url: '/settings',
+            },
+          ]}
+        />
+      )
+
+      const header = screen.getByTestId('card-header')
+      expect(header).toBeInTheDocument()
+      console.log(window.getComputedStyle(header as Element))
+      expect(header).toHaveStyle({
+        'border-bottom-color': 'rgb(220, 236, 255)',
+      })
+    })
+
+    it('with both header background and border colors', () => {
+      render(
+        <Card
+          {...defaultProps}
+          headerProps={{
+            backgroundColor: 'blue.100',
+            borderBottomColor: 'purple.800',
+          }}
+          // Without any footer, the border will be hidden
+          footer={[
+            {
+              label: 'Settings',
+              url: '/settings',
+            },
+          ]}
+        />
+      )
+
+      const header = screen.getByTestId('card-header')
+      expect(header).toBeInTheDocument()
+      expect(header).toHaveStyle({
+        'background-color': 'rgb(220, 236, 255)',
+        'border-bottom-color': 'rgb(120, 110, 253)',
       })
     })
 

--- a/packages/ui/react/src/components/Templates/Card/Card.tsx
+++ b/packages/ui/react/src/components/Templates/Card/Card.tsx
@@ -55,6 +55,7 @@ type CardProps = React.PropsWithChildren<{
    */
   headerProps?: {
     backgroundColor?: Color
+    borderBottomColor?: Color
   }
   /**
    * Icon to display in the card
@@ -148,6 +149,7 @@ const Card = ({ children, ...props }: CardProps) => (
       <StyledHeader
         data-testid="card-header"
         $backgroundColor={props.headerProps?.backgroundColor}
+        $borderBottomColor={props.headerProps?.borderBottomColor}
         $hideBorder={!props.footer && !children}
       >
         <StyledAvatar $backgroundColor={props.avatarProps.backgroundColor}>


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->

- Introduced a new `borderBottomColor` prop in the Card component's `headerProps` for enhanced styling flexibility.
- Updated the styled component to apply the new border color while maintaining existing functionality.
- Added tests to verify the correct application of the new border color in various scenarios.

This change allows users to independently control the header's border color, improving the customization options for the Card component.

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: Card header border bottom color will be customizable

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->

### BEFORE

![image](https://github.com/user-attachments/assets/38f1a975-5ce5-4587-b54f-9590d3bf7c1d)

![image](https://github.com/user-attachments/assets/d2fed1b8-5be6-406f-9557-a8bc6d353f00)

### AFTER

![image](https://github.com/user-attachments/assets/665497bb-8ffb-4bf0-94bb-3333aef6ddb8)

![image](https://github.com/user-attachments/assets/5d855fa0-7e34-40d5-8608-759bcfe329c3)

