### PR TITLE
feat(sdk-python): validate base_url format in DevopnessClientConfig

### DIFF
--- a/.changeset/soft-insects-return.md
+++ b/.changeset/soft-insects-return.md
@@ -1,0 +1,5 @@
+---
+"@devopness/sdk-python": patch
+---
+
+Add validation for base_url in DevopnessClientConfig to ensure it starts with http:// or https://, raising a clear error if invalid.

--- a/packages/sdks/python/src/devopness/client_config.py
+++ b/packages/sdks/python/src/devopness/client_config.py
@@ -42,9 +42,11 @@ class DevopnessClientConfig(DevopnessBaseModel):
     def validate_base_url(cls, value: str) -> str:
         if not re.match(r"^https?://", value):
             raise DevopnessSdkError(
-                f"\n[DevopnessClientConfig] Invalid base_url '{value}' - "
-                "Expected a URL starting with 'http://' or 'https://' - "
-                "Example: 'https://api.devopness.com'"
+                "\nDevopness SDK Error: Invalid 'base_url' in client configuration."
+                "\nExpected a URL starting with 'http://' or 'https://', but received: "
+                f"'{value}'."
+                "\n\nHint: Make sure the 'base_url' includes the correct protocol,"
+                " e.g., 'https://api.devopness.com'."
             )
 
         return value

--- a/packages/sdks/python/src/devopness/client_config.py
+++ b/packages/sdks/python/src/devopness/client_config.py
@@ -2,9 +2,13 @@
 Devopness API Python SDK - Painless essential DevOps to everyone
 """
 
+import re
 from typing import ClassVar, TypedDict
 
+from pydantic import field_validator
+
 from .base import DevopnessBaseModel
+from .core.sdk_error import DevopnessSdkError
 
 __all__ = ["DevopnessClientConfig", "DevopnessClientConfigDict"]
 
@@ -32,6 +36,18 @@ class DevopnessClientConfig(DevopnessBaseModel):
         "Content-Type": "application/json",
     }
     timeout: int = 30
+
+    @field_validator("base_url", mode="before")
+    @classmethod
+    def validate_base_url(cls, value: str) -> str:
+        if not re.match(r"^https?://", value):
+            raise DevopnessSdkError(
+                f"\n[DevopnessClientConfig] Invalid base_url '{value}' - "
+                "Expected a URL starting with 'http://' or 'https://' - "
+                "Example: 'https://api.devopness.com'"
+            )
+
+        return value
 
 
 class DevopnessClientConfigDict(TypedDict, total=False):

--- a/packages/sdks/python/tests/unit/test_client_config.py
+++ b/packages/sdks/python/tests/unit/test_client_config.py
@@ -1,0 +1,53 @@
+"""
+Tests for the DevopnessClientConfig class
+"""
+
+import unittest
+
+from devopness import DevopnessClientConfig
+from devopness.core.sdk_error import DevopnessSdkError
+
+
+class TestDevopnessClientConfig(unittest.TestCase):
+    def test_base_url_with_valid_values(self) -> None:
+        config = DevopnessClientConfig(base_url="https://api.devopness.com")
+        self.assertEqual(config.base_url, "https://api.devopness.com")
+
+        config = DevopnessClientConfig.from_dict(
+            {"base_url": "http://api.devopness.com"}
+        )
+        self.assertEqual(config.base_url, "http://api.devopness.com")
+
+    def test_base_url_with_invalid_values(self) -> None:
+        with self.assertRaises(DevopnessSdkError) as first_raises:
+            DevopnessClientConfig.from_dict({"base_url": "invalid_url"})
+
+        self.assertEqual(
+            str(first_raises.exception),
+            "\nDevopness SDK Error: Invalid 'base_url' in client configuration."
+            "\nExpected a URL starting with 'http://' or 'https://', but received: 'invalid_url'."
+            "\n"
+            "\nHint: Make sure the 'base_url' includes the correct protocol, e.g., 'https://api.devopness.com'.",
+        )
+
+        with self.assertRaises(DevopnessSdkError) as second_raises:
+            DevopnessClientConfig(base_url="api.devopness.com")
+
+        self.assertEqual(
+            str(second_raises.exception),
+            "\nDevopness SDK Error: Invalid 'base_url' in client configuration."
+            "\nExpected a URL starting with 'http://' or 'https://', but received: 'api.devopness.com'."
+            "\n"
+            "\nHint: Make sure the 'base_url' includes the correct protocol, e.g., 'https://api.devopness.com'.",
+        )
+
+        with self.assertRaises(DevopnessSdkError) as third_raises:
+            DevopnessClientConfig(base_url="ftp://api.devopness.com/")
+
+        self.assertEqual(
+            str(third_raises.exception),
+            "\nDevopness SDK Error: Invalid 'base_url' in client configuration."
+            "\nExpected a URL starting with 'http://' or 'https://', but received: 'ftp://api.devopness.com/'."
+            "\n"
+            "\nHint: Make sure the 'base_url' includes the correct protocol, e.g., 'https://api.devopness.com'.",
+        )


### PR DESCRIPTION
## Description of changes

When instantiating the **DevopnessClientConfig**, if an invalid **base_url** is provided (i.e., it doesn't start with **http://** or **https://**), a clear validation error is now raised.

This prevents runtime misconfigurations and helps users catch mistakes earlier when configuring the SDK.

* [x] Added a validator for **base_url** field in **DevopnessClientConfig** to ensure the value starts with **http://** or **https://**
* [x] Raised a **DevopnessSdkError** with guidance when the validation fails

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: Users providing an invalid **base_url** receive an informative error early during SDK initialization.

## More info
