### PR TITLE
refactor(mcp-server): use summaries and add pagination to list projects and environments

### DIFF
--- a/.changeset/healthy-horses-whisper.md
+++ b/.changeset/healthy-horses-whisper.md
@@ -1,0 +1,12 @@
+---
+"@devopness/mcp-server": patch
+---
+
+**Added**
+* `page` argument for project and environment listing tools to enable pagination
+* Summary models (`ProjectSummary`, `EnvironmentSummary`) for lighter responses
+
+**Changed**
+* Updated `devopness_list_projects` and `devopness_list_environments` to use summaries and support pagination
+* Improved response format to enhance LLM interpretation and reduce hallucinations
+

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
@@ -3,12 +3,12 @@ from typing import Optional
 from devopness.base import DevopnessBaseModel
 
 
-class Project(DevopnessBaseModel):
+class ProjectSummary(DevopnessBaseModel):
     id: int
     name: str
 
 
-class Environment(DevopnessBaseModel):
+class EnvironmentSummary(DevopnessBaseModel):
     id: int
     name: str
     description: Optional[str]

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from devopness.base import DevopnessBaseModel
+
+
+class Project(DevopnessBaseModel):
+    id: int
+    name: str
+
+
+class Environment(DevopnessBaseModel):
+    id: int
+    name: str
+    description: Optional[str]

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
@@ -1,8 +1,7 @@
 from typing import List
 
-from devopness.models import EnvironmentRelation
-
 from ..devopness_api import devopness, ensure_authenticated
+from ..models import Environment
 from ..response import MCPResponse
 
 
@@ -10,7 +9,7 @@ class EnvironmentService:
     @staticmethod
     async def tool_list_environments(
         project_id: int,
-    ) -> MCPResponse[List[EnvironmentRelation]]:
+    ) -> MCPResponse[List[Environment]]:
         """
         Rules:
         1. DO NOT execute this tool without first confirming with the user which
@@ -19,12 +18,20 @@ class EnvironmentService:
         await ensure_authenticated()
         response = await devopness.environments.list_project_environments(project_id)
 
+        environments = [
+            Environment(
+                id=environment.id,
+                name=environment.name,
+                description=environment.description,
+            )
+            for environment in response.data
+        ]
+
         return MCPResponse.ok(
-            response.data,
+            environments,
             [
                 "Show the list in the following format:",
                 "#N. {environment.name} (ID: {environment.id})",
-                "   - Type: {environment.type}",
                 "   - Description: {environment.description}",
                 "Rules:"
                 "1. If the user has multiple environments ask them to choose one"

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
@@ -3,7 +3,7 @@ from typing import List
 from pydantic import Field
 
 from ..devopness_api import devopness, ensure_authenticated
-from ..models import Environment
+from ..models import EnvironmentSummary
 from ..response import MCPResponse
 
 
@@ -15,7 +15,7 @@ class EnvironmentService:
             default=1,
             gt=0,
         ),
-    ) -> MCPResponse[List[Environment]]:
+    ) -> MCPResponse[List[EnvironmentSummary]]:
         """
         Rules:
         1. DO NOT execute this tool without first confirming with the user which
@@ -28,7 +28,7 @@ class EnvironmentService:
         )
 
         environments = [
-            Environment(
+            EnvironmentSummary(
                 id=environment.id,
                 name=environment.name,
                 description=environment.description,

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from pydantic import Field
+
 from ..devopness_api import devopness, ensure_authenticated
 from ..models import Environment
 from ..response import MCPResponse
@@ -9,6 +11,10 @@ class EnvironmentService:
     @staticmethod
     async def tool_list_environments(
         project_id: int,
+        page: int = Field(
+            default=1,
+            gt=0,
+        ),
     ) -> MCPResponse[List[Environment]]:
         """
         Rules:
@@ -16,7 +22,10 @@ class EnvironmentService:
           project ID to use.
         """
         await ensure_authenticated()
-        response = await devopness.environments.list_project_environments(project_id)
+        response = await devopness.environments.list_project_environments(
+            project_id,
+            page,
+        )
 
         environments = [
             Environment(

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
@@ -3,7 +3,7 @@ from typing import List
 from pydantic import Field
 
 from ..devopness_api import devopness, ensure_authenticated
-from ..models import Project
+from ..models import ProjectSummary
 from ..response import MCPResponse
 
 
@@ -14,12 +14,12 @@ class ProjectService:
             default=1,
             gt=0,
         ),
-    ) -> MCPResponse[List[Project]]:
+    ) -> MCPResponse[List[ProjectSummary]]:
         await ensure_authenticated()
         response = await devopness.projects.list_projects(page)
 
         projects = [
-            Project(
+            ProjectSummary(
                 id=project.id,
                 name=project.name,
             )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from pydantic import Field
+
 from ..devopness_api import devopness, ensure_authenticated
 from ..models import Project
 from ..response import MCPResponse
@@ -7,9 +9,14 @@ from ..response import MCPResponse
 
 class ProjectService:
     @staticmethod
-    async def tool_list_projects() -> MCPResponse[List[Project]]:
+    async def tool_list_projects(
+        page: int = Field(
+            default=1,
+            gt=0,
+        ),
+    ) -> MCPResponse[List[Project]]:
         await ensure_authenticated()
-        response = await devopness.projects.list_projects()
+        response = await devopness.projects.list_projects(page)
 
         projects = [
             Project(

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
@@ -1,19 +1,26 @@
 from typing import List
 
-from devopness.models import ProjectRelation
-
 from ..devopness_api import devopness, ensure_authenticated
+from ..models import Project
 from ..response import MCPResponse
 
 
 class ProjectService:
     @staticmethod
-    async def tool_list_projects() -> MCPResponse[List[ProjectRelation]]:
+    async def tool_list_projects() -> MCPResponse[List[Project]]:
         await ensure_authenticated()
         response = await devopness.projects.list_projects()
 
+        projects = [
+            Project(
+                id=project.id,
+                name=project.name,
+            )
+            for project in response.data
+        ]
+
         return MCPResponse.ok(
-            response.data,
+            projects,
             [
                 "Show the list in the following format:",
                 "#N. {project.name} (ID: {project.id})",


### PR DESCRIPTION
## Description of changes

Project and environment listings were returning too much data, causing the LLM to skip or hallucinate items.

We now return only summary fields (`id`, `name`, `description`) and added a `page` argument to support pagination.

* [x] Add `ProjectSummary` and `EnvironmentSummary` models
* [x] Update `tool_list_projects` and `tool_list_environments` to use summaries
* [x] Add `page` argument to support pagination

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: LLM should now list all projects/environments correctly, with no omissions or hallucinations.

## More info

