### PR TITLE
chore: add Dockerfile, Makefile, and linting/formatting tools

### DIFF
--- a/packages/ai/mcp-server/Dockerfile
+++ b/packages/ai/mcp-server/Dockerfile
@@ -3,16 +3,16 @@ ARG ALPINE_VERSION="3.21"
 FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION}
 
 # --- System dependencies installation ---
-RUN apk update && apk add --no-cache bash openjdk11-jre
+RUN apk update && apk add --no-cache bash
 
 WORKDIR /mcp
 
 # --- Package dependencies installation ---
 RUN pip install uv==0.7.11
 
+ENV UV_LINK_MODE=copy
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-ENV UV_LINK_MODE=copy
 
 COPY uv.lock pyproject.toml ./
 RUN uv venv $VIRTUAL_ENV --allow-existing -q

--- a/packages/ai/mcp-server/Dockerfile
+++ b/packages/ai/mcp-server/Dockerfile
@@ -1,0 +1,19 @@
+ARG PYTHON_VERSION="3.12"
+ARG ALPINE_VERSION="3.21"
+FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION}
+
+# --- System dependencies installation ---
+RUN apk update && apk add --no-cache bash openjdk11-jre
+
+WORKDIR /mcp
+
+# --- Package dependencies installation ---
+RUN pip install uv==0.7.11
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+ENV UV_LINK_MODE=copy
+
+COPY uv.lock pyproject.toml ./
+RUN uv venv $VIRTUAL_ENV --allow-existing -q
+RUN uv sync --active --all-groups --compile-bytecode

--- a/packages/ai/mcp-server/Makefile
+++ b/packages/ai/mcp-server/Makefile
@@ -20,7 +20,6 @@ shell: build-image ## 🐚 Open a shell inside the MCP Server container
 	$(info 🔧 Starting interactive shell in MCP Server container...)
 	@docker run --rm -it \
 		-v $(PWD):/$(WORKDIR) \
-		-v $(PWD)/../common:/common \
 		--name devopness-mcp-server-shell \
 		$(IMAGE):$(TAG) \
 		/bin/bash

--- a/packages/ai/mcp-server/Makefile
+++ b/packages/ai/mcp-server/Makefile
@@ -1,0 +1,61 @@
+IMAGE ?= devopness-mcp-server
+TAG ?= latest
+
+WORKDIR := mcp
+
+.DEFAULT_GOAL := help
+.PHONY: build-image shell lint format help
+
+##@ Docker
+
+build-image: ## 🔧 Build the Docker image (optional: PYTHON_VERSION / ALPINE_VERSION)
+	$(info 🐳 Building Docker image...)
+	@docker build \
+		-f Dockerfile \
+		$(if $(PYTHON_VERSION),--build-arg PYTHON_VERSION=$(PYTHON_VERSION),) \
+		$(if $(ALPINE_VERSION),--build-arg ALPINE_VERSION=$(ALPINE_VERSION),) \
+		-t $(IMAGE):$(TAG) .
+
+shell: build-image ## 🐚 Open a shell inside the MCP Server container
+	$(info 🔧 Starting interactive shell in MCP Server container...)
+	@docker run --rm -it \
+		-v $(PWD):/$(WORKDIR) \
+		-v $(PWD)/../common:/common \
+		--name devopness-mcp-server-shell \
+		$(IMAGE):$(TAG) \
+		/bin/bash
+
+##@ Lint & Format
+
+lint: build-image ## 🔍 Run linting tools (ruff, mypy)
+	$(info 🧹 Running linters...)
+	@docker run --rm \
+		-v $(PWD):/$(WORKDIR) \
+		--name devopness-mcp-server-lint \
+		$(IMAGE):$(TAG) \
+		/bin/bash -cex ' \
+			ruff check . && \
+			ruff format . --check && \
+			mypy . \
+		'
+
+format: build-image ## 🧼 Auto-format code with ruff
+	$(info ✨ Formatting code...)
+	@docker run --rm \
+		-v $(PWD):/$(WORKDIR) \
+		--name devopness-mcp-server-format \
+		$(IMAGE):$(TAG) \
+		/bin/bash -cex ' \
+			ruff check --fix && \
+			ruff format . \
+		'
+
+##@ Utilities
+
+help: ## 📖 Show this help message
+# `help` function obtained from https://gist.github.com/prwhite/8168133#gistcomment-4160123
+	@echo "Devopness MCP Server"
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} \
+	/^[a-zA-Z0-9_-]+:.*##/ { \
+		printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 \
+	}' $(MAKEFILE_LIST)

