### PR TITLE
fix: 'Sync - Package Versions' to work with PRs from forks

### DIFF
--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -11,7 +11,7 @@ name: Sync - Package Versions
 # versions of these packages are also synchronized in the root package-lock.json file.
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
## Description of changes

This updates the trigger for the `Sync - Package Versions` workflow from ['pull_request' to 'pull_request_target'](https://runs-on.com/github-actions/pull-request-vs-pull-request-target/).

The reason for this change is that when using `pull_request`, GitHub does **not expose repository secrets** (like `DEVOPNESS_PYPI_PACKAGES`) to workflows triggered by forks — causing the workflow to fail.

* [x] Fix `Sync - Package Versions` workflow error detected in https://github.com/devopness/devopness/pull/1921 to properly access secret **DEVOPNESS_PYPI_PACKAGES**

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: 
  - The `Sync - Package Versions` workflow completes successfully for PRs opened from forks and has access to the `DEVOPNESS_PYPI_PACKAGES` secret.

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
