### PR TITLE
feat(sdk-python): expose virtual host service and fix bugs

### DIFF
--- a/packages/sdks/python/.version
+++ b/packages/sdks/python/.version
@@ -14,4 +14,4 @@
 # - For convenience, a package version is also maintained on Test PyPI:
 #   https://test.pypi.org/project/devopness/
 
-TestPyPI==0.0.34
+TestPyPI==0.0.35

--- a/packages/sdks/python/.version
+++ b/packages/sdks/python/.version
@@ -14,4 +14,4 @@
 # - For convenience, a package version is also maintained on Test PyPI:
 #   https://test.pypi.org/project/devopness/
 
-TestPyPI==0.0.35
+TestPyPI==0.0.36

--- a/packages/sdks/python/devopness/_base/base_service.py
+++ b/packages/sdks/python/devopness/_base/base_service.py
@@ -279,12 +279,7 @@ class DevopnessBaseService:
         if isinstance(data, dict):
             payload = data
 
-        stripped_payload = {}
-        for key, value in payload.items():
-            if value is not None:
-                stripped_payload[key] = value
-
-        return stripped_payload
+        return payload
 
     def __debug_request(self, request: httpx.Request) -> None:
         """

--- a/packages/sdks/python/devopness/_client.py
+++ b/packages/sdks/python/devopness/_client.py
@@ -14,6 +14,7 @@ from .services import (
     ServerService,
     SubnetService,
     UserService,
+    VirtualHostService,
 )
 
 __all__ = ["DevopnessClient"]
@@ -31,6 +32,7 @@ class DevopnessClient:
     servers: ServerService
     subnets: SubnetService
     users: UserService
+    virtual_hosts: VirtualHostService
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class DevopnessClient:
         self.servers = ServerService(config)
         self.subnets = SubnetService(config)
         self.users = UserService(config)
+        self.virtual_hosts = VirtualHostService(config)
 
     def __set_access_token(self, access_token: str) -> None:
         # pylint: disable=protected-access

--- a/packages/sdks/python/devopness/_generated/models/action.py
+++ b/packages/sdks/python/devopness/_generated/models/action.py
@@ -174,9 +174,11 @@ class ActionPlain(TypedDict, total=False):
             ]
         ]
     ]
-    triggered_by_user: Union[
-        UserRelation,
-        UserRelationPlain,
+    triggered_by_user: Optional[
+        Union[
+            UserRelation,
+            UserRelationPlain,
+        ]
     ]
     resource: Required[
         Union[
@@ -190,23 +192,31 @@ class ActionPlain(TypedDict, total=False):
             ActionSummaryPlain,
         ]
     ]
-    environment: Union[
-        EnvironmentRelation,
-        EnvironmentRelationPlain,
-    ]
-    project: Union[
-        ProjectRelation,
-        ProjectRelationPlain,
-    ]
-    targets: List[
+    environment: Optional[
         Union[
-            ActionTarget,
-            ActionTargetPlain,
+            EnvironmentRelation,
+            EnvironmentRelationPlain,
         ]
     ]
-    hook_requests: Union[
-        ActionHookRequest,
-        ActionHookRequestPlain,
+    project: Optional[
+        Union[
+            ProjectRelation,
+            ProjectRelationPlain,
+        ]
+    ]
+    targets: Optional[
+        List[
+            Union[
+                ActionTarget,
+                ActionTargetPlain,
+            ]
+        ]
+    ]
+    hook_requests: Optional[
+        Union[
+            ActionHookRequest,
+            ActionHookRequestPlain,
+        ]
     ]
     started_at: Required[str]
     completed_at: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/action_hook_request.py
+++ b/packages/sdks/python/devopness/_generated/models/action_hook_request.py
@@ -34,11 +34,15 @@ class ActionHookRequestPlain(TypedDict, total=False):
     Plain version of ActionHookRequest.
     """
 
