### PR TITLE
feat(mcp-server): add support for daemon and virtual host and improve 'resource list ux'

### DIFF
--- a/.changeset/heavy-experts-attack.md
+++ b/.changeset/heavy-experts-attack.md
@@ -1,0 +1,8 @@
+---
+"@devopness/mcp-server": patch
+---
+
+**Changes**
+- Added support for listing, creating, and deploying `daemon` and `virtual-host` resources.
+- Improved resource listing instructions by switching from numbered to bullet-point format to prevent miscommunication.
+- Enhanced `list-projects` and `list-environments` instructions to ensure LLMs request user confirmation before using `project_id` and `environment_id`.

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
@@ -301,7 +301,7 @@ class VirtualHostSummary(DevopnessBaseModel):
     id: int
     name: str
     root_directory: Optional[str]
-    ssl_certificate: bool
+    ssl_certificate_id: Optional[int] = None
     application_id: Optional[int] = None
     application_name: Optional[str] = None
     application_listen_address: Optional[str] = None
@@ -316,7 +316,9 @@ class VirtualHostSummary(DevopnessBaseModel):
         return cls(
             id=data.id,
             name=data.name,
-            ssl_certificate=data.ssl_certificate is not None,
+            ssl_certificate_id=data.ssl_certificate.id
+            if data.ssl_certificate is not None
+            else None,
             root_directory=data.root_directory,
             application_id=data.application.id
             if data.application is not None

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
@@ -21,6 +21,8 @@ from devopness.models import (
     Application,
     ApplicationRelation,
     CredentialRelation,
+    Daemon,
+    DaemonRelation,
     EnvironmentRelation,
     PipelineRelation,
     ProjectRelation,
@@ -257,5 +259,37 @@ class ServerSummary(DevopnessBaseModel):
                 if data.last_action is not None
                 else None
             ),
+            url_web_permalink=extra_data.url_web_permalink if extra_data else None,
+        )
+
+
+class DaemonSummary(DevopnessBaseModel):
+    id: int
+    name: str
+    command: str
+    run_as_user: str
+    working_directory: Optional[str]
+    application_id: Optional[int] = None
+    application_name: Optional[str] = None
+    url_web_permalink: Optional[str] = None
+
+    @classmethod
+    def from_sdk_model(
+        cls,
+        data: Daemon | DaemonRelation,
+        extra_data: TypeExtraData = None,
+    ) -> "DaemonSummary":
+        return cls(
+            id=data.id,
+            name=data.name,
+            command=data.command,
+            run_as_user=data.run_as_user,
+            working_directory=data.working_directory,
+            application_id=data.application.id
+            if data.application is not None
+            else None,
+            application_name=data.application.name
+            if data.application is not None
+            else None,
             url_web_permalink=extra_data.url_web_permalink if extra_data else None,
         )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
@@ -33,6 +33,8 @@ from devopness.models import (
     ServiceRelation,
     SshKey,
     SshKeyRelation,
+    VirtualHost,
+    VirtualHostRelation,
 )
 
 from .types import TypeExtraData
@@ -291,5 +293,37 @@ class DaemonSummary(DevopnessBaseModel):
             application_name=data.application.name
             if data.application is not None
             else None,
+            url_web_permalink=extra_data.url_web_permalink if extra_data else None,
+        )
+
+
+class VirtualHostSummary(DevopnessBaseModel):
+    id: int
+    name: str
+    root_directory: Optional[str]
+    ssl_certificate: bool
+    application_id: Optional[int] = None
+    application_name: Optional[str] = None
+    application_listen_address: Optional[str] = None
+    url_web_permalink: Optional[str] = None
+
+    @classmethod
+    def from_sdk_model(
+        cls,
+        data: VirtualHost | VirtualHostRelation,
+        extra_data: TypeExtraData = None,
+    ) -> "VirtualHostSummary":
+        return cls(
+            id=data.id,
+            name=data.name,
+            ssl_certificate=data.ssl_certificate is not None,
+            root_directory=data.root_directory,
+            application_id=data.application.id
+            if data.application is not None
+            else None,
+            application_name=data.application.name
+            if data.application is not None
+            else None,
+            application_listen_address=data.application_listen_address,
             url_web_permalink=extra_data.url_web_permalink if extra_data else None,
         )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/application_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/application_service.py
