### PR TITLE
docs: add 'List Teams' and 'View Team' documentation pages

### DIFF
--- a/docs/teams/list-teams.md
+++ b/docs/teams/list-teams.md
@@ -1,0 +1,19 @@
+---
+title: List Teams
+intro: View your list of teams
+links:
+  overview:
+  quickstart:
+  previous: teams/add-team
+  next: teams/view-team
+  guides:
+  related:
+    - teams/add-team
+  featured:
+---
+
+1. When accessing Devopness, existing projects are automatically listed on the home screen. To navigate between projects, click the Devopness logo in the top-left corner.
+2. Select a project.
+3. Find the Teams card.
+4. If you don't have any teams yet, create one by clicking the Add team button. You can also learn how to create a team on the Add a team documentation page.
+5. Click view all on the Teams card to see a list of existing teams.

--- a/docs/teams/view-team.md
+++ b/docs/teams/view-team.md
@@ -1,0 +1,23 @@
+---
+title: View a Team
+intro: In this section, you will learn how to manage your team.
+links:
+  overview:
+  quickstart:
+  previous: teams/list-teams
+  next: teams/invitations/add-invitations
+  guides:
+  related:
+    - teams/add-teams
+    - teams/list-teams
+---
+
+1. On the selected project's page, locate the Teams card.
+2. Click View all on the Teams card to see the list of existing teams.
+   If there are no teams yet, create one by clicking the Add team button.
+3. Select the team you want to manage.
+4. For each team, you can:
+   - Invite new members
+   - View existing members
+   - Edit team information
+   - Delete the team, if needed


### PR DESCRIPTION
## Description of changes

Adds new help pages to the Teams section documentation, allowing users to access clear guidance when visiting the List Teams and View Team pages via the ? button.

- [ ] Created new file `docs/teams/list-teams.md` with complete step-by-step instructions for listing existing teams in Devopness.
- [ ] Created new file `docs/teams/view-team.md` with clear guidance on how to view and manage a team.
- [ ] Added clear and objective steps that help users successfully navigate team-related actions, including viewing, inviting, editing, and deleting teams.
- [ ] Followed the documentation structure and English language standards defined by the project.

## GitHub issues resolved by this PR

- [ ] closes #1204 

## Quality Assurance

- [ ] Verified that both list-teams.md and view-team.md display correctly in the documentation.
- [ ] Checked that the content is clear, consistent, and follows the documentation structure.
- [ ] Confirmed that the ? buttons on the List Teams and View Team pages correctly link to the new help documentation.
- [ ] Proofread for grammar and language accuracy.

## Once the changes in this PR are merged and deployed, success criteria is: 
- Users can access the help documentation for the List Teams and View Team pages by clicking the ? button
- The documentation pages display clear and complete step-by-step guidance.

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
