### PR TITLE
Docs/add help view environment

### DIFF
--- a/docs/environments/view-environment.md
+++ b/docs/environments/view-environment.md
@@ -1,0 +1,38 @@
+---
+title: View Environment
+intro: Learn how to view and manage the details of an environment, including its resources, settings, and team memberships.
+links:
+    overview:
+    quickstart:
+    previous: environments/list-environments
+    next: environments/add-environment
+    guides:
+    related:
+        - environments/list-environments
+        - environments/add-environment
+        - environments/archive-environment
+        - environments/find-archived-environment
+    featured:
+---
+
+1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
+1. Select a `Project`
+1. Find the `Environments` card
+1. Click `View` in the `Environments` card to see a list of existing `Environments`
+1. Find the `Environment` you want to view and click `View`
+1. The `Environment` page will be displayed, showing:
+   - Environment name and type
+   - Resource summary (servers, applications, etc.)
+   - Team memberships
+   - Actions history
+   - Settings and configuration options
+
+:::note
+
+You can perform various actions from the environment view page:
+- Add new resources (servers, applications, etc.)
+- Manage team memberships
+- Archive/unarchive the environment
+- View and manage environment settings
+
+::: 

--- a/packages/ui/react/CHANGELOG.md
+++ b/packages/ui/react/CHANGELOG.md
@@ -8,7 +8,7 @@
 
   ### What Changed
 
-  - Updated iconList const with a new icon (home)
+  - Updated iconList constant with a new icon (home)
 
   ### Example Usage
 


### PR DESCRIPTION
## Description of changes
Adds help documentation for the environment view page, allowing users to access clear guidance when clicking the `?` button on the environment view page.

- [x] Created new file `docs/environments/view-environment.md` with complete documentation
- [x] Added navigation and related links
- [x] Included clear and objective instructions for using the page
- [x] Followed project documentation standards

## GitHub issues resolved by this PR

- [x] closes #1206 

## Quality Assurance

- [x] Documentation follows the correct format (markdown)
- [x] Related links are working
- [x] Content is clear and objective
- [x] Documentation is aligned with existing workflow

## More info
To test the changes:
1. Access the environment view page
2. Click the `?` button
3. Verify if the documentation is displayed correctly
4. Test navigation and related links

The documentation includes:
- Steps to access the page
- Information about what can be seen on the page
- Actions that can be performed
- Links to related pages