### PR TITLE
feat: set custom 'user-agent' for devopness-sdk-python

### DIFF
--- a/packages/sdks/python/src/devopness/client_config.py
+++ b/packages/sdks/python/src/devopness/client_config.py
@@ -3,14 +3,31 @@ Devopness API Python SDK - Painless essential DevOps to everyone
 """
 
 import re
-from typing import ClassVar, TypedDict
+from importlib.metadata import version
+from platform import python_version, system
+from typing import TypedDict
 
 from pydantic import field_validator
 
 from .base import DevopnessBaseModel
 from .core.sdk_error import DevopnessSdkError
 
-__all__ = ["DevopnessClientConfig", "DevopnessClientConfigDict"]
+__all__ = ["DevopnessClientConfig", "DevopnessClientConfigDict", "get_user_agent"]
+
+
+def get_user_agent(
+    product_name: str = "devopness-sdk-python",
+    product_package_name: str = "devopness",
+) -> str:
+    product_version = version(product_package_name)
+    product_home_url = "https://github.com/devopness/devopness"
+
+    platform = "python"
+    platform_version = python_version()
+    platform_system = system()
+
+    # Example: devopness-sdk-python/1.0.0 +https://github.com/devopness/devopness (python/3.13.0 Linux)               # noqa: E501
+    return f"{product_name}/{product_version} +{product_home_url} ({platform}/{platform_version} {platform_system})"  # noqa: E501
 
 
 class DevopnessClientConfig(DevopnessBaseModel):
@@ -23,7 +40,7 @@ class DevopnessClientConfig(DevopnessBaseModel):
         base_url (str): Base URL for API requests.
         debug (bool): Controls whether debug information is printed to the console.
         default_encoding (str): Default encoding for response content.
-        headers (ClassVar[dict[str, str]]): Default headers for API requests.
+        headers (dict[str, str]): Default headers for API requests.
         timeout (int): Request timeout in seconds.
     """
 
@@ -31,9 +48,10 @@ class DevopnessClientConfig(DevopnessBaseModel):
     base_url: str = "https://api.devopness.com"
     debug: bool = False
     default_encoding: str = "utf-8"
-    headers: ClassVar[dict[str, str]] = {
+    headers: dict[str, str] = {  # noqa: RUF012
         "Accept": "application/json",
         "Content-Type": "application/json",
+        "User-Agent": get_user_agent(),
     }
     timeout: int = 30
 
@@ -63,3 +81,4 @@ class DevopnessClientConfigDict(TypedDict, total=False):
     default_encoding: str
     headers: dict[str, str]
     timeout: int
+    user_agent: str

--- a/packages/sdks/python/tests/unit/base/test_service.py
+++ b/packages/sdks/python/tests/unit/base/test_service.py
@@ -55,6 +55,11 @@ class TestDevopnessBaseService(unittest.TestCase):
     DevopnessBaseService._config = DevopnessClientConfig(
         base_url="https://test.local",
         auto_refresh_token=False,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "custom-user-agent",
+        },
     )
     service = DevopnessBaseService()
 
@@ -242,11 +247,30 @@ class TestDevopnessBaseService(unittest.TestCase):
             f"Invalid token expiration date. Expected: {expected.isoformat()}. Actual: {actual.isoformat()}.",  # type: ignore
         )
 
+    @patch("httpx.Client.send")
+    def test_request_use_custom_user_agent(
+        self,
+        mock: Mock,
+    ) -> None:
+        self.service._put("/resource")
+
+        mock.assert_called_once()
+
+        request: httpx.Request = mock.call_args[0][0]
+        self.assertIsInstance(request, httpx.Request)
+
+        self.assertEqual(request.headers["User-Agent"], "custom-user-agent")
+
 
 class TestDevopnessBaseServiceAsync(unittest.IsolatedAsyncioTestCase):
     DevopnessBaseServiceAsync._config = DevopnessClientConfig(
         base_url="https://test.local",
         auto_refresh_token=False,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "custom-user-agent",
+        },
     )
     service = DevopnessBaseServiceAsync()
 
@@ -433,3 +457,17 @@ class TestDevopnessBaseServiceAsync(unittest.IsolatedAsyncioTestCase):
             1,
             f"Invalid token expiration date. Expected: {expected.isoformat()}. Actual: {actual.isoformat()}.",  # type: ignore
         )
+
+    @patch("httpx.AsyncClient.send")
+    async def test_request_use_custom_user_agent(
+        self,
+        mock: Mock,
+    ) -> None:
+        await self.service._put("/resource")
+
+        mock.assert_called_once()
+
+        request: httpx.Request = mock.call_args[0][0]
+        self.assertIsInstance(request, httpx.Request)
+
+        self.assertEqual(request.headers["User-Agent"], "custom-user-agent")


### PR DESCRIPTION
## Description of changes

This PR sets a custom `User-Agent` header for all HTTP requests made by `devopness-sdk-python`.

This change improves observability and debugging by enabling the Devopness Team to identify requests made by this SDK, along with relevant environment metadata.

The `User-Agent` string follows this format:

```ruby
# <product-name>/<product-version> +<product-home> (<platform>/<platform-version> <platform-os>)
devopness-sdk-python/1.0.0 +https://github.com/devopness/devopness (python/3.13.0 Linux)
```

* [x] Define a default `User-Agent` format with SDK name, version, repo URL, and runtime environment
* [x] Automatically detect and inject SDK and Python versions and OS platform

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: 
  - Every request sent from devopness-sdk-python includes a User-Agent header in the format described above. This can be confirmed via backend logging or HTTP interceptors.

## More info

