### PR TITLE
ci: bump `contributor-assistant` action to 2.6.1

### DIFF
--- a/.github/workflows/ci-cla-assistant.yml
+++ b/.github/workflows/ci-cla-assistant.yml
@@ -21,7 +21,7 @@ jobs:
           github.event.comment.body == 'recheck' ||
           github.event.comment.body == 'I have read the CLA document and I hereby sign the CLA' ||
           github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.2
+        uses: contributor-assistant/github-action@v2.6.1
         env:
           # CLA Action uses this in-built GitHub token to make the API calls for interacting with GitHub.
           # It is built into Github Actions and does not need to be manually specified in your secrets store.


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->
- [x] Update contributor assistant action to latest version https://github.com/contributor-assistant/github-action/releases as an attempt to fix, or at least improve error output, for PRs such as #1911 where used added a comment signing CLA but the user was not added to the CLA database.

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: CLA action is triggered using version 2.6.1

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
