### PR TITLE
fix(sdk-python): module exports and add version control for dev-package

### DIFF
--- a/packages/sdks/python/.version
+++ b/packages/sdks/python/.version
@@ -1,0 +1,17 @@
+# Devopness SDK - Python: version registry
+#
+# This file stores specific versions of the Devopness SDK for publication.
+# It allows publishing arbitrary versions to Python Repository's.
+#
+# Format:
+#   <repository-name>==<semver>
+#
+# Example:
+#   SomeRepository==1.2.3
+#
+# Notes:
+# - The main version for PyPI is defined in the `pyproject.toml` under the `version` field.
+# - For convenience, a package version is also maintained on Test PyPI:
+#   https://test.pypi.org/project/devopness/
+
+TestPyPI==0.0.4

--- a/packages/sdks/python/.version
+++ b/packages/sdks/python/.version
@@ -14,4 +14,4 @@
 # - For convenience, a package version is also maintained on Test PyPI:
 #   https://test.pypi.org/project/devopness/
 
-TestPyPI==0.0.4
+TestPyPI==0.0.5

--- a/packages/sdks/python/README.md
+++ b/packages/sdks/python/README.md
@@ -53,7 +53,7 @@ Here is a simple generic example that can be used in `Python` applications:
 ```python
 from devopness import DevopnessClient
 
-devopness_client = DevopnessClient()
+devopness = DevopnessClient()
 ```
 
 ### Authenticating
@@ -68,14 +68,14 @@ import asyncio
 from devopness import DevopnessClient
 from devopness.models import UserLogin
 
-devopness_client = DevopnessClient()
+devopness = DevopnessClient()
 
 async def authenticate(user_email, user_pass):
     user_data = UserLogin(email=user_email, password=user_pass)
-    user_tokens = await devopness_client.users.login_user(user_data)
+    user_tokens = await devopness.users.login_user(user_data)
 
     # The `access_token` must be set every time a token is obtained or refreshed.
-    devopness_client.access_token = user_tokens.data.access_token
+    devopness.access_token = user_tokens.data.access_token
 
 # Invoke the authentication method
 if __name__ == "__main__":
@@ -88,14 +88,14 @@ if __name__ == "__main__":
 from devopness import DevopnessClient
 from devopness.models import UserLogin
 
-devopness_client = DevopnessClient()
+devopness = DevopnessClient()
 
 def authenticate(user_email, user_pass):
     user_data = UserLogin(email=user_email, password=user_pass)
-    user_tokens = devopness_client.users.login_user_sync(user_data)
+    user_tokens = devopness.users.login_user_sync(user_data)
 
     # The `access_token` must be set every time a token is obtained or refreshed.
-    devopness_client.access_token = user_tokens.data.access_token
+    devopness.access_token = user_tokens.data.access_token
 
 # Invoke the authentication method
 if __name__ == "__main__":
@@ -117,14 +117,14 @@ import asyncio
 from devopness import DevopnessClient
 from devopness.models import UserLogin
 
-devopness_client = DevopnessClient()
+devopness = DevopnessClient()
 
 async def authenticate(user_email, user_pass):
     user_data = UserLogin(email=user_email, password=user_pass)
-    user_tokens = await devopness_client.users.login_user(user_data)
+    user_tokens = await devopness.users.login_user(user_data)
 
     # The `access_token` must be set every time a token is obtained or refreshed.
-    devopness_client.access_token = user_tokens.data.access_token
+    devopness.access_token = user_tokens.data.access_token
 
 async def get_user_profile():
     # Ensure an auth token is retrieved and set to the SDK instance
@@ -132,7 +132,7 @@ async def get_user_profile():
 
     # Now that we're authenticated, we can invoke methods on any service.
     # Here we're invoking the `get_user_me()` method on the `users` service
-    current_user = await devopness_client.users.get_user_me()
+    current_user = await devopness.users.get_user_me()
     print(f'Successfully retrieved user profile with ID: {current_user.data.id}')
 
 # Invoke the get user profile method
