### PR TITLE
chore: fix typo and update package script

### DIFF
--- a/packages/ui/react/package.json
+++ b/packages/ui/react/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "rm -Rf dist && tsc -b && vite build",
     "build-storybook": "NODE_ENV=production storybook build -c .storybook -o ./storybook-static",
-    "lint": "eslint --max-warnings=0 . && prettier --write . && prettier --check .",
+    "lint": "eslint --max-warnings=0 . && prettier --check .",
+    "format": "eslint --fix . && prettier --write .",
     "prepublishOnly": "npm run lint && npm test && npm run build",
     "storybook": "storybook dev -p 6006",
     "test": "vitest"

--- a/packages/ui/react/src/components/Forms/Input/Input.stories.tsx
+++ b/packages/ui/react/src/components/Forms/Input/Input.stories.tsx
@@ -49,7 +49,7 @@ const Error: Story = {
       fontStylePlaceholder: 'Placeholder font style',
     },
     error: {
-      message: 'It is a error message',
+      message: 'It is an error message',
     },
     disabled: false,
     readOnly: false,
@@ -93,7 +93,7 @@ const WithAutoFocusOnError: Story = {
   args: {
     name: 'name',
     type: 'text',
-    placeholder: 'This input will auto-focus when error occurs',
+    placeholder: 'This input will auto-focus when an error occurs',
     labelProps: {
       htmlFor: 'name',
       value: 'Auto-focus on error',
@@ -148,6 +148,6 @@ const MultipleInputs: Story = {
   ),
 }
 
-export { Default, Error, Number, WithAutoFocusOnError, MultipleInputs }
+export { Default, Error, MultipleInputs, Number, WithAutoFocusOnError }
 
 export default meta


### PR DESCRIPTION
## Description of changes

- Fixed a minor typo in `Input.stories.tsx` file.
- Updated the `lint` script in `package.json` to **remove the `prettier --write .` step**.

  - This change ensures that CI pipelines **only check for formatting issues**, without automatically fixing them.
  - Developers are expected to run the `format` script locally to apply Prettier fixes when needed.

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- CI lint checks run in **check-only mode**, failing if formatting issues exist.
- Developers can run `npm run format` locally to fix any formatting issues.
- The typo correction is correctly applied.
- CI pipelines pass successfully.

## More info

N/A