### PR TITLE
docs(heztner): update credential guide to be more user friendly

### DIFF
--- a/docs/docs/credentials/add-hetzner-credential.md
+++ b/docs/docs/credentials/add-hetzner-credential.md
@@ -19,9 +19,9 @@ links:
 1. Click `Generate API Token`
 1. In the `Generate API Token` form:
     - Enter a **description** for the token (e.g., `Devopness`) to help track its usage
-    - Choose a **permission**:
-        - **Read** – token can only perform GET requests
-        - **Read & Write** – token can perform GET, POST, PUT, DELETE requests (required for creating servers)
+    - Choose the **Read & Write** permission (required for Devopness)
+        - This permission allows Devopness to fully manage your cloud resources, such as creating, updating, and deleting servers.
+        - **Do not select "Read"**, as it only allows viewing resources and will not work with Devopness.
 1. Click `Generate API Token`
 1. **Copy the API token** shown
     - It will be a long string of characters


### PR DESCRIPTION
## Description of changes
This PR updates the Hetzner API token documentation page to make it clearer and more user-friendly:

- The instructions now explicitly require users to select the Read & Write permission, which is necessary for Devopness to manage cloud resources.

- Simplified technical terms and added explanations so non-technical users can understand what “managing resources” means.

## GitHub issues resolved by this PR
- N/A

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: Users can follow the instructions to generate a Hetzner API token with the correct permissions and successfully add the token as a credential in Devopness.

## More info
<img width="1867" height="791" alt="Screenshot_46" src="https://github.com/user-attachments/assets/1a8d34da-06a1-46e7-92bc-52f3c7622b4c" />