@@ -146,14 +146,14 @@ if __name__ == "__main__":
 from devopness import DevopnessClient
 from devopness.models import UserLogin
 
-devopness_client = DevopnessClient()
+devopness = DevopnessClient()
 
 def authenticate(user_email, user_pass):
     user_data = UserLogin(email=user_email, password=user_pass)
-    user_tokens = devopness_client.users.login_user_sync(user_data)
+    user_tokens = devopness.users.login_user_sync(user_data)
 
     # The `access_token` must be set every time a token is obtained or refreshed.
-    devopness_client.access_token = user_tokens.data.access_token
+    devopness.access_token = user_tokens.data.access_token
 
 def get_user_profile():
     # Ensure an auth token is retrieved and set to the SDK instance
@@ -161,7 +161,7 @@ def get_user_profile():
 
     # Now that we're authenticated, we can invoke methods on any service.
     # Here we're invoking the `get_user_sync()` method on the `users` service
-    current_user = devopness_client.users.get_user_sync(1)
+    current_user = devopness.users.get_user_sync(1)
     print(f'Successfully retrieved user profile with ID: {current_user.data.id}')
 
 # Invoke the get user profile method

--- a/packages/sdks/python/README.md
+++ b/packages/sdks/python/README.md
@@ -10,6 +10,7 @@ The Devopness SDK for Python provides a set of predefined classes that offer eas
 - [Usage](#usage)
   - [Install](#install)
   - [Initializing](#initializing)
+  - [Custom Configuration](#custom-configuration)
   - [Authenticating](#authenticating)
     - [Asynchronous usage](#asynchronous-usage)
     - [Synchronous usage](#synchronous-usage)
@@ -55,6 +56,31 @@ from devopness import DevopnessClient
 
 devopness = DevopnessClient()
 ```
+
+### Custom Configuration
+
+You can customize the SDK behavior by providing a `DevopnessClientConfig` object when instantiating the client:
+
+```python
+from devopness import DevopnessClient, DevopnessClientConfig
+
+config = DevopnessClientConfig(
+    base_url='https://api.devopness.com',
+    timeout=10
+)
+
+devopness = DevopnessClient(config)
+```
+
+The `DevopnessClientConfig` supports the following options:
+
+| Parameter          | Default                     | Description                              |
+| ------------------ | --------------------------- | ---------------------------------------- |
+| `base_url`         | `https://api.devopness.com` | Base URL for all API requests            |
+| `timeout`          | `30`                        | Timeout for HTTP requests (in seconds)   |
+| `default_encoding` | `utf-8`                     | Encoding used to decode response content |
+
+This configuration allows you to adapt the SDK to your specific use case, such as changing the API endpoint or tweaking performance-related settings.
 
 ### Authenticating
 

--- a/packages/sdks/python/devopness/common/__init__.py
+++ b/packages/sdks/python/devopness/common/__init__.py
@@ -1,1 +1,7 @@
-from .api_response import ApiResponse  # noqa: F401
+"""
+Devopness API Python SDK - Painless essential DevOps to everyone
+"""
+
+from .api_response import ApiResponse
+
+__all__ = ["ApiResponse"]

--- a/packages/sdks/python/devopness/models/__init__.py
+++ b/packages/sdks/python/devopness/models/__init__.py
@@ -3,3 +3,8 @@ Devopness API Python SDK - Painless essential DevOps to everyone
 """
 
 from ..api.generated.models import *  # noqa: F401, F403
+from ..common.api_response import ApiResponse
+
+__all__ = [
+    "ApiResponse",
+]

--- a/packages/sdks/python/devopness/services/__init__.py
+++ b/packages/sdks/python/devopness/services/__init__.py
@@ -1,4 +1,15 @@
-from .api_base_service import ApiBaseService  # noqa: F401
-from .api_base_service import DevopnessClientConfig  # noqa: F401
+"""
+Devopness API Python SDK - Painless essential DevOps to everyone
+"""
 
-from .user_service import UserService  # noqa: F401
+from .api_base_service import ApiBaseService
+from .api_base_service import DevopnessClientConfig
+
+from .user_service import UserService
+
+__all__ = [
+    "ApiBaseService",
+    "DevopnessClientConfig",
+    # API Services
+    "UserService",
+]

--- a/packages/sdks/python/pyproject.toml
+++ b/packages/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "devopness"
-version = "0.0.5"
+version = "0.0.0"
 description = "Devopness API Python SDK - Painless essential DevOps to everyone"
 license = "MIT"
 readme = "README.md"

--- a/packages/sdks/python/pyproject.toml
+++ b/packages/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "devopness"
-version = "0.0.3"
+version = "0.0.5"
 description = "Devopness API Python SDK - Painless essential DevOps to everyone"
 license = "MIT"
 readme = "README.md"

--- a/packages/sdks/python/scripts/post-build.sh
+++ b/packages/sdks/python/scripts/post-build.sh
@@ -46,6 +46,12 @@ ruff format "$GENERATED_API_DIR" "$GENERATED_MODELS_DIR"
 echo "🧹  Removing OpenAPI Generator Cache..."
 rm -rf "$GENERATED_DIR/.openapi-generator"
 
+echo "🧹  Removing previous Build Artifacts..."
+rm -rf "$SDK_ROOT_DIR/dist"
+
+echo "📦  Exporting Devopness SDK - Python to a wheel..."
+poetry build
+
 echo "✅  Devopness SDK - Python Build completed successfully!"
 
 bash scripts/temp.sh

--- a/packages/sdks/python/scripts/post-build.sh
+++ b/packages/sdks/python/scripts/post-build.sh
@@ -46,12 +46,6 @@ ruff format "$GENERATED_API_DIR" "$GENERATED_MODELS_DIR"
 echo "🧹  Removing OpenAPI Generator Cache..."
 rm -rf "$GENERATED_DIR/.openapi-generator"
 
-echo "🧹  Removing previous Build Artifacts..."
-rm -rf "$SDK_ROOT_DIR/dist"
-
-echo "📦  Exporting Devopness SDK - Python to a wheel..."
-poetry build
-
 echo "✅  Devopness SDK - Python Build completed successfully!"
 
 bash scripts/temp.sh

--- a/packages/sdks/python/scripts/publish-dev.sh
+++ b/packages/sdks/python/scripts/publish-dev.sh
@@ -2,38 +2,78 @@
 
 # Script to publish the Devopness Python SDK to Test PyPI
 
-set -e
+set -euo pipefail
 
-if [[ -z "$POETRY_TEST_PYPI_TOKEN" ]]; then
-  echo "🚨  POETRY_TEST_PYPI_TOKEN is not set. Please set it before publishing to Test PyPI."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR/.."
+PYPROJECT_FILE="$PROJECT_ROOT/pyproject.toml"
+VERSION_FILE="$PROJECT_ROOT/.version"
+
+# Function to update version in pyproject.toml
+set_version_in_pyproject() {
+  local version="$1"
+  sed -i "s/^version = \".*\"/version = \"$version\"/" "$PYPROJECT_FILE"
+}
+
+# Ensure token is set
+if [[ -z "${POETRY_TEST_PYPI_TOKEN:-}" ]]; then
+  echo "🚨  Environment variable POETRY_TEST_PYPI_TOKEN is not set. Please export it before running this script."
   exit 1
 fi
 
-EXPECTED_VERSION=$(poetry version --short)
-EXPECTED_ARTIFACT="dist/devopness-$EXPECTED_VERSION-py3-none-any.whl"
+# Store original and test version
+ORIGINAL_VERSION=$(poetry version --short)
+TEST_VERSION=$(grep 'TestPyPI==' "$VERSION_FILE" | cut -d '=' -f 3)
+
+# Ensure test version was found
+if [[ -z "$TEST_VERSION" ]]; then
+  echo "🚨  TestPyPI version not found in .version file."
+  exit 1
+fi
+
+# Restore original version on exit
+restore_version() {
+  echo "🧹  Restoring original version ($ORIGINAL_VERSION) in pyproject.toml..."
+  set_version_in_pyproject "$ORIGINAL_VERSION"
+}
+trap restore_version EXIT
+
+# Update to test version
+echo "🔧  Temporarily setting version to $TEST_VERSION in pyproject.toml..."
+set_version_in_pyproject "$TEST_VERSION"
+
+# Build package
+echo "📦  Building Devopness SDK (version $TEST_VERSION)..."
+poetry build --no-cache
+
+# Validate expected artifact
+EXPECTED_ARTIFACT="dist/devopness-$TEST_VERSION-py3-none-any.whl"
 if [[ ! -f "$EXPECTED_ARTIFACT" ]]; then
-  echo "🚨  Expected artifact $EXPECTED_ARTIFACT not found. Please build the SDK before publishing."
+  echo "🚨  Expected artifact not found: $EXPECTED_ARTIFACT"
   exit 1
 fi
 
-echo "📦  Configuring Test PyPI..."
+# Configure PyPI token
+echo "🔐  Configuring Test PyPI credentials..."
 poetry config pypi-token.TestPiPy "$POETRY_TEST_PYPI_TOKEN"
 
-echo "📦  Publishing Devopness SDK - Python to Test PyPI..."
+# Publish package
+echo "🚀  Publishing Devopness SDK to Test PyPI..."
 set +e
 PUBLISH_OUTPUT=$(poetry publish -r TestPiPy 2>&1)
 PUBLISH_EXIT_CODE=$?
 set -e
 
+# Handle result
 if [[ $PUBLISH_EXIT_CODE -ne 0 ]]; then
   if echo "$PUBLISH_OUTPUT" | grep -q "File already exists"; then
-    echo "⚠️  Package already exists on Test PyPI. Skipping publish step."
-    echo "ℹ️  If you want to publish again, you must bump the version."
+    echo "⚠️  Package version already exists on Test PyPI. Skipping publish step."
+    echo "ℹ️  To publish again, you must bump the version in $VERSION_FILE."
   else
     echo "❌  An error occurred during publishing:"
     echo "$PUBLISH_OUTPUT"
     exit $PUBLISH_EXIT_CODE
   fi
 else
-  echo "✅  Successfully published to Test PyPI!"
+  echo "✅  Successfully published version $TEST_VERSION to Test PyPI!"
 fi

--- a/packages/sdks/python/scripts/publish-dev.sh
+++ b/packages/sdks/python/scripts/publish-dev.sh
@@ -9,11 +9,15 @@ if [[ -z "$POETRY_TEST_PYPI_TOKEN" ]]; then
   exit 1
 fi
 
+EXPECTED_VERSION=$(poetry version --short)
+EXPECTED_ARTIFACT="dist/devopness-$EXPECTED_VERSION-py3-none-any.whl"
+if [[ ! -f "$EXPECTED_ARTIFACT" ]]; then
+  echo "🚨  Expected artifact $EXPECTED_ARTIFACT not found. Please build the SDK before publishing."
+  exit 1
+fi
+
 echo "📦  Configuring Test PyPI..."
 poetry config pypi-token.TestPiPy "$POETRY_TEST_PYPI_TOKEN"
-
-echo "📦  Building Devopness SDK - Python..."
-poetry build
 
 echo "📦  Publishing Devopness SDK - Python to Test PyPI..."
 set +e


### PR DESCRIPTION
## Description of changes

- [x] Declare **_ _ all _ _** in SDK Packages to support controlled module exports
- [x] Add **.version** file to manage dev release version
- [x] Refactor **publish-dev.sh** to use and restore version from **.version**
- [x] Improve error handling and logging in **publish-dev.sh**

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: 
  - Consumers can now import SDK modules using simplified import paths (e.g., **from devopness.models import ApiResponse**) without **PrivateImport** Warning.
  - The SDK can be published to TestPyPI using **./scripts/publish-dev.sh** without updating **pyproject.toml**

## More info

- TestPyPI Package: https://test.pypi.org/project/devopness/
