### PR TITLE
feat: add hetzner and fastmcp icons

### DIFF
--- a/.changeset/add-hetzner-and-fastmcp-icons.md
+++ b/.changeset/add-hetzner-and-fastmcp-icons.md
@@ -1,0 +1,21 @@
+---
+
+"@devopness/ui-react": minor
+
+---
+
+Add new `hetzner` and `fastmcp` icons to the icon set
+
+### What Changed
+
+- Added a new `hetzner` icon to the set of supported `Icon` options
+- Added a new `fastmcp` icon to the set of supported `Icon` options
+
+### Example Usage
+
+```tsx
+<Icon name="hetzner" size={14} color="blue.950" />
+<Icon name="python-fastmcp" size={14} color="blue.950" />
+```
+
+These additions expand the available icon set for consistent and recognizable UI design.

--- a/packages/ui/react/src/icons/iconLoader.tsx
+++ b/packages/ui/react/src/icons/iconLoader.tsx
@@ -82,6 +82,7 @@ import type { Icon } from './types'
 
 const awsSVG = getImageAssetUrl('icons_svgs/aws.svg')
 const azureSVG = getImageAssetUrl('icons_svgs/azure.svg')
+const hetznerSVG = getImageAssetUrl('icons_svgs/hetzner.svg')
 const bitbucketSVG = getImageAssetUrl('icons_svgs/bitbucket.svg')
 const centosSVG = getImageAssetUrl('icons_svgs/centos.svg')
 const cSharpSVG = getImageAssetUrl('icons_svgs/c-sharp.svg')
@@ -105,6 +106,7 @@ const phpLaravelSVG = getImageAssetUrl('icons_svgs/php-laravel.svg')
 const phpSVG = getImageAssetUrl('icons_svgs/php.svg')
 const pythonDjangoSVG = getImageAssetUrl('icons_svgs/python-django.svg')
 const pythonFastAPISVG = getImageAssetUrl('icons_svgs/python-fastapi.svg')
+const pythonFastMCPSVG = getImageAssetUrl('icons_svgs/fastmcp.svg')
 const pythonFlaskSVG = getImageAssetUrl('icons_svgs/python-flask.svg')
 const pythonSVG = getImageAssetUrl('icons_svgs/python.svg')
 const rubySVG = getImageAssetUrl('icons_svgs/ruby.svg')
@@ -199,6 +201,7 @@ const iconList = [
 
   // Technology/Brand icons
   { type: 'image', name: 'aws', component: awsSVG },
+  { type: 'image', name: 'hetzner', component: hetznerSVG },
   { type: 'image', name: 'azure', component: azureSVG },
   { type: 'image', name: 'bitbucket', component: bitbucketSVG },
   { type: 'image', name: 'c-sharp', component: cSharpSVG },
@@ -223,6 +226,7 @@ const iconList = [
   { type: 'image', name: 'python', component: pythonSVG },
   { type: 'image', name: 'python-django', component: pythonDjangoSVG },
   { type: 'image', name: 'python-fastapi', component: pythonFastAPISVG },
+  { type: 'image', name: 'python-fastmcp', component: pythonFastMCPSVG },
   { type: 'image', name: 'python-flask', component: pythonFlaskSVG },
   { type: 'image', name: 'ruby', component: rubySVG },
   { type: 'icon', name: 'self-hosted', component: FaServer },


### PR DESCRIPTION
## Description of changes
This PR updates the icon set in @devopness/ui-react by adding two new icons:

- hetzner
- fastmcp

## GitHub issues resolved by this PR
- [x] N/A

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: The hetzner and fastmcp icons should render correctly when used with the Icon component.

## More info
These additions expand the available icon library for use across the application, ensuring consistent branding and visual representation for services and integrations.

### Hetzner SVG
<img width="1446" height="948" alt="imagem_2025-08-13_145503998" src="https://github.com/user-attachments/assets/be991851-7371-471e-9b0d-1b741f901ac3" />

### FastMCP SVG
<img width="1919" height="1017" alt="Captura de tela 2025-08-13 104633" src="https://github.com/user-attachments/assets/0765b3d7-44dd-4948-85c9-3a761dfdc15d" />