### PR TITLE
chore(changeset): add missing changeset for Dropdown refactor

### DIFF
--- a/.changeset/refactor-Dropdown-component.md
+++ b/.changeset/refactor-Dropdown-component.md
@@ -1,5 +1,32 @@
 ---
-"@devopness/ui-react": patch
+"@devopness/ui-react": minor
 ---
 
-Refactored Dropdown to support both sync and async handlers (onClick / onSelect) using Promise.resolve. Introduced handleDropdownOptionClick to centralize and simplify click/select logic.
+Improve Dropdown to support both sync and async handlers and add new Icon option
+
+### What Changed
+
+- Refactored `onClick` and `onSelect` props to support both synchronous and asynchronous functions using `Promise.resolve()`
+- Introduced `handleDropdownOptionClick()` to centralize and simplify the click/select logic in the `Dropdown` component
+- Added support for the new `discord` icon in `iconLoader.tsx`
+
+### Example Usage
+
+```tsx
+<Dropdown
+  options={[
+    {
+      label: "Log out",
+      onClick: async () => {
+        await api.logout();
+      },
+    },
+  ]}
+/>
+```
+
+```tsx
+<Icon name={discord} size={14} color={"blue.950"} />
+```
+
+This improves reusability and flexibility while ensuring the component gracefully handles both sync and async handlers and also adds support for a new icon.


### PR DESCRIPTION
## Description of changes
This PR adds the missing changeset file for the updates already merged in #1945

* [x] Adds missing changeset to document the recent `Dropdown` improvements.

## GitHub issues resolved by this PR
* [x] N/A

## Quality Assurance
* Once this PR is merged, the changeset will be included in the next release, correctly documenting the `Dropdown` improvements made in PR #1945 .

## More info
No logic or UI changes are included in this PR. See PR #1945 for the actual code changes related to this changeset.