### PR TITLE
ci: Enable stale workflow for PRs to close abandoned pull requests

### DIFF
--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -1,4 +1,4 @@
-name: Issue - Stale handler
+name: Issue and PR - Stale handler
 
 on:
   workflow_dispatch: # allows workflow to be manually triggered from GitHub UI
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-pr-stale: -1 # This option is to keep the action workflow from meddling with Pull Requests for now
-          days-before-pr-close: -1 # This option is to keep the action workflow from meddling with Pull Requests for now
+          days-before-pr-stale: 7      # Mark PRs stale after 7 days of inactivity
+          days-before-pr-close: 14      # Close stale PRs after an additional 14 days
           days-before-issue-stale: 21
           days-before-issue-close: 14
           exempt-issue-labels: >-
@@ -21,8 +21,11 @@ jobs:
             priority: P1 must have,
             priority: P2 should have,
             priority: P3 could have
-          labels-to-remove-when-unstale: 'status: no issue activity'
+          exempt-pr-labels: 'work in progress'    # Only exempt WIP PRs from being stale
+          labels-to-remove-when-unstale: 'status: no issue activity,status: no PR activity'
           operations-per-run: 100
+          any-of-labels: ''   # Process all issues and PRs regardless of labels
+          remove-stale-when-updated: true   # Remove stale label when PR is updated
           stale-issue-label: 'status: no issue activity'
           stale-issue-message: |
             👋 Hi there!
@@ -34,3 +37,19 @@ jobs:
           close-issue-message: |
             ❌ This issue was closed because it has been open and inactive for a month.
             If you feel this is still a high-priority issue, or are interested in contributing, please open a new issue or pull request linking to this one, for context.
+          stale-pr-label: 'status: no PR activity'
+          stale-pr-message: |
+            👋 Hi there!
+            This pull request has been automatically marked as stale because there wasn't any activity in the past week.
+            * If you'd like to continue with this PR, please comment or push new commits.
+            * Otherwise, this PR will be automatically closed in 14 days (completing 3 weeks without activity).
+            
+            We appreciate your contributions and want to keep our PR queue clean and relevant.
+          close-pr-message: |
+            ❌ This pull request was closed because it has been stale for 2 weeks (7 days of inactivity + 14 days waiting period after being marked stale).
+            
+            If you wish to continue working on this change:
+            1. Please reopen the PR
+            2. Make the necessary updates to address any feedback or issues
+            
+            Thank you for your understanding and contributions to Devopness!


### PR DESCRIPTION
## Description of changes
- [x] Update stale workflow to handle Pull Requests after periods of inactivity
- [x] Mark PRs as stale after 7 days of inactivity with clear notification message
- [x] Close stale PRs automatically after 14 additional days of inactivity
- [x] Enable automatic removal of stale label when PR is updated
- [x] Only exempt PRs labeled as 'work in progress' from being marked as stale

## GitHub issues resolved by this PR
- [x] closes #1739

## Quality Assurance
<!-- Please complete this checklist before requesting a review of your pull request. -->
- Once the changes in this PR are merged and deployed, success criteria is:
  - Pull requests with 7 days of inactivity will be automatically labeled as stale
  - Stale pull requests will receive a clear notification message
  - If a stale PR remains inactive for 14 more days, it will be automatically closed
  - If a stale PR receives any updates, the stale label will be automatically removed

## More info
This PR configures the workflow with a 7-day threshold for marking PRs as stale and a 14-day period before closing. This helps keep the repository clean by automatically handling abandoned pull requests while giving authors sufficient time to respond.