### PR TITLE
feat: add workflow to auto-merge Dependabot PRs for Patch Updates

### DIFF
--- a/.github/workflows/pr-auto-merge-dependabot.yml
+++ b/.github/workflows/pr-auto-merge-dependabot.yml
@@ -21,21 +21,15 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 
-      - name: Check if it's a patch update
-        id: check_patch
-        run: |
-          if [ "${{ steps.metadata.outputs.update-type }}" != "version-update:semver-patch" ]; then
-            echo "INFO: Not a patch update. Exiting workflow."
-            exit 0
-          fi
-
       - name: Approve the PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable Auto Merge for Patch Update
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-auto-merge-dependabot.yml
+++ b/.github/workflows/pr-auto-merge-dependabot.yml
@@ -1,0 +1,42 @@
+name: Auto Merge Dependabot
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: write
+  checks: read
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Check if it's a patch update
+        id: check_patch
+        run: |
+          if [ "${{ steps.metadata.outputs.update-type }}" != "version-update:semver-patch" ]; then
+            echo "INFO: Not a patch update. Exiting workflow."
+            exit 0
+          fi
+
+      - name: Approve the PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable Auto Merge for Patch Update
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description of changes

- [x] Add workflow for auto-merging Dependabot PR
- [x] Ensure only patch updates from Dependabot trigger the auto-merge

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: Dependabot PR's for patch updates are automatically merged without manual intervention.

## More info

