### PR TITLE
feat(mcp-server): add support for ssl-certificate and show resources in table

### DIFF
--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
@@ -35,6 +35,8 @@ from devopness.models import (
     ServiceRelation,
     SshKey,
     SshKeyRelation,
+    SslCertificate,
+    SslCertificateRelation,
     Step,
     VirtualHost,
     VirtualHostRelation,
@@ -324,6 +326,26 @@ class DaemonSummary(DevopnessBaseModel):
             application_name=data.application.name
             if data.application is not None
             else None,
+            url_web_permalink=extra_data.url_web_permalink if extra_data else None,
+        )
+
+
+class SSLCertificateSummary(DevopnessBaseModel):
+    id: int
+    name: str
+    active: bool
+    url_web_permalink: Optional[str] = None
+
+    @classmethod
+    def from_sdk_model(
+        cls,
+        data: SslCertificate | SslCertificateRelation,
+        extra_data: TypeExtraData = None,
+    ) -> "SSLCertificateSummary":
+        return cls(
+            id=data.id,
+            name=data.name,
+            active=data.active,
             url_web_permalink=extra_data.url_web_permalink if extra_data else None,
         )
 

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/models.py
@@ -110,11 +110,13 @@ class PipelineStepSummary(DevopnessBaseModel):
     runner: PipelineStepRunnerName
     trigger_order: int
     is_auto_generated: bool
+    url_web_permalink: Optional[str]
 
     @classmethod
     def from_sdk_model(
         cls,
         data: Step,
+        extra_data: TypeExtraData = None,
     ) -> "PipelineStepSummary":
         return cls(
             id=data.id,
@@ -123,6 +125,7 @@ class PipelineStepSummary(DevopnessBaseModel):
             runner=data.runner,
             trigger_order=data.trigger_order,
             is_auto_generated=data.is_auto_generated,
+            url_web_permalink=extra_data.url_web_permalink if extra_data else None,
         )
 
 
@@ -131,11 +134,13 @@ class PipelineSummary(DevopnessBaseModel):
     name: str
     operation: str
     steps: Optional[list[PipelineStepSummary]] = None
+    url_web_permalink: Optional[str] = None
 
     @classmethod
     def from_sdk_model(
         cls,
         data: Pipeline | PipelineRelation,
+        extra_data: TypeExtraData = None,
     ) -> "PipelineSummary":
         return cls(
             id=data.id,
@@ -145,6 +150,7 @@ class PipelineSummary(DevopnessBaseModel):
                 PipelineStepSummary.from_sdk_model(step)
                 for step in getattr(data, "steps", [])
             ],