--- a/packages/ai/mcp-server/devopness_api.py
+++ b/packages/ai/mcp-server/devopness_api.py
@@ -1,63 +1,74 @@
 import os
+from typing import List
 
 from devopness import DevopnessClientAsync
-from devopness.models import UserLogin
-
 from devopness.models import (
-    ServerEnvironmentCreate,
+    ApplicationRelation,
+    CredentialRelation,
+    EnvironmentRelation,
+    Hook,
     HookPipelineCreate,
     HookTypeParam,
+    PipelineRelation,
+    ProjectRelation,
+    Server,
+    ServerEnvironmentCreate,
+    ServerRelation,
+    UserLogin,
+    UserMe,
 )
-
 
 devopness = DevopnessClientAsync()
 
 
-async def ensure_authenticated():
+async def ensure_authenticated() -> None:
     user_email = os.environ.get("DEVOPNESS_USER_EMAIL")
     user_pass = os.environ.get("DEVOPNESS_USER_PASSWORD")
+
+    if not user_email or not user_pass:
+        raise Exception("DEVOPNESS_USER_EMAIL and DEVOPNESS_USER_PASSWORD must be set")
 
     # TODO: only invoke login if not yet authenticated
     user_data = UserLogin(email=user_email, password=user_pass)
     await devopness.users.login_user(user_data)
 
 
-async def get_user_profile():
+async def get_user_profile() -> UserMe:
     await ensure_authenticated()
     current_user = await devopness.users.get_user_me()
 
     return current_user.data
 
 
-async def list_projects():
+async def list_projects() -> List[ProjectRelation]:
     await ensure_authenticated()
     response = await devopness.projects.list_projects()
 
     return response.data
 
 
-async def list_environments(project_id: int):
+async def list_environments(project_id: int) -> List[EnvironmentRelation]:
     await ensure_authenticated()
     response = await devopness.environments.list_project_environments(project_id)
 
     return response.data
 
 
-async def list_credentials(environment_id: int):
+async def list_credentials(environment_id: int) -> List[CredentialRelation]:
     await ensure_authenticated()
     response = await devopness.credentials.list_environment_credentials(environment_id)
 
     return response.data
 
 
-async def list_servers(environment_id: int):
+async def list_servers(environment_id: int) -> List[ServerRelation]:
     await ensure_authenticated()
     response = await devopness.servers.list_environment_servers(environment_id)
 
     return response.data
 
 
