### PR TITLE
feat(mcp-server): enhance cloud server provisioning with region/instance discovery

### DIFF
--- a/.changeset/lovely-carrots-look.md
+++ b/.changeset/lovely-carrots-look.md
@@ -1,0 +1,14 @@
+---
+"@devopness/mcp-server": patch
+---
+
+### Added
+- New MCP tools for cloud service discovery:
+  - `devopness_get_regions_of_cloud_service`
+  - `devopness_get_instance_types_of_cloud_service_region`
+
+### Changed
+- Enhanced `devopness_create_cloud_server` with explicit parameters and improved validation
+- Refined response formats for better LLM interaction in:
+  - `devopness_list_projects`
+  - `devopness_list_environments`

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/tools.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/tools.py
@@ -68,13 +68,13 @@ async def devopness_list_projects() -> MCPResponse[List[ProjectRelation]]:
     return MCPResponse.ok(
         response.data,
         [
-            "If the user has multiple projects",
-            "ask them to choose one of the listed project IDs",
-            "to continue with the conversation.",
-            "If the user has only one project, you can use it directly,",
-            "and communicate with the user about it.",
-            "Show the user the main information about the projects.",
-            "{project.name} (ID: {project.id})",
+            "Show the list in the following format:",
+            "#N. {project.name} (ID: {project.id})",
+            "Rules:"
+            "1. If the user has multiple projects ask them to choose one"
+            " of the listed project IDs to continue with the conversation.",
+            "2. If the user has only one project, you can use it directly,"
+            " and communicate with the user about it.",
         ],
     )
 
@@ -93,15 +93,15 @@ async def devopness_list_environments(
     return MCPResponse.ok(
         response.data,
         [
-            "If the user has multiple environments "
-            "ask them to choose one of the listed environment IDs "
-            "to continue with the conversation.",
-            "If the user has only one environment, you can use it directly, "
-            "and communicate with the user about it.",
             "Show the list in the following format:",
-            "[N]. {environment.name} (ID: {environment.id})",
+            "#N. {environment.name} (ID: {environment.id})",
             "   - Type: {environment.type}",
             "   - Description: {environment.description}",
+            "Rules:"
+            "1. If the user has multiple environments ask them to choose one"
+            " of the listed environment IDs to continue with the conversation.",
+            "2. If the user has only one environment, you can use it directly,"
+            " and communicate with the user about it.",
         ],
     )
 


### PR DESCRIPTION
## Description of changes

- [x] Added MCP tool `devopness_get_regions_of_cloud_service` to list regions for a selected cloud-provider service
- [x] Added MCP tool `devopness_get_instance_types_of_cloud_service_region` to return region-specific instance types, grouped by architecture and sorted by price
- [x] Refactored `devopness_create_cloud_server` to accept explicit parameters to help the LLM to undestend the needs to create a server and added rules for LLM call the tool to avoid calls with unexpected parametrs
- [x] Refined response guidelines for `devopness_list_projects` and `devopness_list_environments` to produce numbered lists with follow-up instructions, improving chat UX

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: 
  - A server can be provisioned with the updated `devopness_create_cloud_server` flow
  - LLM/User can list regions and instance types and select using natural language queries (e.g., "cheapest Azure instance type with at least 4GB RAM in eastus2")

## More info

### Example of Natural Language Query
![image](https://github.com/user-attachments/assets/8f7e741c-7b79-4f0c-96fe-22dd3a6d580c)
![image](https://github.com/user-attachments/assets/86e0bf69-7fee-4736-ae93-2d76e97a87f0)
![image](https://github.com/user-attachments/assets/9b513c30-1240-4d3c-b102-0236120df452)

