### PR TITLE
fix(docs): Correct navigation links on add-project page

### DIFF
--- a/docs/docs/projects/add-project.md
+++ b/docs/docs/projects/add-project.md
@@ -4,8 +4,8 @@ intro: Add one or multiple projects to group your infrastructure resources in a 
 links:
     overview:
     quickstart:
-    previous: index
-    next: environments/add-environment
+    previous: pipelines/steps/remove-step
+    next: projects/list-projects
     guides:
     related:
     featured:


### PR DESCRIPTION
## Description of changes

- [x] Corrects the `previous` and `next` navigation links on the "Add a Project" documentation page to follow a logical sequence.

## GitHub issues resolved by this PR

- [x] closes #1912

## Quality Assurance

- [x] Success criteria is to verify that the navigation buttons on the deployed documentation page link to the correct URLs.

## More info

N/A