-async def list_applications(environment_id: int):
+async def list_applications(environment_id: int) -> List[ApplicationRelation]:
     await ensure_authenticated()
     response = await devopness.applications.list_environment_applications(
         environment_id
@@ -66,7 +77,7 @@ async def list_applications(environment_id: int):
     return response.data
 
 
-async def list_application_pipelines(application_id: int):
+async def list_application_pipelines(application_id: int) -> List[PipelineRelation]:
     await ensure_authenticated()
     response = await devopness.pipelines.list_pipelines_by_resource_type(
         application_id, "application"
@@ -76,8 +87,9 @@ async def list_application_pipelines(application_id: int):
 
 
 async def create_server(
-    environment_id: int, server_input_settings: ServerEnvironmentCreate
-):
+    environment_id: int,
+    server_input_settings: ServerEnvironmentCreate,
+) -> Server:
     await ensure_authenticated()
     response = await devopness.servers.add_environment_server(
         environment_id, server_input_settings
@@ -87,8 +99,10 @@ async def create_server(
 
 
 async def create_webhook(
-    pipeline_id: int, hook_type: HookTypeParam, hook_settings: HookPipelineCreate
-):
+    pipeline_id: int,
+    hook_type: HookTypeParam,
+    hook_settings: HookPipelineCreate,
+) -> Hook:
     await ensure_authenticated()
     response = await devopness.hooks.add_pipeline_hook(
         hook_type, pipeline_id, hook_settings

--- a/packages/ai/mcp-server/main.py
+++ b/packages/ai/mcp-server/main.py
@@ -1,7 +1,7 @@
 from server import server
 
 
-def main():
+def main() -> None:
     server.run()
 
 

--- a/packages/ai/mcp-server/pyproject.toml
+++ b/packages/ai/mcp-server/pyproject.toml
@@ -8,3 +8,51 @@ dependencies = [
     "devopness>=1.1.5",
     "mcp[cli]>=1.9.1",
 ]
+
+[dependency-groups]
+dev = [
+    "mypy>=1.16.0",
+    "ruff>=0.11.13",
+]
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+
+[tool.ruff.lint]
+preview = true
+
+extend-select = [
+  "A",   # flake8-builtins (avoid shadowing built-ins)
+  "ANN", # flake8-annotations (type hints for public APIs)
+  "B",   # flake8-bugbear (common bugs and best practices)
+  "E",   # pycodestyle (error)
+  "F",   # pyflakes (basic errors)
+  "I",   # isort (import sorting)
+  "N",   # pep8-naming
+  "PIE", # flake8-pie (extra cleanups)
+  "PLC", # pylint conventions
+  "PLE", # pylint errors
+  "PLW", # pylint warnings
+  "Q",   # flake8-quotes (quote consistency)
+  "RET", # flake8-return (return statement rules)
+  "RUF", # Ruff-specific rules
+  "S",   # flake8-bandit (security rules)
+  "SIM", # flake8-simplify
+  "W",   # pycodestyle (warning)
+]
+
+[tool.ruff.lint.isort]
+case-sensitive = true
+
+[tool.mypy]
+python_version = "3.12"
+
+strict = true
+disallow_any_unimported = true
+strict_optional = true
+warn_no_return = true
+warn_unreachable = true
+
+sqlite_cache = true
+cache_fine_grained = true

--- a/packages/ai/mcp-server/pyproject.toml
+++ b/packages/ai/mcp-server/pyproject.toml
@@ -43,6 +43,7 @@ extend-select = [
 ]
 
 [tool.ruff.lint.isort]
+known-first-party = ["devopness"]
 case-sensitive = true
 
 [tool.mypy]

--- a/packages/ai/mcp-server/server.py
+++ b/packages/ai/mcp-server/server.py
@@ -1,10 +1,21 @@
-import devopness_api
+from typing import List
+
 from mcp.server.fastmcp import FastMCP
 
+import devopness_api
 from devopness.models import (
+    ApplicationRelation,
+    CredentialRelation,
+    EnvironmentRelation,
+    Hook,
     HookPipelineCreate,
-    ServerEnvironmentCreate,
     HookTypeParam,
+    PipelineRelation,
+    ProjectRelation,
+    Server,
+    ServerEnvironmentCreate,
+    ServerRelation,
+    UserMe,
 )
 
 server = FastMCP("Devopness")
@@ -18,32 +29,32 @@ server = FastMCP("Devopness")
 # @server.resource("users://me")
 # @server.resource("users://{user_id}")
 @server.tool()
-async def devopness_get_user_profile() -> str:
+async def devopness_get_user_profile() -> UserMe:
     """Get details for current user"""
     return await devopness_api.get_user_profile()
 
 
 # @server.resource("projects://all")
 @server.tool()
-async def devopness_list_projects():
+async def devopness_list_projects() -> List[ProjectRelation]:
     """List all projects"""
     return await devopness_api.list_projects()
 
 
 @server.tool()
-async def devopness_list_environments(project_id: int):
+async def devopness_list_environments(project_id: int) -> List[EnvironmentRelation]:
     """List all environments for a given project"""
     return await devopness_api.list_environments(project_id)
 
 
 @server.tool()
-async def devopness_list_credentials(environment_id: int):
+async def devopness_list_credentials(environment_id: int) -> List[CredentialRelation]:
     """List all credentials for a given environment"""
     return await devopness_api.list_credentials(environment_id)
 
 
 @server.tool()
-async def devopness_list_servers(environment_id: int):
+async def devopness_list_servers(environment_id: int) -> List[ServerRelation]:
     """List servers in a given environment"""
     return await devopness_api.list_servers(environment_id)
 
@@ -51,26 +62,29 @@ async def devopness_list_servers(environment_id: int):
 @server.tool()
 async def devopness_create_cloud_server(
     environment_id: int, server_input_settings: ServerEnvironmentCreate
-):
+) -> Server:
     """List servers in a given environment"""
 
     # action = create_server.last_action;
     # wait until action.status in ['failed', 'completed']:
     #     # TODO: apply "logger" best practices to display progress of the flow
     # TODO: add validation and recommendation for server_input_settings
-    #   Example: user should be able to tell the spec of the desired instance type, without the need to know the instace type
-    #     e.g.: "I want the cheapest server with at least 4 GB of memory"
+    #   Example: user should be able to tell the spec of the desired instance type,
+    #            without the need to know the instace type
+    #            e.g.: "I want the cheapest server with at least 4 GB of memory"
     return await devopness_api.create_server(environment_id, server_input_settings)
 
 
 @server.tool()
-async def devopness_list_applications(environment_id: int):
+async def devopness_list_applications(environment_id: int) -> List[ApplicationRelation]:
     """List servers in a given environment"""
     return await devopness_api.list_applications(environment_id)
 
 
 @server.tool()
-async def devopness_list_application_pipelines(application_id: int):
+async def devopness_list_application_pipelines(
+    application_id: int,
+) -> List[PipelineRelation]:
     """List pipelines for a given application"""
     return await devopness_api.list_application_pipelines(application_id)
 
@@ -78,7 +92,7 @@ async def devopness_list_application_pipelines(application_id: int):
 @server.tool()
 async def devopness_create_webhook(
     pipeline_id: int, hook_type: HookTypeParam, hook_settings: HookPipelineCreate
-):
+) -> Hook:
     """Creates a webhook for a given pipeline.
     Most common use case is to create an incoming webhook to deploy an application.
     """

--- a/packages/ai/mcp-server/uv.lock
+++ b/packages/ai/mcp-server/uv.lock
@@ -78,10 +78,22 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "devopness", specifier = ">=1.1.5" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.16.0" },
+    { name = "ruff", specifier = ">=0.11.13" },
 ]
 
 [[package]]
