### PR TITLE
fix(design-system): runtime error rendering `shieldLock` icon

### DIFF
--- a/.changeset/fix-shield-lock-icon-runtime-error.md
+++ b/.changeset/fix-shield-lock-icon-runtime-error.md
@@ -1,0 +1,13 @@
+---
+"@devopness/ui-react": patch
+---
+
+Fix `shieldLock` icon rendering error
+
+Previously, the `shieldLock` icon was incorrectly typed as 'icon', which attempted to use the SVG URL as a React component, causing a DOM error:
+"DOMException: Failed to execute 'createElement' on 'Document': The tag name provided is not a valid name."
+
+This change:
+- Updates the shieldLock icon type from 'icon' to 'image', to correctly render it as an <img> element
+- Fixes the runtime error when using the `shieldLock` icon
+- Maintains backward compatibility - the icon name and usage remain the same

--- a/packages/ui/react/src/icons/iconLoader.tsx
+++ b/packages/ui/react/src/icons/iconLoader.tsx
@@ -175,7 +175,7 @@ const iconList = [
   { type: 'icon', name: 'serverOutline', component: FiServer },
   { type: 'icon', name: 'settings', component: MdSettings },
   { type: 'icon', name: 'shield', component: RiShieldCheckFill },
-  { type: 'icon', name: 'shieldLock', component: mdOutlineShieldLockSVG },
+  { type: 'image', name: 'shieldLock', component: mdOutlineShieldLockSVG },
   { type: 'icon', name: 'shieldOutline', component: AiOutlineSafety },
   { type: 'icon', name: 'skip', component: GoSkip },
   { type: 'icon', name: 'snooze', component: MdSnooze },


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->

- Fixes error when attempting to use `shieldLock` icon
    - Read more @ changeset file

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: Users will now be able to use `shieldLock` icon without errors

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->

### BEFORE

![image](https://github.com/user-attachments/assets/f391d597-091b-4ba0-aa77-e768d6b00b48)

### AFTER

https://thlmenezes-storybook.devopness.com/?path=/story/primitives-icon--primary&args=name:shieldLock

![image](https://github.com/user-attachments/assets/cdd0821a-ba7b-49e6-80ed-4ba3c58c854e)
