### PR TITLE
docs(ssh-keys): add pages for listing and viewing SSH keys

### DIFF
--- a/docs/docs/ssh-keys/list-ssh-keys.md
+++ b/docs/docs/ssh-keys/list-ssh-keys.md
@@ -1,0 +1,21 @@
+---
+title: List SSH Keys
+intro: At times, you or your team members may need to connect to your servers to execute commands directly from the terminal. To ensure secure access, you can add SSH keys to your environment servers, allowing connections only from authorized keys.
+links:
+  overview:
+  quickstart:
+  previous: ssh-keys/link-ssh-key
+  next: ssh-keys/remove-ssh-key
+  guides:
+  related:
+    - ssh-keys/create-ssh-key-pair
+    - ssh-keys/add-ssh-key
+  featured:
+---
+
+## How to List SSH Keys
+
+1. In the Devopness dashboard, navigate to your desired project, then select the relevant environment.
+2. Locate the `SSH Keys` card on the environment page.
+3. Click the `View` button on the `SSH Keys` card to display the list of SSH keys currently added to the environment.
+4. If no keys are listed, follow the steps in the [Create SSH Key Pair](../ssh-keys/create-ssh-key-pair) and [Add SSH Key](../ssh-keys/add-ssh-key) guides to add your first key.

--- a/docs/docs/ssh-keys/view-ssh-key.md
+++ b/docs/docs/ssh-keys/view-ssh-key.md
@@ -1,0 +1,25 @@
+---
+title: View SSH Key
+intro: After adding SSH keys to your environment, you may want to review the details of a specific key, such as its label, fingerprint, or creation date. This helps in managing and auditing server access effectively.
+links:
+  overview:
+  quickstart:
+  previous: ssh-keys/remove-ssh-key
+  guides:
+  related:
+    - ssh-keys/create-ssh-key-pair
+    - ssh-keys/add-ssh-key
+  featured:
+---
+
+## How to View Details of an SSH Key
+
+1. In the Devopness dashboard, navigate to your project, then select the environment where the SSH key was added.
+2. Locate the `SSH Keys` card and click `View` to open the list of SSH keys associated with the environment.
+3. From the list, click on the SSH key you want to inspect.
+4. The `SSH key` details page will display important information such as:
+   - **Name**: A user-friendly name for the key.
+   - **Fingerprint**: A unique identifier for the key.
+   - **Created At**: When the key was added to the environment.
+
+Use this view to verify key details or to confirm which keys have access to your servers.


### PR DESCRIPTION
## Description of changes
- Added two new documentation pages for the SSH Keys section:
  - Listing SSH Keys
  - Viewing SSH Key details
- These additions help fill existing gaps in the SSH Keys documentation.

## GitHub issues resolved by this PR
- [x] Closes #1210

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: 
  - The new documentation pages appear correctly in the SSH Keys section on the Devopness Docs site.
  - Content is properly formatted and renders as expected in Docusaurus.
  - Links between related SSH Keys pages work correctly.

## More info
N/A