-    incoming: Union[
-        HookRequestRelation,
-        HookRequestRelationPlain,
+    incoming: Optional[
+        Union[
+            HookRequestRelation,
+            HookRequestRelationPlain,
+        ]
     ]
-    outgoing: Union[
-        HookRequestRelation,
-        HookRequestRelationPlain,
+    outgoing: Optional[
+        Union[
+            HookRequestRelation,
+            HookRequestRelationPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/action_pipeline_create.py
+++ b/packages/sdks/python/devopness/_generated/models/action_pipeline_create.py
@@ -44,9 +44,11 @@ class ActionPipelineCreatePlain(TypedDict, total=False):
     Plain version of ActionPipelineCreate.
     """
 
-    servers: List[int]
-    source_type: Union[
-        SourceType,
-        SourceTypePlain,
+    servers: Optional[List[int]]
+    source_type: Optional[
+        Union[
+            SourceType,
+            SourceTypePlain,
+        ]
     ]
-    source_ref: str
+    source_ref: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/action_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/action_relation.py
@@ -137,14 +137,18 @@ class ActionRelationPlain(TypedDict, total=False):
             ActionResourcePlain,
         ]
     ]
-    summary: Union[
-        ActionSummary,
-        ActionSummaryPlain,
-    ]
-    targets: List[
+    summary: Optional[
         Union[
-            ActionTarget,
-            ActionTargetPlain,
+            ActionSummary,
+            ActionSummaryPlain,
+        ]
+    ]
+    targets: Optional[
+        List[
+            Union[
+                ActionTarget,
+                ActionTargetPlain,
+            ]
         ]
     ]
     started_at: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/action_relation_shallow.py
+++ b/packages/sdks/python/devopness/_generated/models/action_relation_shallow.py
@@ -109,22 +109,30 @@ class ActionRelationShallowPlain(TypedDict, total=False):
     ]
     type_human_readable: Required[str]
     url_web_permalink: Required[str]
-    action_data: Union[
-        ActionData,
-        ActionDataPlain,
-    ]
-    triggered_from: Union[
-        ActionTriggeredFrom,
-        ActionTriggeredFromPlain,
-    ]
-    summary: Union[
-        ActionSummary,
-        ActionSummaryPlain,
-    ]
-    targets: List[
+    action_data: Optional[
         Union[
-            ActionTarget,
-            ActionTargetPlain,
+            ActionData,
+            ActionDataPlain,
+        ]
+    ]
+    triggered_from: Optional[
+        Union[
+            ActionTriggeredFrom,
+            ActionTriggeredFromPlain,
+        ]
+    ]
+    summary: Optional[
+        Union[
+            ActionSummary,
+            ActionSummaryPlain,
+        ]
+    ]
+    targets: Optional[
+        List[
+            Union[
+                ActionTarget,
+                ActionTargetPlain,
+            ]
         ]
     ]
     started_at: Required[datetime]

--- a/packages/sdks/python/devopness/_generated/models/action_resource.py
+++ b/packages/sdks/python/devopness/_generated/models/action_resource.py
@@ -52,7 +52,9 @@ class ActionResourcePlain(TypedDict, total=False):
         ]
     ]
     type_human_readable: Required[str]
-    data: Union[
-        ActionResourceData,
-        ActionResourceDataPlain,
+    data: Optional[
+        Union[
+            ActionResourceData,
+            ActionResourceDataPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/action_retry_response.py
+++ b/packages/sdks/python/devopness/_generated/models/action_retry_response.py
@@ -174,9 +174,11 @@ class ActionRetryResponsePlain(TypedDict, total=False):
             ]
         ]
     ]
-    triggered_by_user: Union[
-        UserRelation,
-        UserRelationPlain,
+    triggered_by_user: Optional[
+        Union[
+            UserRelation,
+            UserRelationPlain,
+        ]
     ]
     resource: Required[
         Union[
@@ -190,23 +192,31 @@ class ActionRetryResponsePlain(TypedDict, total=False):
             ActionSummaryPlain,
         ]
     ]
-    environment: Union[
-        EnvironmentRelation,
-        EnvironmentRelationPlain,
-    ]
-    project: Union[
-        ProjectRelation,
-        ProjectRelationPlain,
-    ]
-    targets: List[
+    environment: Optional[
         Union[
-            ActionTarget,
-            ActionTargetPlain,
+            EnvironmentRelation,
+            EnvironmentRelationPlain,
         ]
     ]
-    hook_requests: Union[
-        ActionHookRequest,
-        ActionHookRequestPlain,
+    project: Optional[
+        Union[
+            ProjectRelation,
+            ProjectRelationPlain,
+        ]
+    ]
+    targets: Optional[
+        List[
+            Union[
+                ActionTarget,
+                ActionTargetPlain,
+            ]
+        ]
+    ]
+    hook_requests: Optional[
+        Union[
+            ActionHookRequest,
+            ActionHookRequestPlain,
+        ]
     ]
     started_at: Required[str]
     completed_at: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/action_step.py
+++ b/packages/sdks/python/devopness/_generated/models/action_step.py
@@ -93,7 +93,7 @@ class ActionStepPlain(TypedDict, total=False):
     action_id: Required[int]
     action_target_id: Required[int]
     name: Required[str]
-    description: str
+    description: Optional[str]
     order: Required[int]
     status: Required[
         Union[
@@ -101,13 +101,15 @@ class ActionStepPlain(TypedDict, total=False):
             ActionStatusPlain,
         ]
     ]
-    status_human_readable: str
-    status_reason_code: Union[
-        ActionStatusReasonCode,
-        ActionStatusReasonCodePlain,
+    status_human_readable: Optional[str]
+    status_reason_code: Optional[
+        Union[
+            ActionStatusReasonCode,
+            ActionStatusReasonCodePlain,
+        ]
     ]
-    status_reason_human_readable: str
-    started_at: datetime
-    completed_at: datetime
-    created_at: datetime
-    updated_at: datetime
+    status_reason_human_readable: Optional[str]
+    started_at: Optional[datetime]
+    completed_at: Optional[datetime]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]

--- a/packages/sdks/python/devopness/_generated/models/action_target.py
+++ b/packages/sdks/python/devopness/_generated/models/action_target.py
@@ -97,35 +97,45 @@ class ActionTargetPlain(TypedDict, total=False):
     Plain version of ActionTarget.
     """
 
-    resource_type: str
-    resource_type_human_readable: str
-    resource_id: int
-    status: Union[
-        ActionStatus,
-        ActionStatusPlain,
+    resource_type: Optional[str]
+    resource_type_human_readable: Optional[str]
+    resource_id: Optional[int]
+    status: Optional[
+        Union[
+            ActionStatus,
+            ActionStatusPlain,
+        ]
     ]
-    status_human_readable: str
-    status_reason_code: Union[
-        ActionStatusReasonCode,
-        ActionStatusReasonCodePlain,
+    status_human_readable: Optional[str]
+    status_reason_code: Optional[
+        Union[
+            ActionStatusReasonCode,
+            ActionStatusReasonCodePlain,
+        ]
     ]
-    status_reason_human_readable: str
-    total_steps: int
-    current_step: Union[
-        ActionStep,
-        ActionStepPlain,
-    ]
-    steps: List[
+    status_reason_human_readable: Optional[str]
+    total_steps: Optional[int]
+    current_step: Optional[
         Union[
             ActionStep,
             ActionStepPlain,
         ]
     ]
-    resource_data: Union[
-        ActionTargetData,
-        ActionTargetDataPlain,
+    steps: Optional[
+        List[
+            Union[
+                ActionStep,
+                ActionStepPlain,
+            ]
+        ]
     ]
-    started_at: datetime
-    completed_at: datetime
-    created_at: datetime
-    updated_at: datetime
+    resource_data: Optional[
+        Union[
+            ActionTargetData,
+            ActionTargetDataPlain,
+        ]
+    ]
+    started_at: Optional[datetime]
+    completed_at: Optional[datetime]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]

--- a/packages/sdks/python/devopness/_generated/models/api_error.py
+++ b/packages/sdks/python/devopness/_generated/models/api_error.py
@@ -38,7 +38,9 @@ class ApiErrorPlain(TypedDict, total=False):
     """
 
     message: Required[str]
-    errors: Union[
-        ApiErrorErrors,
-        ApiErrorErrorsPlain,
+    errors: Optional[
+        Union[
+            ApiErrorErrors,
+            ApiErrorErrorsPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/api_error_errors.py
+++ b/packages/sdks/python/devopness/_generated/models/api_error_errors.py
@@ -41,9 +41,11 @@ class ApiErrorErrorsPlain(TypedDict, total=False):
     Plain version of ApiErrorErrors.
     """
 
-    field_name: List[
-        Union[
-            ApiErrorErrorsFieldNameInner,
-            ApiErrorErrorsFieldNameInnerPlain,
+    field_name: Optional[
+        List[
+            Union[
+                ApiErrorErrorsFieldNameInner,
+                ApiErrorErrorsFieldNameInnerPlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/api_error_errors_field_name_inner.py
+++ b/packages/sdks/python/devopness/_generated/models/api_error_errors_field_name_inner.py
@@ -36,4 +36,4 @@ class ApiErrorErrorsFieldNameInnerPlain(TypedDict, total=False):
     Plain version of ApiErrorErrorsFieldNameInner.
     """
 
-    field: str
+    field: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/application_environment_create.py
+++ b/packages/sdks/python/devopness/_generated/models/application_environment_create.py
@@ -89,26 +89,30 @@ class ApplicationEnvironmentCreatePlain(TypedDict, total=False):
     Plain version of ApplicationEnvironmentCreate.
     """
 
-    linked_resources: List[
-        Union[
-            ResourceToBeLinked,
-            ResourceToBeLinkedPlain,
+    linked_resources: Optional[
+        List[
+            Union[
+                ResourceToBeLinked,
+                ResourceToBeLinkedPlain,
+            ]
         ]
     ]
     name: Required[str]
-    build_command: str
+    build_command: Optional[str]
     engine_version: Required[str]
     framework: Required[str]
     programming_language: Required[str]
     repository: Required[str]
     credential_id: Required[int]
-    root_directory: str
+    root_directory: Optional[str]
     default_branch: Required[str]
-    deployments_keep: int
-    install_dependencies_command: str
-    environments: List[
-        Union[
-            EnvironmentLink,
-            EnvironmentLinkPlain,
+    deployments_keep: Optional[int]
+    install_dependencies_command: Optional[str]
+    environments: Optional[
+        List[
+            Union[
+                EnvironmentLink,
+                EnvironmentLinkPlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/application_last_deployments.py
+++ b/packages/sdks/python/devopness/_generated/models/application_last_deployments.py
@@ -34,11 +34,15 @@ class ApplicationLastDeploymentsPlain(TypedDict, total=False):
     Plain version of ApplicationLastDeployments.
     """
 
-    latest: Union[
-        ActionRelationShallow,
-        ActionRelationShallowPlain,
+    latest: Optional[
+        Union[
+            ActionRelationShallow,
+            ActionRelationShallowPlain,
+        ]
     ]
-    live: Union[
-        ActionRelationShallow,
-        ActionRelationShallowPlain,
+    live: Optional[
+        Union[
+            ActionRelationShallow,
+            ActionRelationShallowPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/application_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/application_relation.py
@@ -135,13 +135,17 @@ class ApplicationRelationPlain(TypedDict, total=False):
     deployments_keep: Required[int]
     install_dependencies_command: Required[str]
     build_command: Required[str]
-    last_deployments: Union[
-        ApplicationLastDeployments,
-        ApplicationLastDeploymentsPlain,
+    last_deployments: Optional[
+        Union[
+            ApplicationLastDeployments,
+            ApplicationLastDeploymentsPlain,
+        ]
     ]
-    credential: Union[
-        Credential,
-        CredentialPlain,
+    credential: Optional[
+        Union[
+            Credential,
+            CredentialPlain,
+        ]
     ]
     created_at: Required[str]
     updated_at: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/application_update.py
+++ b/packages/sdks/python/devopness/_generated/models/application_update.py
@@ -85,13 +85,13 @@ class ApplicationUpdatePlain(TypedDict, total=False):
 
     id: Required[int]
     name: Required[str]
-    build_command: str
+    build_command: Optional[str]
     engine_version: Required[str]
     framework: Required[str]
     programming_language: Required[str]
-    repository: str
-    credential_id: int
-    root_directory: str
+    repository: Optional[str]
+    credential_id: Optional[int]
+    root_directory: Optional[str]
     default_branch: Required[str]
-    deployments_keep: int
-    install_dependencies_command: str
+    deployments_keep: Optional[int]
+    install_dependencies_command: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/archived_environment_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/archived_environment_relation.py
@@ -81,11 +81,13 @@ class ArchivedEnvironmentRelationPlain(TypedDict, total=False):
     type_human_readable: Required[str]
     name: Required[str]
     description: Required[str]
-    used_credits: int
-    resource_summary: List[
-        Union[
-            ResourceSummaryItem,
-            ResourceSummaryItemPlain,
+    used_credits: Optional[int]
+    resource_summary: Optional[
+        List[
+            Union[
+                ResourceSummaryItem,
+                ResourceSummaryItemPlain,
+            ]
         ]
     ]
     created_at: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/blueprint_service.py
+++ b/packages/sdks/python/devopness/_generated/models/blueprint_service.py
@@ -45,10 +45,12 @@ class BlueprintServicePlain(TypedDict, total=False):
     Plain version of BlueprintService.
     """
 
-    auto_start: bool
-    initial_state: Union[
-        ServiceInitialState,
-        ServiceInitialStatePlain,
+    auto_start: Optional[bool]
+    initial_state: Optional[
+        Union[
+            ServiceInitialState,
+            ServiceInitialStatePlain,
+        ]
     ]
     type: Required[
         Union[

--- a/packages/sdks/python/devopness/_generated/models/cloud_provider.py
+++ b/packages/sdks/python/devopness/_generated/models/cloud_provider.py
@@ -55,15 +55,19 @@ class CloudProviderPlain(TypedDict, total=False):
 
     code: Required[str]
     name: Required[str]
-    hint: str
+    hint: Optional[str]
     logo_url: Required[str]
-    cloud_services: List[
-        Union[
-            CloudProviderService,
-            CloudProviderServicePlain,
+    cloud_services: Optional[
+        List[
+            Union[
+                CloudProviderService,
+                CloudProviderServicePlain,
+            ]
         ]
     ]
-    settings: Union[
-        CloudProviderSettingsList,
-        CloudProviderSettingsListPlain,
+    settings: Optional[
+        Union[
+            CloudProviderSettingsList,
+            CloudProviderSettingsListPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/cloud_provider_service.py
+++ b/packages/sdks/python/devopness/_generated/models/cloud_provider_service.py
@@ -63,19 +63,25 @@ class CloudProviderServicePlain(TypedDict, total=False):
         ]
     ]
     name: Required[str]
-    provider: Union[
-        ProviderRelation,
-        ProviderRelationPlain,
-    ]
-    regions: List[
+    provider: Optional[
         Union[
-            CloudProviderServiceRegion,
-            CloudProviderServiceRegionPlain,
+            ProviderRelation,
+            ProviderRelationPlain,
         ]
     ]
-    resource_types: List[
-        Union[
-            CloudProviderServiceResourceType,
-            CloudProviderServiceResourceTypePlain,
+    regions: Optional[
+        List[
+            Union[
+                CloudProviderServiceRegion,
+                CloudProviderServiceRegionPlain,
+            ]
+        ]
+    ]
+    resource_types: Optional[
+        List[
+            Union[
+                CloudProviderServiceResourceType,
+                CloudProviderServiceResourceTypePlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/cloud_provider_service_resource_type.py
+++ b/packages/sdks/python/devopness/_generated/models/cloud_provider_service_resource_type.py
@@ -85,14 +85,18 @@ class CloudProviderServiceResourceTypePlain(TypedDict, total=False):
             ]
         ]
     ]
-    os: List[
-        Union[
-            OperatingSystem,
-            OperatingSystemPlain,
+    os: Optional[
+        List[
+            Union[
+                OperatingSystem,
+                OperatingSystemPlain,
+            ]
         ]
     ]
-    can_keep_disk_after_delete_server: bool
-    operation_custom_settings: Union[
-        OperationCustomSettings,
-        OperationCustomSettingsPlain,
+    can_keep_disk_after_delete_server: Optional[bool]
+    operation_custom_settings: Optional[
+        Union[
+            OperationCustomSettings,
+            OperationCustomSettingsPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/cloud_provider_settings_list.py
+++ b/packages/sdks/python/devopness/_generated/models/cloud_provider_settings_list.py
@@ -40,9 +40,11 @@ class CloudProviderSettingsListPlain(TypedDict, total=False):
     Plain version of CloudProviderSettingsList.
     """
 
-    credential: List[
-        Union[
-            CloudProviderInputSettings,
-            CloudProviderInputSettingsPlain,
+    credential: Optional[
+        List[
+            Union[
+                CloudProviderInputSettings,
+                CloudProviderInputSettingsPlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/cloud_service_settings_aws_ec2.py
+++ b/packages/sdks/python/devopness/_generated/models/cloud_service_settings_aws_ec2.py
@@ -53,7 +53,7 @@ class CloudServiceSettingsAwsEc2Plain(TypedDict, total=False):
 
     instance_type: Required[str]
     region: Required[str]
-    region_human_readable: str
+    region_human_readable: Optional[str]
     storage_size: Required[int]
     os_version_code: Required[
         Union[

--- a/packages/sdks/python/devopness/_generated/models/cloud_service_settings_azure_rm.py
+++ b/packages/sdks/python/devopness/_generated/models/cloud_service_settings_azure_rm.py
@@ -53,7 +53,7 @@ class CloudServiceSettingsAzureRmPlain(TypedDict, total=False):
 
     instance_type: Required[str]
     region: Required[str]
-    region_human_readable: str
+    region_human_readable: Optional[str]
     storage_size: Required[int]
     os_version_code: Required[
         Union[

--- a/packages/sdks/python/devopness/_generated/models/cloud_service_settings_digital_ocean_droplet.py
+++ b/packages/sdks/python/devopness/_generated/models/cloud_service_settings_digital_ocean_droplet.py
@@ -49,7 +49,7 @@ class CloudServiceSettingsDigitalOceanDropletPlain(TypedDict, total=False):
 
     instance_type: Required[str]
     region: Required[str]
-    region_human_readable: str
+    region_human_readable: Optional[str]
     os_version_code: Required[
         Union[
             CloudOsVersionCode,

--- a/packages/sdks/python/devopness/_generated/models/cloud_service_settings_gcp_gce.py
+++ b/packages/sdks/python/devopness/_generated/models/cloud_service_settings_gcp_gce.py
@@ -49,7 +49,7 @@ class CloudServiceSettingsGcpGcePlain(TypedDict, total=False):
 
     instance_type: Required[str]
     region: Required[str]
-    region_human_readable: str
+    region_human_readable: Optional[str]
     os_version_code: Required[
         Union[
             CloudOsVersionCode,

--- a/packages/sdks/python/devopness/_generated/models/credential_update.py
+++ b/packages/sdks/python/devopness/_generated/models/credential_update.py
@@ -46,7 +46,9 @@ class CredentialUpdatePlain(TypedDict, total=False):
 
     id: Required[int]
     name: Required[str]
-    settings: Union[
-        CredentialInputSettings,
-        CredentialInputSettingsPlain,
+    settings: Optional[
+        Union[
+            CredentialInputSettings,
+            CredentialInputSettingsPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/credits.py
+++ b/packages/sdks/python/devopness/_generated/models/credits.py
@@ -44,6 +44,6 @@ class CreditsPlain(TypedDict, total=False):
     Plain version of Credits.
     """
 
-    limit: float
-    used: float
-    remaining: float
+    limit: Optional[float]
+    used: Optional[float]
+    remaining: Optional[float]

--- a/packages/sdks/python/devopness/_generated/models/cron_job_environment_create.py
+++ b/packages/sdks/python/devopness/_generated/models/cron_job_environment_create.py
@@ -59,14 +59,16 @@ class CronJobEnvironmentCreatePlain(TypedDict, total=False):
     Plain version of CronJobEnvironmentCreate.
     """
 
-    linked_resources: List[
-        Union[
-            ResourceToBeLinked,
-            ResourceToBeLinkedPlain,
+    linked_resources: Optional[
+        List[
+            Union[
+                ResourceToBeLinked,
+                ResourceToBeLinkedPlain,
+            ]
         ]
     ]
     name: Required[str]
     command: Required[str]
     pattern: Required[str]
     run_as_user: Required[str]
-    application_id: int
+    application_id: Optional[int]

--- a/packages/sdks/python/devopness/_generated/models/cron_job_update.py
+++ b/packages/sdks/python/devopness/_generated/models/cron_job_update.py
@@ -59,4 +59,4 @@ class CronJobUpdatePlain(TypedDict, total=False):
     name: Required[str]
     command: Required[str]
     run_as_user: Required[str]
-    application_id: int
+    application_id: Optional[int]

--- a/packages/sdks/python/devopness/_generated/models/daemon_environment_create.py
+++ b/packages/sdks/python/devopness/_generated/models/daemon_environment_create.py
@@ -63,10 +63,12 @@ class DaemonEnvironmentCreatePlain(TypedDict, total=False):
     Plain version of DaemonEnvironmentCreate.
     """
 
-    linked_resources: List[
-        Union[
-            ResourceToBeLinked,
-            ResourceToBeLinkedPlain,
+    linked_resources: Optional[
+        List[
+            Union[
+                ResourceToBeLinked,
+                ResourceToBeLinkedPlain,
+            ]
         ]
     ]
     command: Required[str]
@@ -74,4 +76,4 @@ class DaemonEnvironmentCreatePlain(TypedDict, total=False):
     working_directory: Required[str]
     run_as_user: Required[str]
     name: Required[str]
-    application_id: int
+    application_id: Optional[int]

--- a/packages/sdks/python/devopness/_generated/models/daemon_get_status.py
+++ b/packages/sdks/python/devopness/_generated/models/daemon_get_status.py
@@ -35,4 +35,4 @@ class DaemonGetStatusPlain(TypedDict, total=False):
     Plain version of DaemonGetStatus.
     """
 
-    servers: List[int]
+    servers: Optional[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/daemon_restart.py
+++ b/packages/sdks/python/devopness/_generated/models/daemon_restart.py
@@ -35,4 +35,4 @@ class DaemonRestartPlain(TypedDict, total=False):
     Plain version of DaemonRestart.
     """
 
-    servers: List[int]
+    servers: Optional[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/daemon_start.py
+++ b/packages/sdks/python/devopness/_generated/models/daemon_start.py
@@ -35,4 +35,4 @@ class DaemonStartPlain(TypedDict, total=False):
     Plain version of DaemonStart.
     """
 
-    servers: List[int]
+    servers: Optional[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/daemon_stop.py
+++ b/packages/sdks/python/devopness/_generated/models/daemon_stop.py
@@ -35,4 +35,4 @@ class DaemonStopPlain(TypedDict, total=False):
     Plain version of DaemonStop.
     """
 
-    servers: List[int]
+    servers: Optional[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/daemon_update.py
+++ b/packages/sdks/python/devopness/_generated/models/daemon_update.py
@@ -64,4 +64,4 @@ class DaemonUpdatePlain(TypedDict, total=False):
     working_directory: Required[str]
     run_as_user: Required[str]
     name: Required[str]
-    application_id: int
+    application_id: Optional[int]

--- a/packages/sdks/python/devopness/_generated/models/deployment_application_create.py
+++ b/packages/sdks/python/devopness/_generated/models/deployment_application_create.py
@@ -58,14 +58,14 @@ class DeploymentApplicationCreatePlain(TypedDict, total=False):
     Plain version of DeploymentApplicationCreate.
     """
 
-    environment: str
+    environment: Optional[str]
     type: Required[
         Union[
             DeploymentType,
             DeploymentTypePlain,
         ]
     ]
-    source_type: str
-    source_ref: str
-    pipeline_id: int
-    servers: List[int]
+    source_type: Optional[str]
+    source_ref: Optional[str]
+    pipeline_id: Optional[int]
+    servers: Optional[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/environment.py
+++ b/packages/sdks/python/devopness/_generated/models/environment.py
@@ -84,10 +84,12 @@ class EnvironmentPlain(TypedDict, total=False):
     name: Required[str]
     description: Required[str]
     is_archived: Required[bool]
-    resource_summary: List[
-        Union[
-            ResourceSummaryItem,
-            ResourceSummaryItemPlain,
+    resource_summary: Optional[
+        List[
+            Union[
+                ResourceSummaryItem,
+                ResourceSummaryItemPlain,
+            ]
         ]
     ]
     teams: Required[

--- a/packages/sdks/python/devopness/_generated/models/environment_link.py
+++ b/packages/sdks/python/devopness/_generated/models/environment_link.py
@@ -41,5 +41,5 @@ class EnvironmentLinkPlain(TypedDict, total=False):
     """
 
     id: Required[int]
-    name: str
+    name: Optional[str]
     servers: Required[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/environment_project_create.py
+++ b/packages/sdks/python/devopness/_generated/models/environment_project_create.py
@@ -51,4 +51,4 @@ class EnvironmentProjectCreatePlain(TypedDict, total=False):
         ]
     ]
     name: Required[str]
-    description: str
+    description: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/environment_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/environment_relation.py
@@ -81,11 +81,13 @@ class EnvironmentRelationPlain(TypedDict, total=False):
     type_human_readable: Required[str]
     name: Required[str]
     description: Required[str]
-    used_credits: int
-    resource_summary: List[
-        Union[
-            ResourceSummaryItem,
-            ResourceSummaryItemPlain,
+    used_credits: Optional[int]
+    resource_summary: Optional[
+        List[
+            Union[
+                ResourceSummaryItem,
+                ResourceSummaryItemPlain,
+            ]
         ]
     ]
     created_at: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/environment_update.py
+++ b/packages/sdks/python/devopness/_generated/models/environment_update.py
@@ -54,4 +54,4 @@ class EnvironmentUpdatePlain(TypedDict, total=False):
         ]
     ]
     name: Required[str]
-    description: str
+    description: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/hook_incoming_settings.py
+++ b/packages/sdks/python/devopness/_generated/models/hook_incoming_settings.py
@@ -37,9 +37,11 @@ class HookIncomingSettingsPlain(TypedDict, total=False):
     Plain version of HookIncomingSettings.
     """
 
-    variables: List[
-        Union[
-            HookVariable,
-            HookVariablePlain,
+    variables: Optional[
+        List[
+            Union[
+                HookVariable,
+                HookVariablePlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/hook_outgoing_settings.py
+++ b/packages/sdks/python/devopness/_generated/models/hook_outgoing_settings.py
@@ -46,13 +46,17 @@ class HookOutgoingSettingsPlain(TypedDict, total=False):
     Plain version of HookOutgoingSettings.
     """
 
-    request_headers: List[
-        Union[
-            HookOutgoingRequestHeader,
-            HookOutgoingRequestHeaderPlain,
+    request_headers: Optional[
+        List[
+            Union[
+                HookOutgoingRequestHeader,
+                HookOutgoingRequestHeaderPlain,
+            ]
         ]
     ]
-    request_body: Union[
-        HookOutgoingSettingsRequestBody,
-        HookOutgoingSettingsRequestBodyPlain,
+    request_body: Optional[
+        Union[
+            HookOutgoingSettingsRequestBody,
+            HookOutgoingSettingsRequestBodyPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/hook_pipeline_create.py
+++ b/packages/sdks/python/devopness/_generated/models/hook_pipeline_create.py
@@ -65,15 +65,19 @@ class HookPipelineCreatePlain(TypedDict, total=False):
     """
 
     name: Required[str]
-    active: bool
-    requires_secret: bool
-    secret_algorithm: str
-    secret_header_name: str
-    trigger_when: Union[
-        HookTriggerWhen,
-        HookTriggerWhenPlain,
+    active: Optional[bool]
+    requires_secret: Optional[bool]
+    secret_algorithm: Optional[str]
+    secret_header_name: Optional[str]
+    trigger_when: Optional[
+        Union[
+            HookTriggerWhen,
+            HookTriggerWhenPlain,
+        ]
     ]
-    settings: Union[
-        HookPipelineCreateSettings,
-        HookPipelineCreateSettingsPlain,
+    settings: Optional[
+        Union[
+            HookPipelineCreateSettings,
+            HookPipelineCreateSettingsPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/hook_request_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/hook_request_relation.py
@@ -71,7 +71,7 @@ class HookRequestRelationPlain(TypedDict, total=False):
     action_id: Required[int]
     retry_of: Required[str]
     ip_address: Required[str]
-    url: str
-    response_status_code: int
-    created_at: datetime
-    updated_at: datetime
+    url: Optional[str]
+    response_status_code: Optional[int]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]

--- a/packages/sdks/python/devopness/_generated/models/hook_trigger_when.py
+++ b/packages/sdks/python/devopness/_generated/models/hook_trigger_when.py
@@ -44,10 +44,12 @@ class HookTriggerWhenPlain(TypedDict, total=False):
     Plain version of HookTriggerWhen.
     """
 
-    events: List[str]
-    conditions: List[
-        Union[
-            HookTriggerWhenConditionsInner,
-            HookTriggerWhenConditionsInnerPlain,
+    events: Optional[List[str]]
+    conditions: Optional[
+        List[
+            Union[
+                HookTriggerWhenConditionsInner,
+                HookTriggerWhenConditionsInnerPlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/hook_update.py
+++ b/packages/sdks/python/devopness/_generated/models/hook_update.py
@@ -70,15 +70,19 @@ class HookUpdatePlain(TypedDict, total=False):
 
     id: Required[str]
     name: Required[str]
-    active: bool
-    requires_secret: bool
-    secret_algorithm: str
-    secret_header_name: str
-    trigger_when: Union[
-        HookTriggerWhen,
-        HookTriggerWhenPlain,
+    active: Optional[bool]
+    requires_secret: Optional[bool]
+    secret_algorithm: Optional[str]
+    secret_header_name: Optional[str]
+    trigger_when: Optional[
+        Union[
+            HookTriggerWhen,
+            HookTriggerWhenPlain,
+        ]
     ]
-    settings: Union[
-        HookPipelineCreateSettings,
-        HookPipelineCreateSettingsPlain,
+    settings: Optional[
+        Union[
+            HookPipelineCreateSettings,
+            HookPipelineCreateSettingsPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/hook_variable.py
+++ b/packages/sdks/python/devopness/_generated/models/hook_variable.py
@@ -53,14 +53,18 @@ class HookVariablePlain(TypedDict, total=False):
     Plain version of HookVariable.
     """
 
-    name: str
-    path: str
-    type: Union[
-        HookVariableType,
-        HookVariableTypePlain,
+    name: Optional[str]
+    path: Optional[str]
+    type: Optional[
+        Union[
+            HookVariableType,
+            HookVariableTypePlain,
+        ]
     ]
-    required: bool
-    default_value: Union[
-        HookVariableDefaultValue,
-        HookVariableDefaultValuePlain,
+    required: Optional[bool]
+    default_value: Optional[
+        Union[
+            HookVariableDefaultValue,
+            HookVariableDefaultValuePlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/language_runtime_engine_versions_inner.py
+++ b/packages/sdks/python/devopness/_generated/models/language_runtime_engine_versions_inner.py
@@ -32,4 +32,4 @@ class LanguageRuntimeEngineVersionsInnerPlain(TypedDict, total=False):
     Plain version of LanguageRuntimeEngineVersionsInner.
     """
 
-    version: str
+    version: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/language_runtime_framework_commands.py
+++ b/packages/sdks/python/devopness/_generated/models/language_runtime_framework_commands.py
@@ -40,5 +40,5 @@ class LanguageRuntimeFrameworkCommandsPlain(TypedDict, total=False):
     Plain version of LanguageRuntimeFrameworkCommands.
     """
 
-    build: List[str]
-    dependencies: List[str]
+    build: Optional[List[str]]
+    dependencies: Optional[List[str]]

--- a/packages/sdks/python/devopness/_generated/models/language_runtime_framework_defaults.py
+++ b/packages/sdks/python/devopness/_generated/models/language_runtime_framework_defaults.py
@@ -72,14 +72,16 @@ class LanguageRuntimeFrameworkDefaultsPlain(TypedDict, total=False):
     Plain version of LanguageRuntimeFrameworkDefaults.
     """
 
-    default_branch: str
-    engine_version: str
-    framework: str
-    root_directory: str
-    deployments_keep: int
-    commands: Union[
-        LanguageRuntimeFrameworkCommands,
-        LanguageRuntimeFrameworkCommandsPlain,
+    default_branch: Optional[str]
+    engine_version: Optional[str]
+    framework: Optional[str]
+    root_directory: Optional[str]
+    deployments_keep: Optional[int]
+    commands: Optional[
+        Union[
+            LanguageRuntimeFrameworkCommands,
+            LanguageRuntimeFrameworkCommandsPlain,
+        ]
     ]
-    install_dependencies_command: str
-    build_command: str
+    install_dependencies_command: Optional[str]
+    build_command: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/linked_resource_data.py
+++ b/packages/sdks/python/devopness/_generated/models/linked_resource_data.py
@@ -56,11 +56,13 @@ class LinkedResourceDataPlain(TypedDict, total=False):
 
     id: Required[int]
     name: Required[str]
-    summary_fields: List[
-        Union[
-            LinkedResourceSummaryField,
-            LinkedResourceSummaryFieldPlain,
+    summary_fields: Optional[
+        List[
+            Union[
+                LinkedResourceSummaryField,
+                LinkedResourceSummaryFieldPlain,
+            ]
         ]
     ]
-    created_at: datetime
-    updated_at: datetime
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]

--- a/packages/sdks/python/devopness/_generated/models/network_provision_input_settings_aws.py
+++ b/packages/sdks/python/devopness/_generated/models/network_provision_input_settings_aws.py
@@ -42,5 +42,5 @@ class NetworkProvisionInputSettingsAwsPlain(TypedDict, total=False):
     """
 
     region: Required[str]
-    region_human_readable: str
+    region_human_readable: Optional[str]
     cidr_block: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/network_provision_input_settings_azure.py
+++ b/packages/sdks/python/devopness/_generated/models/network_provision_input_settings_azure.py
@@ -42,5 +42,5 @@ class NetworkProvisionInputSettingsAzurePlain(TypedDict, total=False):
     """
 
     region: Required[str]
-    region_human_readable: str
+    region_human_readable: Optional[str]
     cidr_block: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/network_provision_input_settings_digital_ocean.py
+++ b/packages/sdks/python/devopness/_generated/models/network_provision_input_settings_digital_ocean.py
@@ -42,5 +42,5 @@ class NetworkProvisionInputSettingsDigitalOceanPlain(TypedDict, total=False):
     """
 
     region: Required[str]
-    region_human_readable: str
+    region_human_readable: Optional[str]
     cidr_block: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/network_provision_input_settings_gcp.py
+++ b/packages/sdks/python/devopness/_generated/models/network_provision_input_settings_gcp.py
@@ -40,4 +40,4 @@ class NetworkProvisionInputSettingsGcpPlain(TypedDict, total=False):
     """
 
     region: Required[str]
-    region_human_readable: str
+    region_human_readable: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/network_rule_environment_create.py
+++ b/packages/sdks/python/devopness/_generated/models/network_rule_environment_create.py
@@ -56,10 +56,12 @@ class NetworkRuleEnvironmentCreatePlain(TypedDict, total=False):
     Plain version of NetworkRuleEnvironmentCreate.
     """
 
-    linked_resources: List[
-        Union[
-            ResourceToBeLinked,
-            ResourceToBeLinkedPlain,
+    linked_resources: Optional[
+        List[
+            Union[
+                ResourceToBeLinked,
+                ResourceToBeLinkedPlain,
+            ]
         ]
     ]
     name: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/network_rule_update.py
+++ b/packages/sdks/python/devopness/_generated/models/network_rule_update.py
@@ -56,8 +56,10 @@ class NetworkRuleUpdatePlain(TypedDict, total=False):
             NetworkRuleDirectionPlain,
         ]
     ]
-    protocol: Union[
-        NetworkRuleProtocol,
-        NetworkRuleProtocolPlain,
+    protocol: Optional[
+        Union[
+            NetworkRuleProtocol,
+            NetworkRuleProtocolPlain,
+        ]
     ]
     cidr_block: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/operating_system_version.py
+++ b/packages/sdks/python/devopness/_generated/models/operating_system_version.py
@@ -67,7 +67,7 @@ class OperatingSystemVersionPlain(TypedDict, total=False):
             CloudOsVersionCodePlain,
         ]
     ]
-    os_version_code_human_readable: str
+    os_version_code_human_readable: Optional[str]
     released_at: Required[str]
     end_standard_support_at: Required[str]
     end_of_life_at: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/operation_custom_settings.py
+++ b/packages/sdks/python/devopness/_generated/models/operation_custom_settings.py
@@ -45,6 +45,6 @@ class OperationCustomSettingsPlain(TypedDict, total=False):
     Plain version of OperationCustomSettings.
     """
 
-    operation: str
-    operation_human_readable: str
-    triggers_action: bool
+    operation: Optional[str]
+    operation_human_readable: Optional[str]
+    triggers_action: Optional[bool]

--- a/packages/sdks/python/devopness/_generated/models/organization.py
+++ b/packages/sdks/python/devopness/_generated/models/organization.py
@@ -58,10 +58,12 @@ class OrganizationPlain(TypedDict, total=False):
     id: Required[int]
     name: Required[str]
     url_slug: Required[str]
-    resource_summary: List[
-        Union[
-            ResourceSummaryItem,
-            ResourceSummaryItemPlain,
+    resource_summary: Optional[
+        List[
+            Union[
+                ResourceSummaryItem,
+                ResourceSummaryItemPlain,
+            ]
         ]
     ]
     owner: Required[

--- a/packages/sdks/python/devopness/_generated/models/organization_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/organization_relation.py
@@ -55,10 +55,12 @@ class OrganizationRelationPlain(TypedDict, total=False):
     id: Required[int]
     name: Required[str]
     url_slug: Required[str]
-    resource_summary: List[
-        Union[
-            ResourceSummaryItem,
-            ResourceSummaryItemPlain,
+    resource_summary: Optional[
+        List[
+            Union[
+                ResourceSummaryItem,
+                ResourceSummaryItemPlain,
+            ]
         ]
     ]
     created_at: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/pipeline_create.py
+++ b/packages/sdks/python/devopness/_generated/models/pipeline_create.py
@@ -50,8 +50,10 @@ class PipelineCreatePlain(TypedDict, total=False):
 
     name: Required[str]
     operation: Required[str]
-    max_parallel_actions: int
-    trigger_when: Union[
-        PipelineTriggerWhen,
-        PipelineTriggerWhenPlain,
+    max_parallel_actions: Optional[int]
+    trigger_when: Optional[
+        Union[
+            PipelineTriggerWhen,
+            PipelineTriggerWhenPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/pipeline_settings.py
+++ b/packages/sdks/python/devopness/_generated/models/pipeline_settings.py
@@ -52,17 +52,21 @@ class PipelineSettingsPlain(TypedDict, total=False):
     Plain version of PipelineSettings.
     """
 
-    max_pipelines_per_resource: int
-    is_user_managed: bool
-    stages: List[
-        Union[
-            PipelineSettingsStage,
-            PipelineSettingsStagePlain,
+    max_pipelines_per_resource: Optional[int]
+    is_user_managed: Optional[bool]
+    stages: Optional[
+        List[
+            Union[
+                PipelineSettingsStage,
+                PipelineSettingsStagePlain,
+            ]
         ]
     ]
-    variables: List[
-        Union[
-            PipelineSettingsVariable,
-            PipelineSettingsVariablePlain,
+    variables: Optional[
+        List[
+            Union[
+                PipelineSettingsVariable,
+                PipelineSettingsVariablePlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/pipeline_settings_stage.py
+++ b/packages/sdks/python/devopness/_generated/models/pipeline_settings_stage.py
@@ -39,6 +39,6 @@ class PipelineSettingsStagePlain(TypedDict, total=False):
     Plain version of PipelineSettingsStage.
     """
 
-    value: str
-    human_readable: str
-    hint: str
+    value: Optional[str]
+    human_readable: Optional[str]
+    hint: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/pipeline_settings_variable.py
+++ b/packages/sdks/python/devopness/_generated/models/pipeline_settings_variable.py
@@ -43,8 +43,8 @@ class PipelineSettingsVariablePlain(TypedDict, total=False):
     Plain version of PipelineSettingsVariable.
     """
 
-    name: str
-    human_readable: str
-    hint: str
-    type: str
-    required: bool
+    name: Optional[str]
+    human_readable: Optional[str]
+    hint: Optional[str]
+    type: Optional[str]
+    required: Optional[bool]

--- a/packages/sdks/python/devopness/_generated/models/pipeline_trigger_when.py
+++ b/packages/sdks/python/devopness/_generated/models/pipeline_trigger_when.py
@@ -37,9 +37,11 @@ class PipelineTriggerWhenPlain(TypedDict, total=False):
     Plain version of PipelineTriggerWhen.
     """
 
-    conditions: List[
-        Union[
-            TriggerWhenCondition,
-            TriggerWhenConditionPlain,
+    conditions: Optional[
+        List[
+            Union[
+                TriggerWhenCondition,
+                TriggerWhenConditionPlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/pipeline_update.py
+++ b/packages/sdks/python/devopness/_generated/models/pipeline_update.py
@@ -48,8 +48,10 @@ class PipelineUpdatePlain(TypedDict, total=False):
 
     id: Required[int]
     name: Required[str]
-    max_parallel_actions: int
-    trigger_when: Union[
-        PipelineTriggerWhen,
-        PipelineTriggerWhenPlain,
+    max_parallel_actions: Optional[int]
+    trigger_when: Optional[
+        Union[
+            PipelineTriggerWhen,
+            PipelineTriggerWhenPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/project.py
+++ b/packages/sdks/python/devopness/_generated/models/project.py
@@ -68,10 +68,12 @@ class ProjectPlain(TypedDict, total=False):
     user_id: Required[int]
     name: Required[str]
     logo_url: Required[str]
-    resource_summary: List[
-        Union[
-            ResourceSummaryItem,
-            ResourceSummaryItemPlain,
+    resource_summary: Optional[
+        List[
+            Union[
+                ResourceSummaryItem,
+                ResourceSummaryItemPlain,
+            ]
         ]
     ]
     os_users: Required[

--- a/packages/sdks/python/devopness/_generated/models/project_create.py
+++ b/packages/sdks/python/devopness/_generated/models/project_create.py
@@ -49,6 +49,6 @@ class ProjectCreatePlain(TypedDict, total=False):
     """
 
     name: Required[str]
-    organization_id: int
-    logo_image: str
-    logo_url: str
+    organization_id: Optional[int]
+    logo_image: Optional[str]
+    logo_url: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/project_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/project_relation.py
@@ -73,10 +73,12 @@ class ProjectRelationPlain(TypedDict, total=False):
     user_id: Required[int]
     name: Required[str]
     logo_url: Required[str]
-    resource_summary: List[
-        Union[
-            ResourceSummaryItem,
-            ResourceSummaryItemPlain,
+    resource_summary: Optional[
+        List[
+            Union[
+                ResourceSummaryItem,
+                ResourceSummaryItemPlain,
+            ]
         ]
     ]
     os_users: Required[
@@ -93,6 +95,6 @@ class ProjectRelationPlain(TypedDict, total=False):
             UserRelationPlain,
         ]
     ]
-    used_credits: int
+    used_credits: Optional[int]
     created_at: Required[str]
     updated_at: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/project_update.py
+++ b/packages/sdks/python/devopness/_generated/models/project_update.py
@@ -48,5 +48,5 @@ class ProjectUpdatePlain(TypedDict, total=False):
 
     id: Required[int]
     name: Required[str]
-    logo_image: str
-    logo_url: str
+    logo_image: Optional[str]
+    logo_url: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/provider_input_settings_validation.py
+++ b/packages/sdks/python/devopness/_generated/models/provider_input_settings_validation.py
@@ -41,8 +41,8 @@ class ProviderInputSettingsValidationPlain(TypedDict, total=False):
     Plain version of ProviderInputSettingsValidation.
     """
 
-    required: bool
-    type: str
-    min: int
-    max: int
-    allowed_values: List[str]
+    required: Optional[bool]
+    type: Optional[str]
+    min: Optional[int]
+    max: Optional[int]
+    allowed_values: Optional[List[str]]

--- a/packages/sdks/python/devopness/_generated/models/provider_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/provider_relation.py
@@ -62,4 +62,4 @@ class ProviderRelationPlain(TypedDict, total=False):
             ProviderTypePlain,
         ]
     ]
-    type_human_readable: str
+    type_human_readable: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/provider_settings.py
+++ b/packages/sdks/python/devopness/_generated/models/provider_settings.py
@@ -46,7 +46,7 @@ class ProviderSettingsPlain(TypedDict, total=False):
     Plain version of ProviderSettings.
     """
 
-    connect_url: str
+    connect_url: Optional[str]
     input_settings: Required[
         List[
             Union[
@@ -55,9 +55,11 @@ class ProviderSettingsPlain(TypedDict, total=False):
             ]
         ]
     ]
-    cloud_services: List[
-        Union[
-            CloudProviderService,
-            CloudProviderServicePlain,
+    cloud_services: Optional[
+        List[
+            Union[
+                CloudProviderService,
+                CloudProviderServicePlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/related_action.py
+++ b/packages/sdks/python/devopness/_generated/models/related_action.py
@@ -70,7 +70,7 @@ class RelatedActionPlain(TypedDict, total=False):
             ActionStatusPlain,
         ]
     ]
-    status_human_readable: str
+    status_human_readable: Optional[str]
     type: Required[
         Union[
             ActionType,
@@ -78,7 +78,7 @@ class RelatedActionPlain(TypedDict, total=False):
         ]
     ]
     type_human_readable: Required[str]
-    resource_name: str
+    resource_name: Optional[str]
     resource_type: Required[
         Union[
             ResourceType,

--- a/packages/sdks/python/devopness/_generated/models/resource_link_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/resource_link_relation.py
@@ -66,9 +66,11 @@ class ResourceLinkRelationPlain(TypedDict, total=False):
             LinkedResourceDataPlain,
         ]
     ]
-    children: List[
-        Union[
-            ResourceLinkChild,
-            ResourceLinkChildPlain,
+    children: Optional[
+        List[
+            Union[
+                ResourceLinkChild,
+                ResourceLinkChildPlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/resource_operation.py
+++ b/packages/sdks/python/devopness/_generated/models/resource_operation.py
@@ -38,9 +38,11 @@ class ResourceOperationPlain(TypedDict, total=False):
     Plain version of ResourceOperation.
     """
 
-    operation: str
-    operation_human_readable: str
-    pipeline_settings: Union[
-        PipelineSettings,
-        PipelineSettingsPlain,
+    operation: Optional[str]
+    operation_human_readable: Optional[str]
+    pipeline_settings: Optional[
+        Union[
+            PipelineSettings,
+            PipelineSettingsPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/resource_type_related.py
+++ b/packages/sdks/python/devopness/_generated/models/resource_type_related.py
@@ -48,10 +48,12 @@ class ResourceTypeRelatedPlain(TypedDict, total=False):
     Plain version of ResourceTypeRelated.
     """
 
-    resource_type: Union[
-        ResourceType,
-        ResourceTypePlain,
+    resource_type: Optional[
+        Union[
+            ResourceType,
+            ResourceTypePlain,
+        ]
     ]
-    resource_type_human_readable: str
-    resource_type_human_readable_plural: str
-    can_be_linked: bool
+    resource_type_human_readable: Optional[str]
+    resource_type_human_readable_plural: Optional[str]
+    can_be_linked: Optional[bool]

--- a/packages/sdks/python/devopness/_generated/models/role_project_create.py
+++ b/packages/sdks/python/devopness/_generated/models/role_project_create.py
@@ -46,5 +46,5 @@ class RoleProjectCreatePlain(TypedDict, total=False):
     """
 
     name: Required[str]
-    description: str
+    description: Optional[str]
     permissions: Required[List[str]]

--- a/packages/sdks/python/devopness/_generated/models/role_update.py
+++ b/packages/sdks/python/devopness/_generated/models/role_update.py
@@ -49,5 +49,5 @@ class RoleUpdatePlain(TypedDict, total=False):
 
     id: Required[int]
     name: Required[str]
-    description: str
+    description: Optional[str]
     permissions: Required[List[str]]

--- a/packages/sdks/python/devopness/_generated/models/server.py
+++ b/packages/sdks/python/devopness/_generated/models/server.py
@@ -121,7 +121,7 @@ class ServerPlain(TypedDict, total=False):
             ServerCloudServiceCodePlain,
         ]
     ]
-    ip_address: str
+    ip_address: Optional[str]
     ssh_port: Required[int]
     os: Required[
         Union[

--- a/packages/sdks/python/devopness/_generated/models/server_blueprint.py
+++ b/packages/sdks/python/devopness/_generated/models/server_blueprint.py
@@ -51,12 +51,14 @@ class ServerBlueprintPlain(TypedDict, total=False):
     Plain version of ServerBlueprint.
     """
 
-    id: int
-    name: str
-    type: str
-    spec: Union[
-        ServerBlueprintSpec,
-        ServerBlueprintSpecPlain,
+    id: Optional[int]
+    name: Optional[str]
+    type: Optional[str]
+    spec: Optional[
+        Union[
+            ServerBlueprintSpec,
+            ServerBlueprintSpecPlain,
+        ]
     ]
-    created_at: datetime
-    updated_at: datetime
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]

--- a/packages/sdks/python/devopness/_generated/models/server_blueprint_spec.py
+++ b/packages/sdks/python/devopness/_generated/models/server_blueprint_spec.py
@@ -38,9 +38,11 @@ class ServerBlueprintSpecPlain(TypedDict, total=False):
     Plain version of ServerBlueprintSpec.
     """
 
-    services: List[
-        Union[
-            BlueprintService,
-            BlueprintServicePlain,
+    services: Optional[
+        List[
+            Union[
+                BlueprintService,
+                BlueprintServicePlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/server_environment_create.py
+++ b/packages/sdks/python/devopness/_generated/models/server_environment_create.py
@@ -71,20 +71,24 @@ class ServerEnvironmentCreatePlain(TypedDict, total=False):
     Plain version of ServerEnvironmentCreate.
     """
 
-    linked_resources: List[
-        Union[
-            ResourceToBeLinked,
-            ResourceToBeLinkedPlain,
+    linked_resources: Optional[
+        List[
+            Union[
+                ResourceToBeLinked,
+                ResourceToBeLinkedPlain,
+            ]
         ]
     ]
     hostname: Required[str]
-    ip_address: str
-    ssh_port: int
-    max_parallel_actions: int
-    blueprint: List[
-        Union[
-            BlueprintService,
-            BlueprintServicePlain,
+    ip_address: Optional[str]
+    ssh_port: Optional[int]
+    max_parallel_actions: Optional[int]
+    blueprint: Optional[
+        List[
+            Union[
+                BlueprintService,
+                BlueprintServicePlain,
+            ]
         ]
     ]
     provision_input: Required[
@@ -93,4 +97,4 @@ class ServerEnvironmentCreatePlain(TypedDict, total=False):
             ServerProvisionInputPlain,
         ]
     ]
-    credential_id: str
+    credential_id: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/server_provision_input.py
+++ b/packages/sdks/python/devopness/_generated/models/server_provision_input.py
@@ -49,14 +49,16 @@ class ServerProvisionInputPlain(TypedDict, total=False):
     Plain version of ServerProvisionInput.
     """
 
-    subnet_id: int
+    subnet_id: Optional[int]
     cloud_service_code: Required[
         Union[
             ServerCloudServiceCode,
             ServerCloudServiceCodePlain,
         ]
     ]
-    settings: Union[
-        ServerProvisionInputSettings,
-        ServerProvisionInputSettingsPlain,
+    settings: Optional[
+        Union[
+            ServerProvisionInputSettings,
+            ServerProvisionInputSettingsPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/server_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/server_relation.py
@@ -97,7 +97,7 @@ class ServerRelationPlain(TypedDict, total=False):
     ]
     region: Required[str]
     region_human_readable: Required[str]
-    ip_address: str
+    ip_address: Optional[str]
     ssh_port: Required[int]
     active: Required[bool]
     status: Required[

--- a/packages/sdks/python/devopness/_generated/models/server_update.py
+++ b/packages/sdks/python/devopness/_generated/models/server_update.py
@@ -52,7 +52,7 @@ class ServerUpdatePlain(TypedDict, total=False):
     """
 
     id: Required[int]
-    ip_address: str
-    ssh_port: int
-    max_parallel_actions: int
-    credential_id: str
+    ip_address: Optional[str]
+    ssh_port: Optional[int]
+    max_parallel_actions: Optional[int]
+    credential_id: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/service_environment_create.py
+++ b/packages/sdks/python/devopness/_generated/models/service_environment_create.py
@@ -53,16 +53,20 @@ class ServiceEnvironmentCreatePlain(TypedDict, total=False):
     Plain version of ServiceEnvironmentCreate.
     """
 
-    linked_resources: List[
-        Union[
-            ResourceToBeLinked,
-            ResourceToBeLinkedPlain,
+    linked_resources: Optional[
+        List[
+            Union[
+                ResourceToBeLinked,
+                ResourceToBeLinkedPlain,
+            ]
         ]
     ]
-    auto_start: bool
-    initial_state: Union[
-        ServiceInitialState,
-        ServiceInitialStatePlain,
+    auto_start: Optional[bool]
+    initial_state: Optional[
+        Union[
+            ServiceInitialState,
+            ServiceInitialStatePlain,
+        ]
     ]
     type: Required[
         Union[

--- a/packages/sdks/python/devopness/_generated/models/service_get_status.py
+++ b/packages/sdks/python/devopness/_generated/models/service_get_status.py
@@ -35,4 +35,4 @@ class ServiceGetStatusPlain(TypedDict, total=False):
     Plain version of ServiceGetStatus.
     """
 
-    servers: List[int]
+    servers: Optional[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/service_reload.py
+++ b/packages/sdks/python/devopness/_generated/models/service_reload.py
@@ -35,4 +35,4 @@ class ServiceReloadPlain(TypedDict, total=False):
     Plain version of ServiceReload.
     """
 
-    servers: List[int]
+    servers: Optional[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/service_restart.py
+++ b/packages/sdks/python/devopness/_generated/models/service_restart.py
@@ -35,4 +35,4 @@ class ServiceRestartPlain(TypedDict, total=False):
     Plain version of ServiceRestart.
     """
 
-    servers: List[int]
+    servers: Optional[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/service_start.py
+++ b/packages/sdks/python/devopness/_generated/models/service_start.py
@@ -35,4 +35,4 @@ class ServiceStartPlain(TypedDict, total=False):
     Plain version of ServiceStart.
     """
 
-    servers: List[int]
+    servers: Optional[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/service_stop.py
+++ b/packages/sdks/python/devopness/_generated/models/service_stop.py
@@ -35,4 +35,4 @@ class ServiceStopPlain(TypedDict, total=False):
     Plain version of ServiceStop.
     """
 
-    servers: List[int]
+    servers: Optional[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/ssh_key.py
+++ b/packages/sdks/python/devopness/_generated/models/ssh_key.py
@@ -77,8 +77,8 @@ class SshKeyPlain(TypedDict, total=False):
     """
 
     id: Required[int]
-    created_by: int
-    project_id: int
+    created_by: Optional[int]
+    project_id: Optional[int]
     environment_id: Required[int]
     name: Required[str]
     fingerprint: Required[str]
@@ -108,5 +108,5 @@ class SshKeyPlain(TypedDict, total=False):
             ActionRelationPlain,
         ]
     ]
-    created_at: str
-    updated_at: str
+    created_at: Optional[str]
+    updated_at: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/ssh_key_environment_create.py
+++ b/packages/sdks/python/devopness/_generated/models/ssh_key_environment_create.py
@@ -44,10 +44,12 @@ class SshKeyEnvironmentCreatePlain(TypedDict, total=False):
     Plain version of SshKeyEnvironmentCreate.
     """
 
-    linked_resources: List[
-        Union[
-            ResourceToBeLinked,
-            ResourceToBeLinkedPlain,
+    linked_resources: Optional[
+        List[
+            Union[
+                ResourceToBeLinked,
+                ResourceToBeLinkedPlain,
+            ]
         ]
     ]
     name: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/ssh_key_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/ssh_key_relation.py
@@ -67,14 +67,16 @@ class SshKeyRelationPlain(TypedDict, total=False):
     """
 
     id: Required[int]
-    created_by: int
-    project_id: int
+    created_by: Optional[int]
+    project_id: Optional[int]
     environment_id: Required[int]
     name: Required[str]
     fingerprint: Required[str]
-    last_action: Union[
-        ActionRelationShallow,
-        ActionRelationShallowPlain,
+    last_action: Optional[
+        Union[
+            ActionRelationShallow,
+            ActionRelationShallowPlain,
+        ]
     ]
-    created_at: str
-    updated_at: str
+    created_at: Optional[str]
+    updated_at: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/ssl_certificate_environment_create.py
+++ b/packages/sdks/python/devopness/_generated/models/ssl_certificate_environment_create.py
@@ -65,13 +65,17 @@ class SslCertificateEnvironmentCreatePlain(TypedDict, total=False):
             SslCertificateIssuerPlain,
         ]
     ]
-    type: Union[
-        SslCertificateType,
-        SslCertificateTypePlain,
+    type: Optional[
+        Union[
+            SslCertificateType,
+            SslCertificateTypePlain,
+        ]
     ]
-    validation_level: Union[
-        SslCertificateValidationLevel,
-        SslCertificateValidationLevelPlain,
+    validation_level: Optional[
+        Union[
+            SslCertificateValidationLevel,
+            SslCertificateValidationLevelPlain,
+        ]
     ]
-    custom_private_key: str
-    custom_certificate: str
+    custom_private_key: Optional[str]
+    custom_certificate: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/static_billing_info.py
+++ b/packages/sdks/python/devopness/_generated/models/static_billing_info.py
@@ -37,9 +37,11 @@ class StaticBillingInfoPlain(TypedDict, total=False):
     Plain version of StaticBillingInfo.
     """
 
-    subscription_plans: List[
-        Union[
-            SubscriptionPlan,
-            SubscriptionPlanPlain,
+    subscription_plans: Optional[
+        List[
+            Union[
+                SubscriptionPlan,
+                SubscriptionPlanPlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/static_permission.py
+++ b/packages/sdks/python/devopness/_generated/models/static_permission.py
@@ -48,4 +48,4 @@ class StaticPermissionPlain(TypedDict, total=False):
     name: Required[str]
     human_readable: Required[str]
     hint: Required[str]
-    required_permissions: List[str]
+    required_permissions: Optional[List[str]]

--- a/packages/sdks/python/devopness/_generated/models/static_service_type_supported_versions_inner.py
+++ b/packages/sdks/python/devopness/_generated/models/static_service_type_supported_versions_inner.py
@@ -41,10 +41,12 @@ class StaticServiceTypeSupportedVersionsInnerPlain(TypedDict, total=False):
     Plain version of StaticServiceTypeSupportedVersionsInner.
     """
 
-    version: str
-    variable_targets: List[
-        Union[
-            VariableTargets,
-            VariableTargetsPlain,
+    version: Optional[str]
+    variable_targets: Optional[
+        List[
+            Union[
+                VariableTargets,
+                VariableTargetsPlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/step.py
+++ b/packages/sdks/python/devopness/_generated/models/step.py
@@ -83,8 +83,8 @@ class StepPlain(TypedDict, total=False):
     """
 
     id: Required[int]
-    name: str
-    description: str
+    name: Optional[str]
+    description: Optional[str]
     type: Required[str]
     run_as_user: Required[str]
     command: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/step_pipeline_create.py
+++ b/packages/sdks/python/devopness/_generated/models/step_pipeline_create.py
@@ -62,9 +62,9 @@ class StepPipelineCreatePlain(TypedDict, total=False):
     Plain version of StepPipelineCreate.
     """
 
-    name: str
-    description: str
-    type: str
+    name: Optional[str]
+    description: Optional[str]
+    type: Optional[str]
     command: Required[str]
     runner: Required[
         Union[
@@ -72,4 +72,4 @@ class StepPipelineCreatePlain(TypedDict, total=False):
             PipelineStepRunnerNamePlain,
         ]
     ]
-    run_as_user: str
+    run_as_user: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/step_pipeline_update.py
+++ b/packages/sdks/python/devopness/_generated/models/step_pipeline_update.py
@@ -70,9 +70,9 @@ class StepPipelineUpdatePlain(TypedDict, total=False):
     """
 
     id: Required[int]
-    name: str
-    description: str
-    type: str
+    name: Optional[str]
+    description: Optional[str]
+    type: Optional[str]
     command: Required[str]
     runner: Required[
         Union[
@@ -80,5 +80,5 @@ class StepPipelineUpdatePlain(TypedDict, total=False):
             PipelineStepRunnerNamePlain,
         ]
     ]
-    run_as_user: str
-    trigger_after: int
+    run_as_user: Optional[str]
+    trigger_after: Optional[int]

--- a/packages/sdks/python/devopness/_generated/models/subnet_provision_input_settings_aws.py
+++ b/packages/sdks/python/devopness/_generated/models/subnet_provision_input_settings_aws.py
@@ -46,7 +46,7 @@ class SubnetProvisionInputSettingsAwsPlain(TypedDict, total=False):
     Plain version of SubnetProvisionInputSettingsAws.
     """
 
-    region: str
-    region_human_readable: str
+    region: Optional[str]
+    region_human_readable: Optional[str]
     zone: Required[str]
     cidr_block: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/subnet_provision_input_settings_azure.py
+++ b/packages/sdks/python/devopness/_generated/models/subnet_provision_input_settings_azure.py
@@ -42,6 +42,6 @@ class SubnetProvisionInputSettingsAzurePlain(TypedDict, total=False):
     Plain version of SubnetProvisionInputSettingsAzure.
     """
 
-    region: str
-    region_human_readable: str
+    region: Optional[str]
+    region_human_readable: Optional[str]
     cidr_block: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/subnet_provision_input_settings_digital_ocean.py
+++ b/packages/sdks/python/devopness/_generated/models/subnet_provision_input_settings_digital_ocean.py
@@ -42,5 +42,5 @@ class SubnetProvisionInputSettingsDigitalOceanPlain(TypedDict, total=False):
     """
 
     region: Required[str]
-    region_human_readable: str
+    region_human_readable: Optional[str]
     cidr_block: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/subnet_provision_input_settings_gcp.py
+++ b/packages/sdks/python/devopness/_generated/models/subnet_provision_input_settings_gcp.py
@@ -42,5 +42,5 @@ class SubnetProvisionInputSettingsGcpPlain(TypedDict, total=False):
     """
 
     region: Required[str]
-    region_human_readable: str
+    region_human_readable: Optional[str]
     cidr_block: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/subscription.py
+++ b/packages/sdks/python/devopness/_generated/models/subscription.py
@@ -91,25 +91,29 @@ class SubscriptionPlain(TypedDict, total=False):
     Plain version of Subscription.
     """
 
-    id: int
-    user_id: int
-    plan_name: str
-    status: str
-    quantity: int
-    price_unit: float
-    price_total: float
-    price_currency: str
-    cancelled_at: datetime
-    ends_at: datetime
-    created_at: datetime
-    updated_at: datetime
-    current_balance: Union[
-        SubscriptionBalance,
-        SubscriptionBalancePlain,
-    ]
-    balances: List[
+    id: Optional[int]
+    user_id: Optional[int]
+    plan_name: Optional[str]
+    status: Optional[str]
+    quantity: Optional[int]
+    price_unit: Optional[float]
+    price_total: Optional[float]
+    price_currency: Optional[str]
+    cancelled_at: Optional[datetime]
+    ends_at: Optional[datetime]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+    current_balance: Optional[
         Union[
             SubscriptionBalance,
             SubscriptionBalancePlain,
+        ]
+    ]
+    balances: Optional[
+        List[
+            Union[
+                SubscriptionBalance,
+                SubscriptionBalancePlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/subscription_balance.py
+++ b/packages/sdks/python/devopness/_generated/models/subscription_balance.py
@@ -55,12 +55,14 @@ class SubscriptionBalancePlain(TypedDict, total=False):
     Plain version of SubscriptionBalance.
     """
 
-    credits: Union[
-        Credits,
-        CreditsPlain,
+    credits: Optional[
+        Union[
+            Credits,
+            CreditsPlain,
+        ]
     ]
-    unit: str
-    billing_period_started_at: datetime
-    billing_period_ends_at: datetime
-    created_at: datetime
-    updated_at: datetime
+    unit: Optional[str]
+    billing_period_started_at: Optional[datetime]
+    billing_period_ends_at: Optional[datetime]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]

--- a/packages/sdks/python/devopness/_generated/models/subscription_plan.py
+++ b/packages/sdks/python/devopness/_generated/models/subscription_plan.py
@@ -36,6 +36,6 @@ class SubscriptionPlanPlain(TypedDict, total=False):
     Plain version of SubscriptionPlan.
     """
 
-    provider_plan_id: str
-    human_readable: str
-    allow_subscriptions: bool
+    provider_plan_id: Optional[str]
+    human_readable: Optional[str]
+    allow_subscriptions: Optional[bool]

--- a/packages/sdks/python/devopness/_generated/models/team_project_create.py
+++ b/packages/sdks/python/devopness/_generated/models/team_project_create.py
@@ -40,4 +40,4 @@ class TeamProjectCreatePlain(TypedDict, total=False):
     """
 
     name: Required[str]
-    photo_url: str
+    photo_url: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/team_update.py
+++ b/packages/sdks/python/devopness/_generated/models/team_update.py
@@ -43,4 +43,4 @@ class TeamUpdatePlain(TypedDict, total=False):
 
     id: Required[int]
     name: Required[str]
-    photo_url: str
+    photo_url: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/trigger_when_condition.py
+++ b/packages/sdks/python/devopness/_generated/models/trigger_when_condition.py
@@ -53,7 +53,7 @@ class TriggerWhenConditionPlain(TypedDict, total=False):
     Plain version of TriggerWhenCondition.
     """
 
-    name: str
+    name: Optional[str]
     type: Required[
         Union[
             TriggerWhenConditionType,

--- a/packages/sdks/python/devopness/_generated/models/triggered_action_stats.py
+++ b/packages/sdks/python/devopness/_generated/models/triggered_action_stats.py
@@ -51,11 +51,13 @@ class TriggeredActionStatsPlain(TypedDict, total=False):
     Plain version of TriggeredActionStats.
     """
 
-    resource_type: str
-    action_type: str
-    resource_type_human_readable: str
-    action_type_human_readable: str
-    summary: Union[
-        TriggeredActionSummary,
-        TriggeredActionSummaryPlain,
+    resource_type: Optional[str]
+    action_type: Optional[str]
+    resource_type_human_readable: Optional[str]
+    action_type_human_readable: Optional[str]
+    summary: Optional[
+        Union[
+            TriggeredActionSummary,
+            TriggeredActionSummaryPlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/triggered_action_summary.py
+++ b/packages/sdks/python/devopness/_generated/models/triggered_action_summary.py
@@ -60,9 +60,9 @@ class TriggeredActionSummaryPlain(TypedDict, total=False):
     Plain version of TriggeredActionSummary.
     """
 
-    count: float
-    queued: float
-    pending: float
-    in_progress: float
-    completed: float
-    failed: float
+    count: Optional[float]
+    queued: Optional[float]
+    pending: Optional[float]
+    in_progress: Optional[float]
+    completed: Optional[float]
+    failed: Optional[float]

--- a/packages/sdks/python/devopness/_generated/models/triggered_actions.py
+++ b/packages/sdks/python/devopness/_generated/models/triggered_actions.py
@@ -39,13 +39,17 @@ class TriggeredActionsPlain(TypedDict, total=False):
     Plain version of TriggeredActions.
     """
 
-    summary: Union[
-        TriggeredActionSummary,
-        TriggeredActionSummaryPlain,
-    ]
-    operations: List[
+    summary: Optional[
         Union[
-            TriggeredActionStats,
-            TriggeredActionStatsPlain,
+            TriggeredActionSummary,
+            TriggeredActionSummaryPlain,
+        ]
+    ]
+    operations: Optional[
+        List[
+            Union[
+                TriggeredActionStats,
+                TriggeredActionStatsPlain,
+            ]
         ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/user_environment_stats.py
+++ b/packages/sdks/python/devopness/_generated/models/user_environment_stats.py
@@ -41,5 +41,5 @@ class UserEnvironmentStatsPlain(TypedDict, total=False):
     Plain version of UserEnvironmentStats.
     """
 
-    owner_of: float
-    member_of: float
+    owner_of: Optional[float]
+    member_of: Optional[float]

--- a/packages/sdks/python/devopness/_generated/models/user_project_stats.py
+++ b/packages/sdks/python/devopness/_generated/models/user_project_stats.py
@@ -41,5 +41,5 @@ class UserProjectStatsPlain(TypedDict, total=False):
     Plain version of UserProjectStats.
     """
 
-    owner_of: float
-    member_of: float
+    owner_of: Optional[float]
+    member_of: Optional[float]

--- a/packages/sdks/python/devopness/_generated/models/user_relation.py
+++ b/packages/sdks/python/devopness/_generated/models/user_relation.py
@@ -66,11 +66,13 @@ class UserRelationPlain(TypedDict, total=False):
     id: Required[int]
     name: Required[str]
     email: Required[str]
-    url_slug: str
-    language: Union[
-        Language,
-        LanguagePlain,
+    url_slug: Optional[str]
+    language: Optional[
+        Union[
+            Language,
+            LanguagePlain,
+        ]
     ]
-    active: bool
-    created_at: datetime
-    updated_at: datetime
+    active: Optional[bool]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]

--- a/packages/sdks/python/devopness/_generated/models/user_team_stats.py
+++ b/packages/sdks/python/devopness/_generated/models/user_team_stats.py
@@ -41,5 +41,5 @@ class UserTeamStatsPlain(TypedDict, total=False):
     Plain version of UserTeamStats.
     """
 
-    owner_of: float
-    member_of: float
+    owner_of: Optional[float]
+    member_of: Optional[float]

--- a/packages/sdks/python/devopness/_generated/models/user_update.py
+++ b/packages/sdks/python/devopness/_generated/models/user_update.py
@@ -53,7 +53,9 @@ class UserUpdatePlain(TypedDict, total=False):
     name: Required[str]
     email: Required[str]
     url_slug: Required[str]
-    language: Union[
-        Language,
-        LanguagePlain,
+    language: Optional[
+        Union[
+            Language,
+            LanguagePlain,
+        ]
     ]

--- a/packages/sdks/python/devopness/_generated/models/user_verify.py
+++ b/packages/sdks/python/devopness/_generated/models/user_verify.py
@@ -55,5 +55,5 @@ class UserVerifyPlain(TypedDict, total=False):
     email: Required[str]
     token: Required[str]
     name: Required[str]
-    url_slug: str
+    url_slug: Optional[str]
     password: Required[str]

--- a/packages/sdks/python/devopness/_generated/models/variable_application_create.py
+++ b/packages/sdks/python/devopness/_generated/models/variable_application_create.py
@@ -57,7 +57,7 @@ class VariableApplicationCreatePlain(TypedDict, total=False):
 
     key: Required[str]
     value: Required[str]
-    description: str
+    description: Optional[str]
     target: Required[
         Union[
             VariableTarget,

--- a/packages/sdks/python/devopness/_generated/models/variable_create.py
+++ b/packages/sdks/python/devopness/_generated/models/variable_create.py
@@ -57,7 +57,7 @@ class VariableCreatePlain(TypedDict, total=False):
 
     key: Required[str]
     value: Required[str]
-    description: str
+    description: Optional[str]
     target: Required[
         Union[
             VariableTarget,

--- a/packages/sdks/python/devopness/_generated/models/variable_service_create.py
+++ b/packages/sdks/python/devopness/_generated/models/variable_service_create.py
@@ -57,7 +57,7 @@ class VariableServiceCreatePlain(TypedDict, total=False):
 
     key: Required[str]
     value: Required[str]
-    description: str
+    description: Optional[str]
     target: Required[
         Union[
             VariableTarget,

--- a/packages/sdks/python/devopness/_generated/models/variable_targets.py
+++ b/packages/sdks/python/devopness/_generated/models/variable_targets.py
@@ -43,9 +43,11 @@ class VariableTargetsPlain(TypedDict, total=False):
     Plain version of VariableTargets.
     """
 
-    name: Union[
-        VariableTarget,
-        VariableTargetPlain,
+    name: Optional[
+        Union[
+            VariableTarget,
+            VariableTargetPlain,
+        ]
     ]
-    name_human_readable: str
-    hint: str
+    name_human_readable: Optional[str]
+    hint: Optional[str]

--- a/packages/sdks/python/devopness/_generated/models/variable_update.py
+++ b/packages/sdks/python/devopness/_generated/models/variable_update.py
@@ -60,7 +60,7 @@ class VariableUpdatePlain(TypedDict, total=False):
     id: Required[int]
     key: Required[str]
     value: Required[str]
-    description: str
+    description: Optional[str]
     target: Required[
         Union[
             VariableTarget,

--- a/packages/sdks/python/devopness/_generated/models/virtual_host_environment_create.py
+++ b/packages/sdks/python/devopness/_generated/models/virtual_host_environment_create.py
@@ -59,14 +59,16 @@ class VirtualHostEnvironmentCreatePlain(TypedDict, total=False):
     Plain version of VirtualHostEnvironmentCreate.
     """
 
-    linked_resources: List[
-        Union[
-            ResourceToBeLinked,
-            ResourceToBeLinkedPlain,
+    linked_resources: Optional[
+        List[
+            Union[
+                ResourceToBeLinked,
+                ResourceToBeLinkedPlain,
+            ]
         ]
     ]
     type: Required[str]
     name: Required[str]
-    root_directory: str
-    application_listen_address: str
-    application_id: int
+    root_directory: Optional[str]
+    application_listen_address: Optional[str]
+    application_id: Optional[int]

--- a/packages/sdks/python/devopness/_generated/models/virtual_host_get_status.py
+++ b/packages/sdks/python/devopness/_generated/models/virtual_host_get_status.py
@@ -35,4 +35,4 @@ class VirtualHostGetStatusPlain(TypedDict, total=False):
     Plain version of VirtualHostGetStatus.
     """
 
-    servers: List[int]
+    servers: Optional[List[int]]

--- a/packages/sdks/python/devopness/_generated/models/virtual_host_update.py
+++ b/packages/sdks/python/devopness/_generated/models/virtual_host_update.py
@@ -54,6 +54,6 @@ class VirtualHostUpdatePlain(TypedDict, total=False):
 
     id: Required[int]
     name: Required[str]
-    root_directory: str
-    application_listen_address: str
-    application_id: int
+    root_directory: Optional[str]
+    application_listen_address: Optional[str]
+    application_id: Optional[int]

--- a/packages/sdks/python/devopness/_services/virtual_host_service.py
+++ b/packages/sdks/python/devopness/_services/virtual_host_service.py
@@ -1,0 +1,15 @@
+"""
+Devopness API Python SDK - Painless essential DevOps to everyone
+"""
+
+from .._generated.api.virtual_hosts_api import VirtualHostsApiService
+
+__all__ = ["VirtualHostService"]
+
+# pylint: disable=missing-class-docstring
+
+
+class VirtualHostService(
+    VirtualHostsApiService,
+):
+    pass

--- a/packages/sdks/python/devopness/services.py
+++ b/packages/sdks/python/devopness/services.py
@@ -9,6 +9,7 @@ from ._services.project_service import ProjectService
 from ._services.server_service import ServerService
 from ._services.subnet_service import SubnetService
 from ._services.user_service import UserService
+from ._services.virtual_host_service import VirtualHostService
 
 __all__ = [
     "CredentialService",
@@ -18,4 +19,5 @@ __all__ = [
     "ServerService",
     "SubnetService",
     "UserService",
+    "VirtualHostService",
 ]

--- a/packages/sdks/python/generator/templates/model_generic.mustache
+++ b/packages/sdks/python/generator/templates/model_generic.mustache
@@ -20,6 +20,7 @@ class {{classname}}Plain(TypedDict, total=False):
 
 {{#vars}}
     {{baseName}}: (
+        {{^required}} Optional[ {{/required}}
         {{#required}} Required[ {{/required}}
             {{#isPrimitiveType}}{{dataType}}{{/isPrimitiveType}}
             {{^isPrimitiveType}}
@@ -28,6 +29,7 @@ class {{classname}}Plain(TypedDict, total=False):
               {{#isContainer}}{{baseType}}[ Union[{{items.dataType}}, {{items.dataType}}Plain,] ]{{/isContainer}}
             {{/isPrimitiveType}}
         {{#required}} ] {{/required}}
+        {{^required}} ] {{/required}}
     )
 {{/vars}}
 

--- a/packages/sdks/python/tests/unit/base/test_service.py
+++ b/packages/sdks/python/tests/unit/base/test_service.py
@@ -1,11 +1,31 @@
 import unittest
+from typing import Optional, Required, TypedDict
 from unittest.mock import Mock, patch
 
 import httpx
+from pydantic import Field, StrictInt, StrictStr
 
 from devopness import DevopnessClientConfig
 from devopness._base import DevopnessBaseService
-from devopness.models import ProjectCreate, ProjectUpdate
+from devopness._base.base_model import DevopnessBaseModel
+
+
+class DummyModel(DevopnessBaseModel):
+    id: Optional[StrictInt] = Field(
+        default=None,
+        description="The unique ID of the given Dummy.",
+    )
+    name: StrictStr = Field(description="The name of the dummy.")
+    description: Optional[StrictStr] = Field(
+        default=None,
+        description="The description of the dummy.",
+    )
+
+
+class DummyModelPlain(TypedDict, total=False):
+    id: Optional[int]
+    name: Required[str]
+    description: Optional[str]
 
 
 class TestDevopnessBaseService(unittest.TestCase):
@@ -57,7 +77,7 @@ class TestDevopnessBaseService(unittest.TestCase):
         self,
         mock: Mock,
     ) -> None:
-        payload = {"name": "John Doe", "age": None}
+        payload: DummyModelPlain = {"name": "John Doe"}
         self.service._post_sync("/resource", payload)
 
         mock.assert_called_once()
@@ -76,7 +96,7 @@ class TestDevopnessBaseService(unittest.TestCase):
         self,
         mock: Mock,
     ) -> None:
-        payload = ProjectCreate(name="Cool Project", organization_id=None)
+        payload = DummyModel(name="John Doe")
         self.service._post_sync("/resource", payload)
 
         mock.assert_called_once()
@@ -88,7 +108,7 @@ class TestDevopnessBaseService(unittest.TestCase):
         self.assertEqual(request.url, "https://test.local/resource")
 
         self.assertEqual(request.headers["Content-Type"], "application/json")
-        self.assertEqual(request.content, b'{"name":"Cool Project"}')
+        self.assertEqual(request.content, b'{"name":"John Doe"}')
 
     @patch("httpx.Client.send")
     def test_post_without_payload(
@@ -113,7 +133,7 @@ class TestDevopnessBaseService(unittest.TestCase):
         self,
         mock: Mock,
     ) -> None:
-        payload = {"name": "John Doe", "age": None}
+        payload: DummyModelPlain = {"id": 123, "name": "John Doe"}
         self.service._put_sync("/resource", payload)
 
         mock.assert_called_once()
@@ -125,14 +145,14 @@ class TestDevopnessBaseService(unittest.TestCase):
         self.assertEqual(request.url, "https://test.local/resource")
 
         self.assertEqual(request.headers["Content-Type"], "application/json")
-        self.assertEqual(request.content, b'{"name":"John Doe"}')
+        self.assertEqual(request.content, b'{"id":123,"name":"John Doe"}')
 
     @patch("httpx.Client.send")
     def test_put_sdk_model_removes_null_fields(
         self,
         mock: Mock,
     ) -> None:
-        payload = ProjectUpdate(id=123, name="Cool Project", logo_image=None)
+        payload = DummyModel(id=123, name="John Doe")
         self.service._put_sync("/resource", payload)
 
         mock.assert_called_once()
@@ -144,7 +164,7 @@ class TestDevopnessBaseService(unittest.TestCase):
         self.assertEqual(request.url, "https://test.local/resource")
 
         self.assertEqual(request.headers["Content-Type"], "application/json")
-        self.assertEqual(request.content, b'{"id":123,"name":"Cool Project"}')
+        self.assertEqual(request.content, b'{"id":123,"name":"John Doe"}')
 
     @patch("httpx.Client.send")
     def test_put_without_payload(
@@ -238,7 +258,7 @@ class TestDevopnessBaseServiceAsync(unittest.IsolatedAsyncioTestCase):
         self,
         mock: Mock,
     ) -> None:
-        payload = {"name": "John Doe", "age": None}
+        payload: DummyModelPlain = {"name": "Cool Project"}
         await self.service._post("/resource", payload)
 
         mock.assert_called_once()
@@ -250,14 +270,14 @@ class TestDevopnessBaseServiceAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.url, "https://test.local/resource")
 
         self.assertEqual(request.headers["Content-Type"], "application/json")
-        self.assertEqual(request.content, b'{"name":"John Doe"}')
+        self.assertEqual(request.content, b'{"name":"Cool Project"}')
 
     @patch("httpx.AsyncClient.send")
     async def test_post_sdk_model_removes_null_fields(
         self,
         mock: Mock,
     ) -> None:
-        payload = ProjectCreate(name="Cool Project", organization_id=None)
+        payload = DummyModel(name="Cool Project")
         await self.service._post("/resource", payload)
 
         mock.assert_called_once()
@@ -294,7 +314,7 @@ class TestDevopnessBaseServiceAsync(unittest.IsolatedAsyncioTestCase):
         self,
         mock: Mock,
     ) -> None:
-        payload = {"name": "John Doe", "age": None}
+        payload: DummyModelPlain = {"id": 123, "name": "Cool Project"}
         await self.service._put("/resource", payload)
 
         mock.assert_called_once()
@@ -306,14 +326,14 @@ class TestDevopnessBaseServiceAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.url, "https://test.local/resource")
 
         self.assertEqual(request.headers["Content-Type"], "application/json")
-        self.assertEqual(request.content, b'{"name":"John Doe"}')
+        self.assertEqual(request.content, b'{"id":123,"name":"Cool Project"}')
 
     @patch("httpx.AsyncClient.send")
     async def test_put_sdk_model_removes_null_fields(
         self,
         mock: Mock,
     ) -> None:
-        payload = ProjectUpdate(id=123, name="Cool Project", logo_image=None)
+        payload = DummyModel(id=123, name="Cool Project")
         await self.service._put("/resource", payload)
 
         mock.assert_called_once()


### PR DESCRIPTION
## Description of changes

**Devopness Client**

- [x] Exposed the Virtual Host Service in the Devopness Client
   - Supports the following operations:
     - Create virtual host
     - Delete virtual host
     - Get details of virtual host
     - Get current status of virtual host
     - List virtual hosts belonging to an environment
     - Update details of virtual host

**Bug Fixes**

- [x] Fixed typing for optional fields in Plain models
   - Optional Fields now correctly marked as **Optional**, allowing **None** to be passed
- [x] Fixed the payload transformation logic in **DevopnessBaseService.__get_payload** to preserve keys **explicitly** set to **None** by the user:
   - Only fields with a default value of None are excluded from the payload
   - Previously, required **nullable** fields were incorrectly removed from the payload, even when explicitly set to None, causing validation errors from the API **(e.g., VirtualHost.application_id in VirtualHostUpdate)**

## GitHub issues resolved by this PR

- N/A
- contribute to #921

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: 
  - The virtual host service are available and functional in the SDK
  - Typing of optional fields does not raise errors when passing None

## More info

