### PR TITLE
docs(heztner-credential): add heztner credential page

### DIFF
--- a/docs/docs/credentials/add-hetzner-credential.md
+++ b/docs/docs/credentials/add-hetzner-credential.md
@@ -5,7 +5,7 @@ links:
     overview:
     quickstart:
     previous:
-    next:
+    next: credentials/add-credential
     guides:
     related:
     featured:

--- a/docs/docs/credentials/add-hetzner-credential.md
+++ b/docs/docs/credentials/add-hetzner-credential.md
@@ -1,0 +1,31 @@
+---
+title: Add Hetzner Credential
+intro: To allow Devopness to manage Hetzner Cloud resources on your behalf, an API token must be provided.
+links:
+    overview:
+    quickstart:
+    previous:
+    next:
+    guides:
+    related:
+    featured:
+---
+
+> If you don't have access to a Hetzner account, you can create an account for free following the Hetzner Cloud [Sign Up](https://accounts.hetzner.com/signUp) page.
+
+1. Log in to the [Hetzner Cloud Console](https://accounts.hetzner.com/login)
+1. In the left navigation panel, click `Security`
+1. At the top menu, select the `API Tokens` tab
+1. Click `Generate API Token`
+1. In the `Generate API Token` form:
+    - Enter a **description** for the token (e.g., `Devopness`) to help track its usage
+    - Choose a **permission**:
+        - **Read** – token can only perform GET requests
+        - **Read & Write** – token can perform GET, POST, PUT, DELETE requests (required for creating servers)
+1. Click `Generate API Token`
+1. **Copy the API token** shown
+    - It will be a long string of characters
+    - **Important:** The token will not be shown again, so make sure to save it securely
+1. To add the token to Devopness, follow the guide: [/docs/credentials/add-credential]
+
+> For more details, see the official Hetzner documentation on [Generating an API Token](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token/)


### PR DESCRIPTION
## Description of changes
This PR adds a new documentation page explaining how to generate a Hetzner API token and add it as a credential in Devopness.

- The page guides users step by step through logging into Hetzner Cloud, generating a new API token with the appropriate permissions (Read & Write), and copying the token.

- It also explains how to add the token to Devopness and includes links to official Hetzner documentation.

- Best practices for naming and managing the token are also included to improve clarity for users.

## GitHub issues resolved by this PR
- N/A

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: The new Add Hetzner Credential documentation page is accessible from the Docs section and users can follow the instructions to generate a Hetzner API token and successfully add it to Devopness.

## More info
<img width="1868" height="973" alt="Captura de tela 2025-08-14 192250" src="https://github.com/user-attachments/assets/5ad66f79-2730-4869-927d-2fa55da44345" />