### PR TITLE
fix(package-lock): rename sdk-python-dev to sdk-python

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1119,7 +1119,7 @@
       "resolved": "packages/sdks/javascript",
       "link": true
     },
-    "node_modules/@devopness/sdk-python-dev": {
+    "node_modules/@devopness/sdk-python": {
       "resolved": "packages/sdks/python",
       "link": true
     },
@@ -17144,8 +17144,8 @@
       }
     },
     "packages/sdks/python": {
-      "name": "@devopness/sdk-python-dev",
-      "version": "0.0.79"
+      "name": "@devopness/sdk-python",
+      "version": "0.0.0"
     },
     "packages/ui/react": {
       "name": "@devopness/ui-react",

--- a/packages/sdks/python/package.json
+++ b/packages/sdks/python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devopness/sdk-python",
   "version": "0.0.0",
-  "description": "This is used by Changesets Action to manage the versions of the SDK-Python, in the same way as it's done for SDK-JS.",
+  "description": "This file is used by Changesets Action to build and publish versions of Devopness Python SDK. For further details see https://github.com/devopness/devopness/blob/main/package.json",
   "private": true
 }

--- a/packages/sdks/python/package.json
+++ b/packages/sdks/python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devopness/sdk-python",
   "version": "0.0.0",
-  "description": "This is used by Changesets Action to manage the versions of the SDK-Python, in the same way as it's done for SDK-JS",
+  "description": "This is used by Changesets Action to manage the versions of the SDK-Python, in the same way as it's done for SDK-JS.",
   "private": true
 }


### PR DESCRIPTION
## Description of changes

- [x] Fix the main package-lock.json file to replace the **@devopness/sdk-python-dev** with **@devopness/sdk-python** reflecting the package rename

This PR ensures the lock file is aligned with package.json, preventing errors such as:

```ruby
npm ci can only install packages when your package.json
and package-lock.json or npm-shrinkwrap.json are in sync.

Missing: @devopness/sdk-python@0.0.0 from lock file  
```

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: publish pipeline work normally.

## More info

CI failure details can be found in the workflow run logs: https://github.com/devopness/devopness/actions/runs/15077237309/job/42387322168