@@ -184,6 +196,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/38/13c2f1abae94d5ea0354e146b95a1be9b2137a0d506728e0da037c4276f6/mypy-1.16.0.tar.gz", hash = "sha256:84b94283f817e2aa6350a14b4a8fb2a35a53c286f97c9d30f53b63620e7af8ab", size = 3323139, upload-time = "2025-05-29T13:46:12.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/cf/158e5055e60ca2be23aec54a3010f89dcffd788732634b344fc9cb1e85a0/mypy-1.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5436d11e89a3ad16ce8afe752f0f373ae9620841c50883dc96f8b8805620b13", size = 11062927, upload-time = "2025-05-29T13:35:52.328Z" },
+    { url = "https://files.pythonhosted.org/packages/94/34/cfff7a56be1609f5d10ef386342ce3494158e4d506516890142007e6472c/mypy-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f2622af30bf01d8fc36466231bdd203d120d7a599a6d88fb22bdcb9dbff84090", size = 10083082, upload-time = "2025-05-29T13:35:33.378Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7f/7242062ec6288c33d8ad89574df87c3903d394870e5e6ba1699317a65075/mypy-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d045d33c284e10a038f5e29faca055b90eee87da3fc63b8889085744ebabb5a1", size = 11828306, upload-time = "2025-05-29T13:21:02.164Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5f/b392f7b4f659f5b619ce5994c5c43caab3d80df2296ae54fa888b3d17f5a/mypy-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b4968f14f44c62e2ec4a038c8797a87315be8df7740dc3ee8d3bfe1c6bf5dba8", size = 12702764, upload-time = "2025-05-29T13:20:42.826Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c0/7646ef3a00fa39ac9bc0938626d9ff29d19d733011be929cfea59d82d136/mypy-1.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:eb14a4a871bb8efb1e4a50360d4e3c8d6c601e7a31028a2c79f9bb659b63d730", size = 12896233, upload-time = "2025-05-29T13:18:37.446Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/38/52f4b808b3fef7f0ef840ee8ff6ce5b5d77381e65425758d515cdd4f5bb5/mypy-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:bd4e1ebe126152a7bbaa4daedd781c90c8f9643c79b9748caa270ad542f12bec", size = 9565547, upload-time = "2025-05-29T13:20:02.836Z" },
+    { url = "https://files.pythonhosted.org/packages/97/9c/ca03bdbefbaa03b264b9318a98950a9c683e06472226b55472f96ebbc53d/mypy-1.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9e056237c89f1587a3be1a3a70a06a698d25e2479b9a2f57325ddaaffc3567b", size = 11059753, upload-time = "2025-05-29T13:18:18.167Z" },
+    { url = "https://files.pythonhosted.org/packages/36/92/79a969b8302cfe316027c88f7dc6fee70129490a370b3f6eb11d777749d0/mypy-1.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0b07e107affb9ee6ce1f342c07f51552d126c32cd62955f59a7db94a51ad12c0", size = 10073338, upload-time = "2025-05-29T13:19:48.079Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9b/a943f09319167da0552d5cd722104096a9c99270719b1afeea60d11610aa/mypy-1.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6fb60cbd85dc65d4d63d37cb5c86f4e3a301ec605f606ae3a9173e5cf34997b", size = 11827764, upload-time = "2025-05-29T13:46:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/ff75e71c65a0cb6ee737287c7913ea155845a556c64144c65b811afdb9c7/mypy-1.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7e32297a437cc915599e0578fa6bc68ae6a8dc059c9e009c628e1c47f91495d", size = 12701356, upload-time = "2025-05-29T13:35:13.553Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ad/0e93c18987a1182c350f7a5fab70550852f9fabe30ecb63bfbe51b602074/mypy-1.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:afe420c9380ccec31e744e8baff0d406c846683681025db3531b32db56962d52", size = 12900745, upload-time = "2025-05-29T13:17:24.409Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5d/036c278d7a013e97e33f08c047fe5583ab4f1fc47c9a49f985f1cdd2a2d7/mypy-1.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:55f9076c6ce55dd3f8cd0c6fff26a008ca8e5131b89d5ba6d86bd3f47e736eeb", size = 9572200, upload-time = "2025-05-29T13:33:44.92Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a3/6ed10530dec8e0fdc890d81361260c9ef1f5e5c217ad8c9b21ecb2b8366b/mypy-1.16.0-py3-none-any.whl", hash = "sha256:29e1499864a3888bca5c1542f2d7232c6e586295183320caa95758fc84034031", size = 2265773, upload-time = "2025-05-29T13:35:18.762Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]
@@ -295,6 +351,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.11.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/da/9c6f995903b4d9474b39da91d2d626659af3ff1eeb43e9ae7c119349dba6/ruff-0.11.13.tar.gz", hash = "sha256:26fa247dc68d1d4e72c179e08889a25ac0c7ba4d78aecfc835d49cbfd60bf514", size = 4282054, upload-time = "2025-06-05T21:00:15.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/ce/a11d381192966e0b4290842cc8d4fac7dc9214ddf627c11c1afff87da29b/ruff-0.11.13-py3-none-linux_armv6l.whl", hash = "sha256:4bdfbf1240533f40042ec00c9e09a3aade6f8c10b6414cf11b519488d2635d46", size = 10292516, upload-time = "2025-06-05T20:59:32.944Z" },
+    { url = "https://files.pythonhosted.org/packages/78/db/87c3b59b0d4e753e40b6a3b4a2642dfd1dcaefbff121ddc64d6c8b47ba00/ruff-0.11.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aef9c9ed1b5ca28bb15c7eac83b8670cf3b20b478195bd49c8d756ba0a36cf48", size = 11106083, upload-time = "2025-06-05T20:59:37.03Z" },
+    { url = "https://files.pythonhosted.org/packages/77/79/d8cec175856ff810a19825d09ce700265f905c643c69f45d2b737e4a470a/ruff-0.11.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53b15a9dfdce029c842e9a5aebc3855e9ab7771395979ff85b7c1dedb53ddc2b", size = 10436024, upload-time = "2025-06-05T20:59:39.741Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5b/f6d94f2980fa1ee854b41568368a2e1252681b9238ab2895e133d303538f/ruff-0.11.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab153241400789138d13f362c43f7edecc0edfffce2afa6a68434000ecd8f69a", size = 10646324, upload-time = "2025-06-05T20:59:42.185Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9c/b4c2acf24ea4426016d511dfdc787f4ce1ceb835f3c5fbdbcb32b1c63bda/ruff-0.11.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6c51f93029d54a910d3d24f7dd0bb909e31b6cd989a5e4ac513f4eb41629f0dc", size = 10174416, upload-time = "2025-06-05T20:59:44.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/10/e2e62f77c65ede8cd032c2ca39c41f48feabedb6e282bfd6073d81bb671d/ruff-0.11.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1808b3ed53e1a777c2ef733aca9051dc9bf7c99b26ece15cb59a0320fbdbd629", size = 11724197, upload-time = "2025-06-05T20:59:46.935Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f0/466fe8469b85c561e081d798c45f8a1d21e0b4a5ef795a1d7f1a9a9ec182/ruff-0.11.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d28ce58b5ecf0f43c1b71edffabe6ed7f245d5336b17805803312ec9bc665933", size = 12511615, upload-time = "2025-06-05T20:59:49.534Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0e/cefe778b46dbd0cbcb03a839946c8f80a06f7968eb298aa4d1a4293f3448/ruff-0.11.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55e4bc3a77842da33c16d55b32c6cac1ec5fb0fbec9c8c513bdce76c4f922165", size = 12117080, upload-time = "2025-06-05T20:59:51.654Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2c/caaeda564cbe103bed145ea557cb86795b18651b0f6b3ff6a10e84e5a33f/ruff-0.11.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:633bf2c6f35678c56ec73189ba6fa19ff1c5e4807a78bf60ef487b9dd272cc71", size = 11326315, upload-time = "2025-06-05T20:59:54.469Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/782e7d681d660eda8c536962920c41309e6dd4ebcea9a2714ed5127d44bd/ruff-0.11.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ffbc82d70424b275b089166310448051afdc6e914fdab90e08df66c43bb5ca9", size = 11555640, upload-time = "2025-06-05T20:59:56.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/d4/3d580c616316c7f07fb3c99dbecfe01fbaea7b6fd9a82b801e72e5de742a/ruff-0.11.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4a9ddd3ec62a9a89578c85842b836e4ac832d4a2e0bfaad3b02243f930ceafcc", size = 10507364, upload-time = "2025-06-05T20:59:59.154Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/dc/195e6f17d7b3ea6b12dc4f3e9de575db7983db187c378d44606e5d503319/ruff-0.11.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d237a496e0778d719efb05058c64d28b757c77824e04ffe8796c7436e26712b7", size = 10141462, upload-time = "2025-06-05T21:00:01.481Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8e/39a094af6967faa57ecdeacb91bedfb232474ff8c3d20f16a5514e6b3534/ruff-0.11.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26816a218ca6ef02142343fd24c70f7cd8c5aa6c203bca284407adf675984432", size = 11121028, upload-time = "2025-06-05T21:00:04.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c0/b0b508193b0e8a1654ec683ebab18d309861f8bd64e3a2f9648b80d392cb/ruff-0.11.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:51c3f95abd9331dc5b87c47ac7f376db5616041173826dfd556cfe3d4977f492", size = 11602992, upload-time = "2025-06-05T21:00:06.249Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/91/263e33ab93ab09ca06ce4f8f8547a858cc198072f873ebc9be7466790bae/ruff-0.11.13-py3-none-win32.whl", hash = "sha256:96c27935418e4e8e77a26bb05962817f28b8ef3843a6c6cc49d8783b5507f250", size = 10474944, upload-time = "2025-06-05T21:00:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/7c27734ac2073aae8efb0119cae6931b6fb48017adf048fdf85c19337afc/ruff-0.11.13-py3-none-win_amd64.whl", hash = "sha256:29c3189895a8a6a657b7af4e97d330c8a3afd2c9c8f46c81e2fc5a31866517e3", size = 11548669, upload-time = "2025-06-05T21:00:11.147Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bf/b273dd11673fed8a6bd46032c0ea2a04b2ac9bfa9c628756a5856ba113b0/ruff-0.11.13-py3-none-win_arm64.whl", hash = "sha256:b4385285e9179d608ff1d2fb9922062663c658605819a6876d8beef0c30b7f3b", size = 10683928, upload-time = "2025-06-05T21:00:13.758Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description of changes

This PR introduces foundational tooling improvements for the devopness-mcp-server project:

- [x] Added a Dockerfile and Makefile to streamline development setup across different machines
- [x] Added ruff and mypy as development dependencies and configured them in pyproject.toml
- [x] Created make lint and make format commands for consistent code linting and formatting
- [x] Fixed isort configuration by marking devopness as a known first-party package
- [x] Addressed existing linting and typing issues flagged by ruff and mypy

These changes make it easier for contributors to get started quickly, ensure consistent code quality, and reduce setup friction across developer environments.

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is:
   -  Developers can run make shell, make lint, and make format in any environment consistently

## More info

