### PR TITLE
feat(mcp-server): add tools to create application variables and config files

### DIFF
--- a/.changeset/good-sheep-itch.md
+++ b/.changeset/good-sheep-itch.md
@@ -1,0 +1,7 @@
+---
+"@devopness/mcp-server": patch
+---
+
+**New**
+- Added `tool_create_application_variable` to allow creation of application environment variables
+- Added `tool_create_application_config_file` to allow creation of application configuration files

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/application_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/application_service.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Any, List, Optional
 
 from mcp.server.fastmcp import Context
-from pydantic import StringConstraints
+from pydantic import Field, StringConstraints
 
 from devopness.models import (
     Action,
@@ -175,5 +175,45 @@ class ApplicationService:
             response.data,
             [
                 "Inform the user that the variable has been created.",
+            ],
+        )
+
+    @staticmethod
+    async def tool_create_application_config_file(
+        application_id: int,
+        file_path: Annotated[
+            str,
+            Field(
+                description="The path to the configuration file,"
+                "relative to the application directory.",
+                examples=[
+                    ".env",
+                    "config.json",
+                    "config/database.yml",
+                ],
+            ),
+        ],
+        file_content: str,
+        file_description: Optional[str] = None,
+    ) -> MCPResponse[Variable]:
+        await ensure_authenticated()
+
+        response = await devopness.variables.add_variable(
+            application_id,
+            "application",
+            {
+                "key": file_path,
+                "value": file_content,
+                "type": "file",
+                "target": "resource-config-file",
+                "hidden": False,
+                "description": file_description,
+            },
+        )
+
+        return MCPResponse[Variable].ok(
+            response.data,
+            [
+                "Inform the user that the configuration file has been created.",
             ],
         )


### PR DESCRIPTION
## Description of changes

- [x] Added tool to allow the creation of OS Environment Variables for an Application
- [x] Added tool to allow the creation of Configuration Files for an Application

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: 
  - Users will be able to create application environment variables and configuration files via the new tools added to the MCP Server

## More info

