### PR TITLE
bufix: fixing dropdown.badge.color component

### DIFF
--- a/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.test.tsx
+++ b/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.test.tsx
@@ -73,6 +73,9 @@ describe('Dropdown', () => {
       expect(icon.closest('span')).toHaveStyle({
         backgroundColor: getColor('blue.100'),
       })
+      expect(screen.getByLabelText('add')).toHaveStyle({
+        color: 'rgb(255, 255, 255)',
+      })
     })
 
     it('renders icon badge with default size', async () => {

--- a/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.tsx
+++ b/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.tsx
@@ -28,8 +28,7 @@ const DEFAULT_BUTTON_ICON_SIZE = 10
 const DEFAULT_ICON_MARGIN = 10
 
 type DropdownOptionIcon = Unwrap<
-  Partial<Pick<IconProps, 'name' | 'size'>> &
-    Pick<React.CSSProperties, 'backgroundColor' | 'color'>
+  IconProps & Pick<React.CSSProperties, 'backgroundColor'>
 > & { icon: true }
 
 type DropdownOptionLetter = Unwrap<
@@ -350,7 +349,7 @@ const Dropdown = ({
                           >
                             {option.badge.icon ? (
                               <Icon
-                                name={option.badge.name}
+                                {...option.badge}
                                 size={option.badge.size ?? 12}
                               />
                             ) : (


### PR DESCRIPTION
Description of changes
Fixed an issue where the Dropdown component badge color could not be changed when using the badge: '#some_color' property.

Identified that the problem was caused by the color property not being passed correctly to the icon inside the badge.

Updated the code to ensure that all parameters are correctly forwarded to the icon.

Adjusted the typing to accept all properties from IconProps, instead of only name and size.

Removed the unnecessary color typing restriction based on React.CSSProperties.

GitHub issues resolved by this PR
<!-- Check list box of GitHub issues completed by this PR. -->
- [x] closes ISSUE #1570 

Quality Assurance
Once the changes in this PR are merged and deployed, success criteria is:

The Dropdown badge correctly applies the custom color when the badge property is set.

Icons inside the badge now properly receive and apply the color attribute.

Typings are aligned with IconProps, ensuring future flexibility.