### PR TITLE
fix: make 'sync - package versions' a required workflow for pr targeting main

### DIFF
--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -104,3 +104,28 @@ jobs:
           file_pattern: 'package-lock.json'
           commit_user_name: ${{ vars.DEVOPNESS_AUTOMATIONS_USERNAME }}
           commit_user_email: ${{ vars.DEVOPNESS_AUTOMATIONS_EMAIL }}
+
+  verify-sync:
+    name: Verify sync of package versions
+    needs: [detect-changes, sync-pypi-package-versions, sync-main-lockfile]
+    if: success() || failure()
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Fail if sync-pypi-package-versions did not succeed
+        run: |
+          if [ "${{ needs.sync-pypi-package-versions.result }}" != "success" ]; then
+            exit 1
+          fi
+
+      - name: Fail if sync-main-lockfile did not succeed
+        run: |
+          if [ "${{ needs.sync-main-lockfile.result }}" != "success" ]; then
+            exit 1
+          fi

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -16,8 +16,6 @@ on:
       - opened
       - edited
       - synchronize
-    paths:
-      - packages/**/package.json
     branches:
       - main
 
@@ -28,8 +26,25 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  detect-changes:
+    name: Detect changes in package.json files
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      changes: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            changes:
+              - 'packages/**/package.json'
+
   sync-pypi-package-versions:
     name: Sync the pyproject.toml
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.changes == 'true' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -60,12 +75,14 @@ jobs:
         if: github.repository == 'devopness/devopness'
         with:
           commit_message: "chore: sync '${{ matrix.name }}' version"
-          file_pattern: "${{ matrix.path }}/pyproject.toml ${{ matrix.path }}/*.lock"
+          file_pattern: '${{ matrix.path }}/pyproject.toml ${{ matrix.path }}/*.lock'
           commit_user_name: ${{ vars.DEVOPNESS_AUTOMATIONS_USERNAME }}
           commit_user_email: ${{ vars.DEVOPNESS_AUTOMATIONS_EMAIL }}
 
   sync-main-lockfile:
     name: Sync the package-lock.json
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.changes == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -16,8 +16,6 @@ on:
       - opened
       - edited
       - synchronize
-    branches:
-      - main
 
 permissions:
   contents: write

--- a/package-lock.json
+++ b/package-lock.json
@@ -16673,7 +16673,7 @@
     },
     "packages/ai/mcp-server": {
       "name": "@devopness/mcp-server",
-      "version": "0.0.9"
+      "version": "0.0.10"
     },
     "packages/sdks/javascript": {
       "name": "@devopness/sdk-js",

--- a/packages/ai/mcp-server/package.json
+++ b/packages/ai/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devopness/mcp-server",
   "version": "0.0.10",
-  "description": "This file is used by Changesets Action to build and publish versions of Devopness MCP Server. For further details see https://github.com/devopness/devopness/blob/main/package.json",
-  "private": true
+  "private": true,
+  "description": "This file is used by Changesets Action to build and publish versions of Devopness MCP Server. For further details see https://github.com/devopness/devopness/blob/main/package.json"
 }

--- a/packages/ai/mcp-server/pyproject.toml
+++ b/packages/ai/mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "devopness-mcp-server"
-version = "0.0.9"
+version = "0.0.10"
 description = "A Model Context Protocol (MCP) server that uses Devopness to allow AI Agents to provision infrastructure and deploy any app to any cloud"
 license = "MIT"
 readme = "README.md"

--- a/packages/ai/mcp-server/uv.lock
+++ b/packages/ai/mcp-server/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "devopness-mcp-server"
-version = "0.0.5"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "devopness" },


### PR DESCRIPTION
## Description of changes

* [x] The `Sync - Package Versions` workflow was updated to **always run on all PRs**, regardless of file changes.
* [x] A new job called `detect-changes` was added to detect whether any `packages/**/package.json` files were modified — which would indicate a need to sync package versions.
* [x] With this change, the workflow can now be added to the list of **required workflows for PRs targeting the `main` branch**, preventing `changeset` PRs (e.g., version bumps) from being merged without running this validation.
* [x] A `verify-sync` job was also added to detect whether the sync job succeeded or failed.
* [x] This ensures that `chore: version packages` PRs using auto-merge won't break the `Release - Packages` workflow due to unsynced Python package versions in `pyproject.toml`.

Example of a failed `Release - Packages` run caused by a missing version sync:

* ❌ [Failed `Release - Packages` run](https://github.com/devopness/devopness/actions/runs/15611356857/job/43972799463)

![image](https://github.com/user-attachments/assets/5717c848-352e-4620-9336-70c7ccc2827d)
![image](https://github.com/user-attachments/assets/ce04e178-2e2b-4ccc-abbb-c47f639f849a)

* ⚠️ [Auto-merged PR that caused the failure](https://github.com/devopness/devopness/pull/1848)

## GitHub issues resolved by this PR

* N/A

## Quality Assurance

* Once the changes in this PR are merged and deployed, success criteria is:
  * The `verify-sync` job blocks merges if the sync step fails, preventing unsynced version issues in the release pipeline

## More info
