### PR TITLE
fix(ci): change Dependabot auto-merge strategy to use squash

### DIFF
--- a/.github/workflows/pr-auto-merge-dependabot.yml
+++ b/.github/workflows/pr-auto-merge-dependabot.yml
@@ -1,4 +1,4 @@
-name: Auto Merge Dependabot
+name: PR - Auto Merge Dependabot
 
 on:
   pull_request:
@@ -30,7 +30,7 @@ jobs:
 
       - name: Enable Auto Merge for Patch Update
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description of changes

- [x] Replace `--merge` with `--squash` in the **gh pr merge** command used in **PR - Auto Merge Dependabot**

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: Dependabot PRs will successfully auto-merge using squash strategy.

## More info

This change was necessary because GitHub threw the following error when attempting to merge using --merge:

```ruby
GraphQL: Merge method merge commits are not allowed on this repository
and Pull request User is not authorized for this protected branch (enablePullRequestAutoMerge)
```

Now, with --squash, merges comply with repository policy and unblock automation workflows.
