### PR TITLE
refactor(docs): add access/create project step

### DIFF
--- a/docs/docs/credentials/add-hetzner-credential.md
+++ b/docs/docs/credentials/add-hetzner-credential.md
@@ -14,6 +14,14 @@ links:
 > If you don't have access to a Hetzner account, you can create an account for free following the Hetzner Cloud [Sign Up](https://accounts.hetzner.com/signUp) page.
 
 1. Log in to the [Hetzner Cloud Console](https://accounts.hetzner.com/login)
+1. Access a Hetzner Cloud project or create a new one: [Projects page](https://console.hetzner.com/projects)
+   > If you don't have a project, click on **New project**.
+   >
+   > Enter a name for the project and click **Add project**.
+   >
+   > Once the project is created, select it from the list to continue.
+   >
+   > **Note**: It might take a few seconds for the new project to be visible in the project list. If it does not appear, reload the console page.
 1. In the left navigation panel, click `Security`
 1. At the top menu, select the `API Tokens` tab
 1. Click `Generate API Token`


### PR DESCRIPTION
## Description of changes
- This PR updates the documentation to clarify the `API Token` setup process by adding an explicit step instructing users to **access or create a project** before navigating to the **Security** section.  

## GitHub issues resolved by this PR
- N/A

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: Documentation clearly instructs users to **create or select a project** before accessing the `Security` panel.

## More info
<img width="1868" height="855" alt="Screenshot_59" src="https://github.com/user-attachments/assets/45a999c9-0366-449f-9372-62ec05caffcd" />