### PR TITLE
feat: set custom 'user-agent' for devopness-mcp-server

### DIFF
--- a/packages/ai/mcp-server/pyproject.toml
+++ b/packages/ai/mcp-server/pyproject.toml
@@ -49,7 +49,10 @@ classifiers = [
   "Topic :: System :: Systems Administration",
   "Topic :: Utilities",
 ]
-dependencies = ["devopness>=1.1.5", "mcp[cli]>=1.9.1"]
+dependencies = [
+    "devopness>=1.2.0",
+    "mcp[cli]>=1.9.1",
+]
 
 [project.urls]
 homepage = "https://www.devopness.com"

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/devopness_api.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/devopness_api.py
@@ -1,11 +1,23 @@
 import os
 
 from devopness import DevopnessClientAsync
+from devopness.client_config import get_user_agent
 from devopness.models import (
     UserLogin,
 )
 
-devopness = DevopnessClientAsync()
+devopness = DevopnessClientAsync(
+    {
+        "headers": {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": get_user_agent(
+                product_name="devopness-mcp-server",
+                product_package_name="devopness-mcp-server",
+            ),
+        },
+    }
+)
 
 
 async def ensure_authenticated() -> None:

--- a/packages/ai/mcp-server/uv.lock
+++ b/packages/ai/mcp-server/uv.lock
@@ -57,16 +57,16 @@ wheels = [
 
 [[package]]
 name = "devopness"
-version = "1.1.5"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpcore" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/3f/fe37c9e3b058d8b57efbac93c6c036120ae936020c4b1b24d57f9f8e3845/devopness-1.1.5.tar.gz", hash = "sha256:c8e2e13dc2e5a2812ddd274614e679df3b5b74d81f3ecc5454993a6c750fb478", size = 111914, upload-time = "2025-06-04T11:39:41.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/d5/4553f7cefaa6736ddd68c9abfe5ff6fbc1500789083dfd21e6a272db8181/devopness-1.2.0.tar.gz", hash = "sha256:ba36ddb4f150880d69d7a41df6d9c2609d873644f6886a956ea0549d6dcb87f4", size = 112149, upload-time = "2025-06-18T19:24:56.518Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/c8/947e1b27cea33ec26393d19737c1202091abda1f7ba3abbde6f0b3551685/devopness-1.1.5-py3-none-any.whl", hash = "sha256:4310d342ff647fc3d7118611259214879b9396fc866f862624e855c67d867510", size = 360957, upload-time = "2025-06-04T11:39:39.918Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/3a/ee2cc927105f369d09ad80c88af5201d298b4e1188a6c0d7ce005540ccfd/devopness-1.2.0-py3-none-any.whl", hash = "sha256:08147dcef9cde7b6c6a65356b75d39741dbdba1742e02bc86dd9ffac8158444e", size = 361214, upload-time = "2025-06-18T19:24:55.424Z" },
 ]
 
 [[package]]
@@ -86,7 +86,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "devopness", specifier = ">=1.1.5" },
+    { name = "devopness", specifier = ">=1.2.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.1" },
 ]
 


### PR DESCRIPTION
## Description of changes

This PR sets a custom `User-Agent` header for all HTTP requests made by `devopness-mcp-server`.

This change improves observability and debugging by enabling the Devopness Team to identify requests made by this MCP, along with relevant environment metadata.

The `User-Agent` string follows this format:

```ruby
# <product-name>/<product-version> +<product-home> (<platform>/<platform-version> <platform-os>)
devopness-mcp-server/1.0.0 +https://github.com/devopness/devopness (python/3.13.0 Linux)
```

* [x] Define a default `User-Agent` format with SDK name, version, repo URL, and runtime environment
* [x] Automatically detect and inject MCP and Python versions and OS platform

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: 
  - Every request sent from devopness-mcp-server includes a User-Agent header in the format described above

## More info

***Example: testing a request against a server that logs the User-Agent used:***
![image](https://github.com/user-attachments/assets/1e7dc0f2-fd75-4c28-bb01-ac8e0d631def)


