### PR TITLE
refactor(mcp-server): improve 'create application' tool with validation and runtime suggestions

### DIFF
--- a/.changeset/eighty-trainers-hang.md
+++ b/.changeset/eighty-trainers-hang.md
@@ -1,0 +1,8 @@
+---
+"@devopness/mcp-server": patch
+---
+
+**Changed**
+- Improved the `create application` tool by adding parameter-level validation with clear error messages
+- Enhanced the tool response with suggested next steps after application creation
+- Introduced `get_available_language_runtimes` tool to list supported programming languages, versions, and frameworks

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/server_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/server_service.py
@@ -15,13 +15,13 @@ from ..response import MCPResponse
 
 class ServerService:
     @staticmethod
-    async def tool_get_regions_of_cloud_service(
-        cloud_provider_service_code: ServerCloudServiceCode,
+    async def tool_get_cloud_service_regions(
+        cloud_service_code: ServerCloudServiceCode,
     ) -> MCPResponse[List[CloudProviderServiceRegion]]:
         await ensure_authenticated()
 
         response = await devopness.static.get_static_cloud_provider_service(
-            str(cloud_provider_service_code)
+            str(cloud_service_code)
         )
 
         return MCPResponse.ok(
@@ -35,7 +35,7 @@ class ServerService:
         )
 
     @staticmethod
-    async def tool_get_instance_types_of_cloud_service_region(
+    async def tool_get_available_instance_types(
         cloud_provider_service_code: ServerCloudServiceCode,
         region_code: str,
     ) -> MCPResponse[List[CloudInstanceRelation]]:


### PR DESCRIPTION
## Description of changes

* [x] Improved `create application` tool to provide field-level validation using Pydantic, helping LLM understand input constraints
* [x] Enhanced the tool's response with actionable suggestions for next steps after creating an application
* [x] Added a new tool `get_available_language_runtimes` to allow listing supported languages, versions, and frameworks

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: 
  - LLMs receive precise validation feedback when creating an application, know what to do next through suggested actions, and can retrieve valid runtime options via the new tool

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