@@ -84,7 +84,7 @@ class ApplicationService:
             applications,
             [
                 get_instructions_format_list(
-                    "`N.` [{application.name}]({application.url_web_permalink})"
+                    "- [{application.name}]({application.url_web_permalink})"
                     " (ID: {application.id})",
                     [
                         "- Repository: {application.repository}",

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/credential_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/credential_service.py
@@ -50,7 +50,7 @@ class CredentialService:
             credentials,
             [
                 get_instructions_format_list(
-                    "`N.` [{credential.name}]({credential.url_web_permalink})"
+                    "- [{credential.name}]({credential.url_web_permalink})"
                     " (ID: {credential.id})",
                     [
                         "Provider: {credential.provider}",

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/daemon_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/daemon_service.py
@@ -120,7 +120,8 @@ class DaemonService:
                 get_instructions_format_resource(
                     "daemon",
                     [
-                        "**Name:** [{daemon.name}]({daemon.url_web_permalink})",
+                        "**Name:** [{daemon.name}]({daemon.url_web_permalink})"
+                        " (ID: {daemon.id})",
                         "**Command:** `{daemon.command}`",
                         "**Run as user:** {daemon.run_as_user}",
                         "**Working directory:** "

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/daemon_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/daemon_service.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Annotated, List, Optional
 
 from pydantic import Field
 
@@ -9,6 +9,8 @@ from ..types import MAX_RESOURCES_PER_PAGE, ExtraData
 from ..utils import (
     get_instructions_choose_resource,
     get_instructions_format_list,
+    get_instructions_format_resource,
+    get_instructions_next_action_suggestion,
     get_web_link_to_environment_resource,
 )
 
@@ -63,5 +65,72 @@ class DaemonService:
                 get_instructions_choose_resource(
                     "daemon",
                 ),
+            ],
+        )
+
+    @staticmethod
+    async def tool_create_daemon(
+        project_id: int,
+        environment_id: int,
+        name: str,
+        command: str,
+        working_directory: Annotated[
+            str,
+            Field(
+                examples=[
+                    "IF application is set: 'relative/path/in/app/directory'",
+                    "IF application is not set: '/absolute/path'",
+                ],
+            ),
+        ],
+        process_count: int = 1,
+        run_as_user: str = "devopness",
+        application_id: Optional[int] = None,
+    ) -> MCPResponse[DaemonSummary]:
+        await ensure_authenticated()
+
+        response = await devopness.daemons.add_environment_daemon(
+            environment_id,
+            {
+                "name": name,
+                "command": command,
+                "run_as_user": run_as_user,
+                "process_count": process_count,
+                "working_directory": working_directory,
+                "application_id": application_id,
+            },
+        )
+
+        daemon = DaemonSummary.from_sdk_model(
+            response.data,
+            ExtraData(
+                url_web_permalink=get_web_link_to_environment_resource(
+                    project_id,
+                    environment_id,
+                    "daemon",
+                    response.data.id,
+                ),
+            ),
+        )
+
+        return MCPResponse.ok(
+            daemon,
+            [
+                get_instructions_format_resource(
+                    "daemon",
+                    [
+                        "**Name:** [{daemon.name}]({daemon.url_web_permalink})",
+                        "**Command:** `{daemon.command}`",
+                        "**Run as user:** {daemon.run_as_user}",
+                        "**Working directory:** "
+                        "`~/{daemon.application_name}/current/{daemon.working_directory}`"
+                        "if {daemon.application_name} is set, "
+                        "otherwise `{daemon.working_directory}`",
+                        "**Application:** {daemon.application_name} "
+                        "(ID: {daemon.application_id})"
+                        "if {daemon.application_name} is set, otherwise `-`",
+                    ],
+                ),
+                get_instructions_next_action_suggestion("deploy", "daemon"),
             ],
         )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
@@ -45,7 +45,7 @@ class EnvironmentService:
             environments,
             [
                 get_instructions_format_list(
-                    "`N.` [{environment.name}]({environment.url_web_permalink})"
+                    "- [{environment.name}]({environment.url_web_permalink})"
                     " (ID: {environment.id})",
                     [
                         "Description: {environment.description}",

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
@@ -20,8 +20,14 @@ class EnvironmentService:
     ) -> MCPResponse[List[EnvironmentSummary]]:
         """
         Rules:
-        1. DO NOT execute this tool without first confirming with the user which
+        - BEFORE executing this tool, show to the user all the existing projects,
+          so that the user can choose the project to be used, using the tool
+          `devopness_list_projects`.
+        - DO NOT execute this tool without first confirming with the user which
           project ID to use.
+        - EVEN if a candidate project is found by name or ID, please confirm with
+          the user the project to be used.
+        - Do not use environment 'name or ID' as project 'name or ID'.
         """
         await ensure_authenticated()
 

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/pipeline_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/pipeline_service.py
@@ -30,7 +30,7 @@ class PipelineService:
             pipelines,
             [
                 get_instructions_format_list(
-                    "`N.` {pipeline.name} (ID: {pipeline.id})",
+                    "- {pipeline.name} (ID: {pipeline.id})",
                     [
                         "Operation: {pipeline.operation}",
                     ],

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
@@ -37,5 +37,8 @@ class ProjectService:
                 get_instructions_choose_resource(
                     "project",
                 ),
+                "EVEN if a candidate project is found by name or ID, please confirm"
+                " with the user the project to be used.",
+                "Do not use environment 'name or ID' as project 'name or ID'.",
             ],
         )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
@@ -30,7 +30,7 @@ class ProjectService:
             projects,
             [
                 get_instructions_format_list(
-                    "`N.` [{project.name}]({project.url_web_permalink})"
+                    "- [{project.name}]({project.url_web_permalink})"
                     " (ID: {project.id})",
                 ),
                 f"Founded {len(projects)} projects.",

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/server_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/server_service.py
@@ -111,8 +111,7 @@ class ServerService:
             servers,
             [
                 get_instructions_format_list(
-                    "- [{server.name}]({server.url_web_permalink})"
-                    " (ID: {server.id})",
+                    "- [{server.name}]({server.url_web_permalink}) (ID: {server.id})",
                     [
                         "**Status:** {server.status}",
                         "**IP Address:** {server.ip_address}",

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/server_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/server_service.py
@@ -111,7 +111,7 @@ class ServerService:
             servers,
             [
                 get_instructions_format_list(
-                    "`N.` [{server.name}]({server.url_web_permalink})"
+                    "- [{server.name}]({server.url_web_permalink})"
                     " (ID: {server.id})",
                     [
                         "**Status:** {server.status}",

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/service_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/service_service.py
@@ -146,7 +146,7 @@ class ServiceService:
             services,
             [
                 get_instructions_format_list(
-                    "`N.` [{service.name}]({service.url_web_permalink})"
+                    "- [{service.name}]({service.url_web_permalink})"
                     " (ID: {service.id})",
                 ),
                 f"Founded {len(services)} services.",

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
@@ -56,7 +56,7 @@ class VirtualHostService:
                     "- [{virtual_host.name}]({virtual_host.url_web_permalink})"
                     " (ID: {virtual_host.id})",
                     [
-                        "**Has active SSL:** {virtual_host.ssl_certificate_id}",
+                        "**Has active SSL:** {virtual_host.ssl_certificate_id.is.set}",
                         "**Working directory:** "
                         "`~/{virtual_host.application_name}/current/{virtual_host.root_directory}`"
                         "if {virtual_host.application_name} is set, "
@@ -155,7 +155,7 @@ class VirtualHostService:
                     [
                         "**Name:** [{virtual_host.name}]({virtual_host.url_web_permalink})"  # noqa: E501
                         " (ID: {virtual_host.id})",
-                        "**Has active SSL:** {virtual_host.ssl_certificate_id}",
+                        "**Has active SSL:** {virtual_host.ssl_certificate_id.is.set}",
                         "**Application:** {virtual_host.application_name} "
                         "(ID: {virtual_host.application_id})"
                         "if {virtual_host.application_name} is set, otherwise `-`",

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
@@ -56,7 +56,7 @@ class VirtualHostService:
                     "- [{virtual_host.name}]({virtual_host.url_web_permalink})"
                     " (ID: {virtual_host.id})",
                     [
-                        "**Has active SSL:** {virtual_host.ssl_certificate}",
+                        "**Has active SSL:** {virtual_host.ssl_certificate_id}",
                         "**Working directory:** "
                         "`~/{virtual_host.application_name}/current/{virtual_host.root_directory}`"
                         "if {virtual_host.application_name} is set, "
@@ -155,7 +155,7 @@ class VirtualHostService:
                     [
                         "**Name:** [{virtual_host.name}]({virtual_host.url_web_permalink})"  # noqa: E501
                         " (ID: {virtual_host.id})",
-                        "**Has active SSL:** {virtual_host.ssl_certificate}",
+                        "**Has active SSL:** {virtual_host.ssl_certificate_id}",
                         "**Application:** {virtual_host.application_name} "
                         "(ID: {virtual_host.application_id})"
                         "if {virtual_host.application_name} is set, otherwise `-`",
@@ -193,7 +193,7 @@ class VirtualHostService:
             [
                 get_instructions_how_to_monitor_action(action.url_web_permalink),
                 "Show to the user how to access the virtual host using the URL --> "
-                "IF {virtual_host.ssl_certificate} is set, 'https://{virtual_host.name}'"
+                "IF {virtual_host.ssl_certificate_id} is set, 'https://{virtual_host.name}'"
                 "otherwise 'http://{virtual_host.name}'.",
             ],
         )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
@@ -3,15 +3,13 @@ from typing import Annotated, List, Optional
 from pydantic import Field
 
 from ..devopness_api import devopness, ensure_authenticated
-from ..models import ActionSummary, VirtualHostSummary
+from ..models import VirtualHostSummary
 from ..response import MCPResponse
-from ..types import MAX_RESOURCES_PER_PAGE, ExtraData, TypeListServerID
+from ..types import MAX_RESOURCES_PER_PAGE, ExtraData
 from ..utils import (
     get_instructions_choose_resource,
     get_instructions_format_list,
     get_instructions_format_resource,
-    get_instructions_how_to_monitor_action,
-    get_instructions_next_action_suggestion,
     get_web_link_to_environment_resource,
 )
 
@@ -68,6 +66,103 @@ class VirtualHostService:
                 ),
                 get_instructions_choose_resource(
                     "virtual-host",
+                ),
+            ],
+        )
+
+    @staticmethod
+    async def tool_create_virtual_host(
+        project_id: int,
+        environment_id: int,
+        vh_name: Annotated[
+            str,
+            Field(
+                examples=[
+                    "Domain: example.com",
+                    "Subdomain: sub.example.com",
+                    "IP address: 127.0.0.1",
+                    "IP address with port: 127.0.0.1:3000",
+                ]
+            ),
+        ],
+        vh_type: Annotated[
+            str,
+            Field(
+                examples=[
+                    "IF domain or subdomain: name-based",
+                    "IF IP address or IP address with port: ip-based",
+                ]
+            ),
+        ],
+        application_id: Optional[int],
+        vh_root_directory: Annotated[
+            Optional[str],
+            Field(
+                description="Only applicable if `application_id` is set."
+                "Must be a relative path inside the application directory."
+            ),
+        ] = None,
+        vh_routes_to_address: Annotated[
+            Optional[str],
+            Field(
+                description="Only applicable if `application_id` is set."
+                "Must be the address where the application is listening to.",
+                examples=[
+                    "http://localhost:3000http://127.0.0.1:8080",
+                    "unix:/var/run/example.sock",
+                ],
+            ),
+        ] = None,
+    ) -> MCPResponse[VirtualHostSummary]:
+        await ensure_authenticated()
+
+        if not application_id:
+            vh_root_directory = None
+            vh_routes_to_address = None
+
+        response = await devopness.virtual_hosts.add_environment_virtual_host(
+            environment_id,
+            {
+                "name": vh_name,
+                "type": vh_type,
+                "application_id": application_id,
+                "root_directory": vh_root_directory,
+                "application_listen_address": vh_routes_to_address,
+            },
+        )
+
+        virtual_host = VirtualHostSummary.from_sdk_model(
+            response.data,
+            ExtraData(
+                url_web_permalink=get_web_link_to_environment_resource(
+                    project_id,
+                    environment_id,
+                    "virtual-host",
+                    response.data.id,
+                ),
+            ),
+        )
+
+        return MCPResponse.ok(
+            virtual_host,
+            [
+                get_instructions_format_resource(
+                    "virtual-host",
+                    [
+                        "**Name:** [{virtual_host.name}]({virtual_host.url_web_permalink})"  # noqa: E501
+                        " (ID: {virtual_host.id})",
+                        "**Has active SSL:** {virtual_host.ssl_certificate}",
+                        "**Application:** {virtual_host.application_name} "
+                        "(ID: {virtual_host.application_id})"
+                        "if {virtual_host.application_name} is set, otherwise `-`",
+                        "**Working directory:** "
+                        "`~/{virtual_host.application_name}/current/{virtual_host.root_directory}`"
+                        "if {virtual_host.application_name} is set, "
+                        "otherwise `-`",
+                        "**Routes to:** <<{virtual_host.application_listen_address}>>"
+                        "if {virtual_host.application_listen_address} is set, "
+                        "otherwise `-`",
+                    ],
                 ),
             ],
         )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List, Optional
+from typing import Annotated, List, Literal, Optional
 
 from pydantic import Field
 
@@ -88,6 +88,7 @@ class VirtualHostService:
         ],
         vh_type: Annotated[
             str,
+            Literal["ip-based", "name-based"],
             Field(
                 examples=[
                     "IF domain or subdomain: name-based",

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
@@ -10,6 +10,7 @@ from ..utils import (
     get_instructions_choose_resource,
     get_instructions_format_list,
     get_instructions_format_resource,
+    get_instructions_next_action_suggestion,
     get_web_link_to_environment_resource,
 )
 
@@ -108,7 +109,8 @@ class VirtualHostService:
                 description="Only applicable if `application_id` is set."
                 "Must be the address where the application is listening to.",
                 examples=[
-                    "http://localhost:3000http://127.0.0.1:8080",
+                    "http://localhost:3000",
+                    "http://127.0.0.1:8080",
                     "unix:/var/run/example.sock",
                 ],
             ),
@@ -164,5 +166,6 @@ class VirtualHostService:
                         "otherwise `-`",
                     ],
                 ),
+                get_instructions_next_action_suggestion("deploy", "virtual-host"),
             ],
         )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
@@ -60,7 +60,10 @@ class VirtualHostService:
                         "**Working directory:** "
                         "`~/{virtual_host.application_name}/current/{virtual_host.root_directory}`"
                         "if {virtual_host.application_name} is set, "
-                        "otherwise `{virtual_host.root_directory}`",
+                        "otherwise `not include the field`",
+                        "**Routes to:** <<{virtual_host.application_listen_address}>>"
+                        "if {virtual_host.application_listen_address} is set, "
+                        "otherwise `not include the field`",
                     ],
                 ),
                 get_instructions_choose_resource(

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
@@ -1,0 +1,70 @@
+from typing import Annotated, List, Optional
+
+from pydantic import Field
+
+from ..devopness_api import devopness, ensure_authenticated
+from ..models import ActionSummary, VirtualHostSummary
+from ..response import MCPResponse
+from ..types import MAX_RESOURCES_PER_PAGE, ExtraData, TypeListServerID
+from ..utils import (
+    get_instructions_choose_resource,
+    get_instructions_format_list,
+    get_instructions_format_resource,
+    get_instructions_how_to_monitor_action,
+    get_instructions_next_action_suggestion,
+    get_web_link_to_environment_resource,
+)
+
+
+class VirtualHostService:
+    @staticmethod
+    async def tool_list_virtual_hosts(
+        project_id: int,
+        environment_id: int,
+        page: int = Field(
+            default=1,
+            gt=0,
+        ),
+    ) -> MCPResponse[List[VirtualHostSummary]]:
+        await ensure_authenticated()
+
+        response = await devopness.virtual_hosts.list_environment_virtual_hosts(
+            environment_id,
+            page,
+            per_page=MAX_RESOURCES_PER_PAGE,
+        )
+
+        virtual_hosts = [
+            VirtualHostSummary.from_sdk_model(
+                virtual_host,
+                ExtraData(
+                    url_web_permalink=get_web_link_to_environment_resource(
+                        project_id,
+                        environment_id,
+                        "virtual-host",
+                        virtual_host.id,
+                    ),
+                ),
+            )
+            for virtual_host in response.data
+        ]
+
+        return MCPResponse.ok(
+            virtual_hosts,
+            [
+                get_instructions_format_list(
+                    "- [{virtual_host.name}]({virtual_host.url_web_permalink})"
+                    " (ID: {virtual_host.id})",
+                    [
+                        "**Has active SSL:** {virtual_host.ssl_certificate}",
+                        "**Working directory:** "
+                        "`~/{virtual_host.application_name}/current/{virtual_host.root_directory}`"
+                        "if {virtual_host.application_name} is set, "
+                        "otherwise `{virtual_host.root_directory}`",
+                    ],
+                ),
+                get_instructions_choose_resource(
+                    "virtual-host",
+                ),
+            ],
+        )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/tools.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/tools.py
@@ -16,6 +16,7 @@ from mcp.server.fastmcp import FastMCP
 
 from .services.application_service import ApplicationService
 from .services.credential_service import CredentialService
+from .services.daemon_service import DaemonService
 from .services.environment_service import EnvironmentService
 from .services.pipeline_service import PipelineService
 from .services.project_service import ProjectService
@@ -64,6 +65,7 @@ def register_tools(mcp_server: FastMCP) -> None:
     services = [
         ApplicationService,
         CredentialService,
+        DaemonService,
         EnvironmentService,
         PipelineService,
         ProjectService,

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/tools.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/tools.py
@@ -24,6 +24,7 @@ from .services.server_service import ServerService
 from .services.service_service import ServiceService
 from .services.ssh_key_service import SSHKeyService
 from .services.user_service import UserService
+from .services.virtual_host_service import VirtualHostService
 from .services.webhook_service import WebHookService
 
 
@@ -73,6 +74,7 @@ def register_tools(mcp_server: FastMCP) -> None:
         ServiceService,
         SSHKeyService,
         UserService,
+        VirtualHostService,
         WebHookService,
     ]
 

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/types.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/types.py
@@ -25,6 +25,7 @@ the LLM is able to list the <page + 1> until it finds the user's resource.
 type ResourceType = Literal[
     "application",
     "credential",
+    "daemon",
     "environment",
     "project",
     "server",

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/types.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/types.py
@@ -31,6 +31,7 @@ type ResourceType = Literal[
     "server",
     "service",
     "ssh-key",
+    "virtual-host",
 ]
 
 type TypeListServerID = Annotated[

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/utils.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/utils.py
@@ -61,7 +61,7 @@ def get_instructions_format_list(
     extra_instructions: list[str] | None = None,
 ) -> list[str]:
     return [
-        "You MUST present the list in the exact format shown below:",
+        "You MUST present a bullet list in the below format:",
         header,
         *(extra_instructions or []),
         "Make sure each item follows this structure and "
@@ -96,10 +96,10 @@ def get_instructions_choose_resource(
 ) -> str:
     return f"""
         Rules:
-        1. If the user has multiple {resource_type}s ask them to choose one
-           of the listed {resource_type} IDs to continue with the conversation.
-        2. If the user has only one {resource_type}, you can use it directly,
-           and communicate with the user about it.
-        3. Inform the user that the {resource_type} might be located on a different
+        - If the user has multiple {resource_type}s ask them to choose one
+          of the listed {resource_type} IDs to continue with the conversation.
+        - If the user has only one {resource_type}, you can use it directly,
+          and communicate with the user about it.
+        - Inform the user that the {resource_type} might be located on a different
           'page' and offer to display the next page.
     """

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/utils.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/utils.py
@@ -93,13 +93,15 @@ def get_instructions_how_to_monitor_action(
 
 def get_instructions_choose_resource(
     resource_type: ResourceType,
-) -> str:
-    return f"""
-        Rules:
-        - If the user has multiple {resource_type}s ask them to choose one
-          of the listed {resource_type} IDs to continue with the conversation.
-        - If the user has only one {resource_type}, you can use it directly,
-          and communicate with the user about it.
-        - Inform the user that the {resource_type} might be located on a different
-          'page' and offer to display the next page.
-    """
+) -> list[str]:
+    return [
+        f"IF the list contains multiple {resource_type}s. "
+        "You MUST show the following message to the user:",
+        f"Please enter the ID or name of the {resource_type} you want to work with, "
+        f"or type `next page` if your {resource_type} isn't listed here.",
+        #
+        f"IF the list contains only one {resource_type}. "
+        "You MUST show the following message to the user:",
+        "Found one " + resource_type + " with ID {resource_id}. "
+        "I will use it to achieve our goal.",
+    ]


### PR DESCRIPTION
## Description of changes

* [x] Added tools for listing, creating, and deploying `daemon` and `virtual-host` resources
* [x] Improved the instruction prompt for listing resources by switching from a numbered to a bullet-point list to avoid miscommunication
* [x] Added extra instructions for `list-projects` and `list-environments` to guide the LLM to avoid assuming `project_id` and `environment_id` without explicit user confirmation

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: 
  - The LLM successfully guides users to list, create, and deploy daemon and virtual-host resources
  - The LLM never assumes project/environment IDs without user confirmation

## More info

**Before**
![image](https://github.com/user-attachments/assets/f4249ea5-4b8f-49e0-8c5f-fe406ee8004e)

**After**
![image](https://github.com/user-attachments/assets/921a00ce-3868-48ec-bde4-7ad1fbc1b0b2)