+            url_web_permalink=extra_data.url_web_permalink if extra_data else None,
         )
 
 

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/application_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/application_service.py
@@ -15,7 +15,8 @@ from ..types import MAX_RESOURCES_PER_PAGE, ExtraData, TypeListServerID
 from ..utils import (
     get_instructions_choose_resource,
     get_instructions_format_list,
-    get_instructions_format_resource,
+    get_instructions_format_resource_table,
+    get_instructions_format_table,
     get_instructions_how_to_monitor_action,
     get_instructions_next_action_suggestion,
     get_web_link_to_environment_resource,
@@ -83,21 +84,44 @@ class ApplicationService:
         return MCPResponse.ok(
             applications,
             [
-                get_instructions_format_list(
-                    "- [{application.name}]({application.url_web_permalink})"
-                    " (ID: {application.id})",
+                get_instructions_format_table(
                     [
-                        "- Repository: {application.repository}",
-                        "- Root directory: {application.root_directory}",
-                        "- Stack: {application.programming_language}"
-                        " {application.programming_language_version}"
-                        " ({application.programming_language_framework})",
-                        "- Commands:",
-                        "  - Install: {application.install_dependencies_command}",
-                        "  - Build: {application.build_command}",
-                    ],
+                        (
+                            "ID",
+                            "{application.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{application.name}]({application.url_web_permalink})",
+                        ),
+                        (
+                            "Repository",
+                            "{application.repository}",
+                        ),
+                        (
+                            "Root directory",
+                            "{application.root_directory}",
+                        ),
+                        (
+                            "Stack (Language, Version, Framework)",
+                            "{application.programming_language} "
+                            #
+                            "[IF {application.programming_language_version} == 'none'"
+                            " THEN `` ELSE {application.programming_language_version}]"
+                            #
+                            "[IF {application.programming_language_framework} == 'none'"
+                            " THEN `` ELSE ({application.programming_language_framework})]",  # noqa: E501
+                        ),
+                        (
+                            "Build command",
+                            "{application.build_command} or `-`",
+                        ),
+                        (
+                            "Install dependencies command",
+                            "{application.install_dependencies_command} or `-`",
+                        ),
+                    ]
                 ),
-                f"Founded {len(applications)} applications.",
                 get_instructions_choose_resource("application"),
                 get_instructions_next_action_suggestion("deploy", "application"),
             ],
@@ -182,20 +206,43 @@ class ApplicationService:
         return MCPResponse.ok(
             application,
             [
-                get_instructions_format_resource(
-                    "application",
+                get_instructions_format_resource_table(
                     [
-                        "Name: {application.name}",
-                        "Repository: {application.repository}",
-                        "Root directory: {application.root_directory}",
-                        "Stack:",
-                        "- Language: {application.programming_language}",
-                        "- Version: {application.programming_language_version}",
-                        "- Framework: {application.programming_language_framework}",
-                        "Commands:",
-                        "- Install: {application.install_dependencies_command}",
-                        "- Build: {application.build_command}",
-                    ],
+                        (
+                            "ID",
+                            "{application.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{application.name}]({application.url_web_permalink})",
+                        ),
+                        (
+                            "Repository",
+                            "{application.repository}",
+                        ),
+                        (
+                            "Root directory",
+                            "{application.root_directory}",
+                        ),
+                        (
+                            "Stack (Language, Version, Framework)",
+                            "{application.programming_language} "
+                            #
+                            "[IF {application.programming_language_version} == 'none'"
+                            " THEN `` ELSE {application.programming_language_version}]"
+                            #
+                            "[IF {application.programming_language_framework} == 'none'"
+                            " THEN `` ELSE ({application.programming_language_framework})]",  # noqa: E501
+                        ),
+                        (
+                            "Build command",
+                            "{application.build_command} or `-`",
+                        ),
+                        (
+                            "Install dependencies command",
+                            "{application.install_dependencies_command} or `-`",
+                        ),
+                    ]
                 ),
                 "See more details at: "
                 + get_web_link_to_environment_resource(

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/credential_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/credential_service.py
@@ -8,7 +8,7 @@ from ..response import MCPResponse
 from ..types import MAX_RESOURCES_PER_PAGE, ExtraData
 from ..utils import (
     get_instructions_choose_resource,
-    get_instructions_format_list,
+    get_instructions_format_table,
     get_web_link_to_environment_resource,
 )
 
@@ -49,17 +49,26 @@ class CredentialService:
         return MCPResponse.ok(
             credentials,
             [
-                get_instructions_format_list(
-                    "- [{credential.name}]({credential.url_web_permalink})"
-                    " (ID: {credential.id})",
+                get_instructions_format_table(
                     [
-                        "Provider: {credential.provider}",
-                        "Provider Type: {credential.provider_type}",
-                    ],
+                        (
+                            "ID",
+                            "{credential.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{credential.name}]({credential.url_web_permalink})",
+                        ),
+                        (
+                            "Provider",
+                            "{credential.provider}",
+                        ),
+                        (
+                            "Provider Type",
+                            "{credential.provider_type}",
+                        ),
+                    ]
                 ),
-                f"Founded {len(credentials)} credentials.",
-                get_instructions_choose_resource(
-                    "credential",
-                ),
+                get_instructions_choose_resource("credential"),
             ],
         )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/daemon_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/daemon_service.py
@@ -8,8 +8,8 @@ from ..response import MCPResponse
 from ..types import MAX_RESOURCES_PER_PAGE, ExtraData, TypeListServerID
 from ..utils import (
     get_instructions_choose_resource,
-    get_instructions_format_list,
-    get_instructions_format_resource,
+    get_instructions_format_resource_table,
+    get_instructions_format_table,
     get_instructions_how_to_monitor_action,
     get_instructions_next_action_suggestion,
     get_web_link_to_environment_resource,
@@ -52,20 +52,38 @@ class DaemonService:
         return MCPResponse.ok(
             daemons,
             [
-                get_instructions_format_list(
-                    "- [{daemon.name}]({daemon.url_web_permalink}) (ID: {daemon.id})",
+                get_instructions_format_table(
                     [
-                        "**Command:** `{daemon.command}`",
-                        "**Run as user:** {daemon.run_as_user}",
-                        "**Working directory:** "
-                        "`~/{daemon.application_name}/current/{daemon.working_directory}`"
-                        "if {daemon.application_name} is set, "
-                        "otherwise `{daemon.working_directory}`",
-                    ],
+                        (
+                            "ID",
+                            "{daemon.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{daemon.name}]({daemon.url_web_permalink})",
+                        ),
+                        (
+                            "Command",
+                            "{daemon.command}",
+                        ),
+                        (
+                            "Run as user",
+                            "{daemon.run_as_user}",
+                        ),
+                        (
+                            "Application",
+                            "{daemon.application_name} OR `-`",
+                        ),
+                        (
+                            "Working directory",
+                            "IF {daemon.application_name} "
+                            "THEN `~/{daemon.application_name}/current/{daemon.working_directory}`"  # noqa: E501
+                            "ELSE `{daemon.working_directory}`",
+                        ),
+                    ]
                 ),
-                get_instructions_choose_resource(
-                    "daemon",
-                ),
+                get_instructions_choose_resource("daemon"),
+                get_instructions_next_action_suggestion("deploy", "daemon"),
             ],
         )
 
@@ -118,21 +136,35 @@ class DaemonService:
         return MCPResponse.ok(
             daemon,
             [
-                get_instructions_format_resource(
-                    "daemon",
+                get_instructions_format_resource_table(
                     [
-                        "**Name:** [{daemon.name}]({daemon.url_web_permalink})"
-                        " (ID: {daemon.id})",
-                        "**Command:** `{daemon.command}`",
-                        "**Run as user:** {daemon.run_as_user}",
-                        "**Working directory:** "
-                        "`~/{daemon.application_name}/current/{daemon.working_directory}`"
-                        "if {daemon.application_name} is set, "
-                        "otherwise `{daemon.working_directory}`",
-                        "**Application:** {daemon.application_name} "
-                        "(ID: {daemon.application_id})"
-                        "if {daemon.application_name} is set, otherwise `-`",
-                    ],
+                        (
+                            "ID",
+                            "{daemon.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{daemon.name}]({daemon.url_web_permalink})",
+                        ),
+                        (
+                            "Command",
+                            "{daemon.command}",
+                        ),
+                        (
+                            "Run as user",
+                            "{daemon.run_as_user}",
+                        ),
+                        (
+                            "Application",
+                            "{daemon.application_name} OR `-`",
+                        ),
+                        (
+                            "Working directory",
+                            "IF {daemon.application_name} "
+                            "THEN `~/{daemon.application_name}/current/{daemon.working_directory}`"  # noqa: E501
+                            "ELSE `{daemon.working_directory}`",
+                        ),
+                    ]
                 ),
                 get_instructions_next_action_suggestion("deploy", "daemon"),
             ],

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/daemon_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/daemon_service.py
@@ -79,7 +79,8 @@ class DaemonService:
             str,
             Field(
                 examples=[
-                    "IF application is set: 'relative/path/in/app/directory'",
+                    "IF application is set: 'relative/path/in/app/directory'"
+                    " or EMPTY STRING",
                     "IF application is not set: '/absolute/path'",
                 ],
             ),

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/environment_service.py
@@ -6,7 +6,10 @@ from ..devopness_api import devopness, ensure_authenticated
 from ..models import EnvironmentSummary
 from ..response import MCPResponse
 from ..types import MAX_RESOURCES_PER_PAGE, ExtraData
-from ..utils import get_instructions_choose_resource, get_instructions_format_list
+from ..utils import (
+    get_instructions_choose_resource,
+    get_instructions_format_resource_table,
+)
 
 
 class EnvironmentService:
@@ -50,14 +53,22 @@ class EnvironmentService:
         return MCPResponse.ok(
             environments,
             [
-                get_instructions_format_list(
-                    "- [{environment.name}]({environment.url_web_permalink})"
-                    " (ID: {environment.id})",
+                get_instructions_format_resource_table(
                     [
-                        "Description: {environment.description}",
-                    ],
+                        (
+                            "ID",
+                            "{environment.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{environment.name}]({environment.url_web_permalink})",
+                        ),
+                        (
+                            "Description",
+                            "{environment.description} OR `-`",
+                        ),
+                    ]
                 ),
-                f"Founded {len(environments)} environments.",
                 get_instructions_choose_resource(
                     "environment",
                 ),

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/project_service.py
@@ -6,7 +6,10 @@ from ..devopness_api import devopness, ensure_authenticated
 from ..models import ProjectSummary
 from ..response import MCPResponse
 from ..types import MAX_RESOURCES_PER_PAGE
-from ..utils import get_instructions_choose_resource, get_instructions_format_list
+from ..utils import (
+    get_instructions_choose_resource,
+    get_instructions_format_table,
+)
 
 
 class ProjectService:
@@ -29,11 +32,18 @@ class ProjectService:
         return MCPResponse.ok(
             projects,
             [
-                get_instructions_format_list(
-                    "- [{project.name}]({project.url_web_permalink})"
-                    " (ID: {project.id})",
+                get_instructions_format_table(
+                    [
+                        (
+                            "ID",
+                            "{project.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{project.name}]({project.url_web_permalink})",
+                        ),
+                    ]
                 ),
-                f"Founded {len(projects)} projects.",
                 get_instructions_choose_resource(
                     "project",
                 ),

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/server_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/server_service.py
@@ -14,12 +14,13 @@ from ..models import ServerSummary
 from ..response import MCPResponse
 from ..types import MAX_RESOURCES_PER_PAGE, ExtraData
 from ..utils import (
+    format_last_action_field,
     get_instructions_choose_resource,
     get_instructions_format_list,
-    get_instructions_format_resource,
+    get_instructions_format_resource_table,
+    get_instructions_format_table,
     get_instructions_how_to_monitor_action,
     get_instructions_next_action_suggestion,
-    get_last_action_repl,
     get_web_link_to_environment_resource,
 )
 
@@ -110,19 +111,45 @@ class ServerService:
         return MCPResponse.ok(
             servers,
             [
-                get_instructions_format_list(
-                    "- [{server.name}]({server.url_web_permalink}) (ID: {server.id})",
+                get_instructions_format_table(
                     [
-                        "**Status:** {server.status}",
-                        "**IP Address:** {server.ip_address}",
-                        "**SSH Port:** {server.ssh_port}",
-                        "**Provider:** {server.provider_code}",
-                        "**Region:** {server.provider_region}",
-                        get_last_action_repl("server"),
-                    ],
+                        (
+                            "ID",
+                            "{server.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{server.name}]({server.url_web_permalink})",
+                        ),
+                        (
+                            "🚦 Status",
+                            "MATCHING {server.status}"
+                            " CASE 'running' THEN '🟢 {server.status}'"
+                            " CASE 'failed' THEN '🔴 {server.status}'"
+                            " ELSE '🟠 {server.status}'",
+                        ),
+                        (
+                            "IP Address",
+                            "{server.ip_address} OR `-`",
+                        ),
+                        (
+                            "SSH Port",
+                            "{server.ssh_port}",
+                        ),
+                        (
+                            "Provider",
+                            "{server.provider_code}",
+                        ),
+                        (
+                            "Region",
+                            "{server.provider_region} OR `-`",
+                        ),
+                        (
+                            "Last Action",
+                            format_last_action_field("server"),
+                        ),
+                    ]
                 ),
-                f"Founded {len(servers)} servers.",
-                "Names of servers: " + ", ".join([server.name for server in servers]),
                 get_instructions_choose_resource("server"),
             ],
         )
@@ -184,16 +211,40 @@ class ServerService:
         return MCPResponse.ok(
             server,
             [
-                get_instructions_format_resource(
-                    "server",
+                get_instructions_format_resource_table(
                     [
-                        "[{server.name}]({server.url_web_permalink}) (ID: {server.id})",
-                        "Status: {server.status}",
-                        "IP Address: {server.ip_address}",
-                        "SSH Port: {server.ssh_port}",
-                        "Provider: {server.provider_code}",
-                        "Region: {server.provider_region}",
-                    ],
+                        (
+                            "ID",
+                            "{server.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{server.name}]({server.url_web_permalink})",
+                        ),
+                        (
+                            "🚦 Status",
+                            "MATCHING {server.status}"
+                            " CASE 'running' THEN '🟢 {server.status}'"
+                            " CASE 'failed' THEN '🔴 {server.status}'"
+                            " ELSE '🟠 {server.status}'",
+                        ),
+                        (
+                            "IP Address",
+                            "{server.ip_address} OR `-`",
+                        ),
+                        (
+                            "SSH Port",
+                            "{server.ssh_port}",
+                        ),
+                        (
+                            "Provider",
+                            "{server.provider_code}",
+                        ),
+                        (
+                            "Region",
+                            "{server.provider_region} OR `-`",
+                        ),
+                    ]
                 ),
                 (
                     get_instructions_how_to_monitor_action(
@@ -202,5 +253,6 @@ class ServerService:
                     if server.last_action is not None
                     else ""
                 ),
+                get_instructions_next_action_suggestion("deploy", "application"),
             ],
         )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/ssh_key_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/ssh_key_service.py
@@ -3,7 +3,7 @@ from ..models import ActionSummary, SSHKeySummary
 from ..response import MCPResponse
 from ..types import TypeListServerID
 from ..utils import (
-    get_instructions_format_resource,
+    get_instructions_format_resource_table,
     get_instructions_how_to_monitor_action,
     get_instructions_next_action_suggestion,
 )
@@ -37,12 +37,17 @@ class SSHKeyService:
         return MCPResponse.ok(
             ssh_key,
             [
-                get_instructions_format_resource(
-                    "ssh-key",
+                get_instructions_format_resource_table(
                     [
-                        "[{ssh_key.name}]({ssh_key.url_web_permalink})"
-                        " (ID: {ssh_key.id})",
-                    ],
+                        (
+                            "ID",
+                            "{ssh_key.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{ssh_key.name}]({ssh_key.url_web_permalink})",
+                        ),
+                    ]
                 ),
                 get_instructions_next_action_suggestion("deploy", "ssh-key"),
             ],

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/ssl_certificate.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/ssl_certificate.py
@@ -1,0 +1,64 @@
+from typing import Annotated, List, Literal, Optional
+
+from pydantic import Field
+
+from ..devopness_api import devopness, ensure_authenticated
+from ..models import ActionSummary, SSLCertificateSummary
+from ..response import MCPResponse
+from ..types import MAX_RESOURCES_PER_PAGE, ExtraData, TypeListServerID
+from ..utils import (
+    get_instructions_choose_resource,
+    get_instructions_format_list,
+    get_instructions_format_resource,
+    get_instructions_how_to_monitor_action,
+    get_instructions_next_action_suggestion,
+    get_web_link_to_environment_resource,
+)
+
+
+class SSLCertificateService:
+    @staticmethod
+    async def tool_list_ssl_certificates(
+        project_id: int,
+        environment_id: int,
+        page: int = Field(
+            default=1,
+            gt=0,
+        ),
+    ) -> MCPResponse[List[SSLCertificateSummary]]:
+        await ensure_authenticated()
+
+        response = await devopness.ssl_certificates.list_environment_ssl_certificates(
+            environment_id,
+            page,
+            per_page=MAX_RESOURCES_PER_PAGE,
+        )
+
+        ssl_certificates = [
+            SSLCertificateSummary.from_sdk_model(
+                ssl_certificate,
+                ExtraData(
+                    url_web_permalink=get_web_link_to_environment_resource(
+                        project_id,
+                        environment_id,
+                        "ssl-certificate",
+                        ssl_certificate.id,
+                    ),
+                ),
+            )
+            for ssl_certificate in response.data
+        ]
+
+        return MCPResponse(
+            data=ssl_certificates,
+            status="ok",
+            instructions=[
+                get_instructions_format_list(
+                    "- [{ssl_certificate.name}]({ssl_certificate.url_web_permalink})"
+                    " (ID: {ssl_certificate.id},"
+                    " Active: IF {ssl_certificate.active}"
+                    " THEN `🔒 Yes`"
+                    " ELSE `🔓 False`)",
+                ),
+            ],
+        )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/ssl_certificate.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/ssl_certificate.py
@@ -10,6 +10,7 @@ from ..utils import (
     get_instructions_choose_resource,
     get_instructions_format_list,
     get_instructions_format_resource,
+    get_instructions_format_table,
     get_instructions_how_to_monitor_action,
     get_instructions_next_action_suggestion,
     get_web_link_to_environment_resource,
@@ -53,12 +54,21 @@ class SSLCertificateService:
             data=ssl_certificates,
             status="ok",
             instructions=[
-                get_instructions_format_list(
-                    "- [{ssl_certificate.name}]({ssl_certificate.url_web_permalink})"
-                    " (ID: {ssl_certificate.id},"
-                    " Active: IF {ssl_certificate.active}"
-                    " THEN `🔒 Yes`"
-                    " ELSE `🔓 False`)",
-                ),
+                get_instructions_format_table(
+                    [
+                        (
+                            "ID",
+                            "{ssl_certificate.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{ssl_certificate.name}]({ssl_certificate.url_web_permalink})",
+                        ),
+                        (
+                            "Active",
+                            "IF {ssl_certificate.active} THEN `🔒 Yes` ELSE `🔓 False`",
+                        ),
+                    ]
+                )
             ],
         )

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/ssl_certificate.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/ssl_certificate.py
@@ -8,7 +8,7 @@ from ..response import MCPResponse
 from ..types import MAX_RESOURCES_PER_PAGE, ExtraData
 from ..utils import (
     get_instructions_choose_resource,
-    get_instructions_format_resource,
+    get_instructions_format_resource_table,
     get_instructions_format_table,
     get_instructions_next_action_suggestion,
     get_web_link_to_environment_resource,
@@ -64,7 +64,7 @@ class SSLCertificateService:
                         ),
                         (
                             "Active",
-                            "IF {ssl_certificate.active} THEN `🔒 Yes` ELSE `🔓 False`",
+                            "IF {ssl_certificate.active} THEN `🔒 Yes` ELSE `🔓 No`",
                         ),
                     ]
                 ),
@@ -104,11 +104,21 @@ class SSLCertificateService:
         return MCPResponse.ok(
             ssl_certificate,
             [
-                get_instructions_format_resource(
-                    "ssl-certificate",
+                get_instructions_format_resource_table(
                     [
-                        "[{ssl_certificate.name}]({ssl_certificate.url_web_permalink})",
-                    ],
+                        (
+                            "ID",
+                            "{ssl_certificate.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{ssl_certificate.name}]({ssl_certificate.url_web_permalink})",
+                        ),
+                        (
+                            "Active",
+                            "IF {ssl_certificate.active} THEN `🔒 Yes` ELSE `🔓 No`",
+                        ),
+                    ]
                 ),
                 get_instructions_next_action_suggestion("deploy", "ssl-certificate"),
             ],

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
@@ -8,8 +8,8 @@ from ..response import MCPResponse
 from ..types import MAX_RESOURCES_PER_PAGE, ExtraData, TypeListServerID
 from ..utils import (
     get_instructions_choose_resource,
-    get_instructions_format_list,
-    get_instructions_format_resource,
+    get_instructions_format_resource_table,
+    get_instructions_format_table,
     get_instructions_how_to_monitor_action,
     get_instructions_next_action_suggestion,
     get_web_link_to_environment_resource,
@@ -52,23 +52,40 @@ class VirtualHostService:
         return MCPResponse.ok(
             virtual_hosts,
             [
-                get_instructions_format_list(
-                    "- [{virtual_host.name}]({virtual_host.url_web_permalink})"
-                    " (ID: {virtual_host.id})",
+                get_instructions_format_table(
                     [
-                        "**Has active SSL:** {virtual_host.ssl_certificate_id.is.set}",
-                        "**Working directory:** "
-                        "`~/{virtual_host.application_name}/current/{virtual_host.root_directory}`"
-                        "if {virtual_host.application_name} is set, "
-                        "otherwise `not include the field`",
-                        "**Routes to:** <<{virtual_host.application_listen_address}>>"
-                        "if {virtual_host.application_listen_address} is set, "
-                        "otherwise `not include the field`",
-                    ],
+                        (
+                            "ID",
+                            "{virtual_host.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{virtual_host.name}]({virtual_host.url_web_permalink})",
+                        ),
+                        (
+                            "Has active SSL",
+                            "IF {virtual_host.ssl_certificate_id} THEN `🔒 Yes` ELSE `🔓 No`",  # noqa: E501
+                        ),
+                        (
+                            "Application",
+                            "{virtual_host.application_name} OR `-`",
+                        ),
+                        (
+                            "Working directory",
+                            "IF {virtual_host.application_name}` "
+                            "THEN ~/{virtual_host.application_name}/current/{virtual_host.root_directory}` "  # noqa: E501
+                            "ELSE `-`",
+                        ),
+                        (
+                            "Routes to",
+                            "{virtual_host.application_listen_address} OR `-`",
+                        ),
+                    ]
                 ),
                 get_instructions_choose_resource(
                     "virtual-host",
                 ),
+                get_instructions_next_action_suggestion("deploy", "virtual-host"),
             ],
         )
 
@@ -150,23 +167,35 @@ class VirtualHostService:
         return MCPResponse.ok(
             virtual_host,
             [
-                get_instructions_format_resource(
-                    "virtual-host",
+                get_instructions_format_resource_table(
                     [
-                        "**Name:** [{virtual_host.name}]({virtual_host.url_web_permalink})"  # noqa: E501
-                        " (ID: {virtual_host.id})",
-                        "**Has active SSL:** {virtual_host.ssl_certificate_id.is.set}",
-                        "**Application:** {virtual_host.application_name} "
-                        "(ID: {virtual_host.application_id})"
-                        "if {virtual_host.application_name} is set, otherwise `-`",
-                        "**Working directory:** "
-                        "`~/{virtual_host.application_name}/current/{virtual_host.root_directory}`"
-                        "if {virtual_host.application_name} is set, "
-                        "otherwise `-`",
-                        "**Routes to:** <<{virtual_host.application_listen_address}>>"
-                        "if {virtual_host.application_listen_address} is set, "
-                        "otherwise `-`",
-                    ],
+                        (
+                            "ID",
+                            "{virtual_host.id}",
+                        ),
+                        (
+                            "Name",
+                            "[{virtual_host.name}]({virtual_host.url_web_permalink})",
+                        ),
+                        (
+                            "Has active SSL",
+                            "IF {virtual_host.ssl_certificate_id} THEN `🔒 Yes` ELSE `🔓 No`",  # noqa: E501
+                        ),
+                        (
+                            "Application",
+                            "{virtual_host.application_name} OR `-`",
+                        ),
+                        (
+                            "Working directory",
+                            "IF {virtual_host.application_name}` "
+                            "THEN ~/{virtual_host.application_name}/current/{virtual_host.root_directory}` "  # noqa: E501
+                            "ELSE `-`",
+                        ),
+                        (
+                            "Routes to",
+                            "{virtual_host.application_listen_address} OR `-`",
+                        ),
+                    ]
                 ),
                 get_instructions_next_action_suggestion("deploy", "virtual-host"),
             ],

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/services/virtual_host_service.py
@@ -64,7 +64,9 @@ class VirtualHostService:
                         ),
                         (
                             "Has active SSL",
-                            "IF {virtual_host.ssl_certificate_id} THEN `🔒 Yes` ELSE `🔓 No`",  # noqa: E501
+                            "IF {virtual_host.ssl_certificate_id}"
+                            " THEN `🔒 Yes`"
+                            " ELSE `🔓 No`",
                         ),
                         (
                             "Application",
@@ -72,9 +74,9 @@ class VirtualHostService:
                         ),
                         (
                             "Working directory",
-                            "IF {virtual_host.application_name}` "
-                            "THEN ~/{virtual_host.application_name}/current/{virtual_host.root_directory}` "  # noqa: E501
-                            "ELSE `-`",
+                            "IF {virtual_host.application_name}`"
+                            " THEN ~/{virtual_host.application_name}/current/{virtual_host.root_directory}`"  # noqa: E501
+                            " ELSE `-`",
                         ),
                         (
                             "Routes to",
@@ -179,7 +181,9 @@ class VirtualHostService:
                         ),
                         (
                             "Has active SSL",
-                            "IF {virtual_host.ssl_certificate_id} THEN `🔒 Yes` ELSE `🔓 No`",  # noqa: E501
+                            "IF {virtual_host.ssl_certificate_id}"
+                            " THEN `🔒 Yes`"
+                            " ELSE `🔓 No`",
                         ),
                         (
                             "Application",
@@ -187,9 +191,9 @@ class VirtualHostService:
                         ),
                         (
                             "Working directory",
-                            "IF {virtual_host.application_name}` "
-                            "THEN ~/{virtual_host.application_name}/current/{virtual_host.root_directory}` "  # noqa: E501
-                            "ELSE `-`",
+                            "IF {virtual_host.application_name}`"
+                            " THEN ~/{virtual_host.application_name}/current/{virtual_host.root_directory}`"  # noqa: E501
+                            " ELSE `-`",
                         ),
                         (
                             "Routes to",

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/tools.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/tools.py
@@ -23,6 +23,7 @@ from .services.project_service import ProjectService
 from .services.server_service import ServerService
 from .services.service_service import ServiceService
 from .services.ssh_key_service import SSHKeyService
+from .services.ssl_certificate import SSLCertificateService
 from .services.user_service import UserService
 from .services.virtual_host_service import VirtualHostService
 from .services.webhook_service import WebHookService
@@ -73,6 +74,7 @@ def register_tools(mcp_server: FastMCP) -> None:
         ServerService,
         ServiceService,
         SSHKeyService,
+        SSLCertificateService,
         UserService,
         VirtualHostService,
         WebHookService,

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/types.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/types.py
@@ -31,6 +31,7 @@ type ResourceType = Literal[
     "server",
     "service",
     "ssh-key",
+    "ssl-certificate",
     "virtual-host",
 ]
 

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/utils.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/utils.py
@@ -56,6 +56,20 @@ def get_instructions_format_resource(
     )
 
 
+def get_instructions_format_resource_table(
+    column_and_value_templates: list[tuple[str, str]],
+) -> str:
+    table = "Field | Value\n"
+
+    for column, value in column_and_value_templates:
+        table += f"{column} | {value}\n"
+    table += "\n"
+
+    return f"""You MUST present a table in the below format:
+    {table}
+    """
+
+
 def get_instructions_format_list(
     header: str,
     extra_instructions: list[str] | None = None,

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/utils.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/utils.py
@@ -71,6 +71,24 @@ def get_instructions_format_list(
     ]
 
 
+def get_instructions_format_table(
+    column_and_value_templates: list[tuple[str, str]],
+) -> str:
+    table = ""
+
+    for column, _ in column_and_value_templates:
+        table += f"{column} |"
+    table += "\n"
+
+    for _, value in column_and_value_templates:
+        table += f"- {value} |"
+    table += "\n"
+
+    return f"""You MUST present a table in the below format:
+    {table}
+    """
+
+
 def get_instructions_next_action_suggestion(
     action: str,
     resource_type: ResourceType,

--- a/packages/ai/mcp-server/src/devopness_mcp_server/lib/utils.py
+++ b/packages/ai/mcp-server/src/devopness_mcp_server/lib/utils.py
@@ -13,7 +13,7 @@ when interacting with resources in the Devopness MCP server ecosystem.
 from .types import ResourceType
 
 
-def get_last_action_repl(
+def format_last_action_field(
     resource_type: ResourceType,
 ) -> str:
     """
@@ -21,7 +21,6 @@ def get_last_action_repl(
     on a resource.
     """
     return (
-        "**Last Action:** "
         "[{" + resource_type + "}.last_action.type}]"
         "({" + resource_type + ".last_action.url_web_permalink}) "
         "**({" + resource_type + ".last_action.status})**"


### PR DESCRIPTION
## Description of changes

- [x] Added tools to list, create, and deploy ssl-certificate
- [x] Refactored list and create tools output to display resources in table format instead of bullet-point list
- [x] Implemented LLM instructions to guide the correct generation of table-based outputs

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: 
   - The LLM successfully guides users to list, create, and deploy ssl-certificate
   - Tools output are presented in a readable table format

## More info

**After**
- TODO

**Before**
- TODO