### PR TITLE
docs(add-credentials): fix navigation links between credential docs

### DIFF
--- a/docs/docs/credentials/add-credential.md
+++ b/docs/docs/credentials/add-credential.md
@@ -4,7 +4,7 @@ intro: Devopness allows you to manage multiple provider accounts from a single p
 links:
     overview:
     quickstart:
-    previous:
+    previous: index
     next:
     guides:
     related:


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed
-->
- [ ] This PR updates the previous link in credentials/add-credential.md to point back to credentials/index.md.
- [ ] Previously, the next button on the credentials/index.md pointed to credentials/add-credential.md, but there was no previous button on credentials/add-credential.md

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [ ] N/A


## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: Previous button should appear on "Add Credentials" Page, and it should redirect to "credentials/" on click.

## More info
N/A