### PR TITLE
feat(ci): add workflow_dispatch trigger to PR - Auto Merge Dependabot action

### DIFF
--- a/.github/workflows/pr-auto-merge-dependabot.yml
+++ b/.github/workflows/pr-auto-merge-dependabot.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Description of changes
- This PR aims to add one more action to  `PR - Auto Merge Dependabot` action, this change is necessary to integrate to others github-actions as mentioned [here](https://github.com/devopness/devopness-web-app/pull/1181#discussion_r2097163802)

## GitHub issues resolved by this PR

<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: after the merge the action will have another trigger to run, this will allow to run this action manually.