### PR TITLE
refactor(Dropdown): make popover styling more dynamic

### DIFF
--- a/.changeset/refactor-dropdown-component.md
+++ b/.changeset/refactor-dropdown-component.md
@@ -1,0 +1,33 @@
+---
+"@devopness/ui-react": minor
+---
+
+Refactor `Dropdown` component to add `popoverProps` for more flexible Popover styling
+
+### What Changed
+
+- Refactored the `Dropdown` component to accept a new `popoverProps` property.
+- This prop allows consumers to fully customize the Popover, including `slotProps` and `paper` styles.
+- If `popoverProps` is not provided, the Popover falls back to a default style, ensuring backward compatibility.
+
+### Example Usage
+
+```tsx
+<Dropdown
+  id="example-dropdown"
+  options={[{ label: 'Option 1' }, { label: 'Option 2' }]}
+  anchorType="button"
+  label="Open Menu"
+  popoverProps={{
+    slotProps: {
+      paper: {
+        marginTop: '5px',
+        minWidth: '250px',
+        borderRadius: '12px',
+        boxShadow: '0 4px 20px rgba(0,0,0,0.2)',
+      },
+    },
+  }}
+/>
+```
+This change allows full flexibility to style the Popover while keeping a default consistent look when `popoverProps` is not provided.

--- a/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.stories.ts
+++ b/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.stories.ts
@@ -76,6 +76,19 @@ const Primary: Story = {
       vertical: 'bottom',
       horizontal: 'left',
     },
+    popoverProps: {
+      slotProps: {
+        paper: {
+          style: {
+            marginTop: '10px',
+            backgroundColor: '#FFF',
+            width: '200px',
+            borderRadius: '8px',
+            boxShadow: '0 0 30px 0px rgba(0,0,0,0.15)',
+          },
+        },
+      },
+    },
   },
 }
 

--- a/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.tsx
+++ b/packages/ui/react/src/components/Primitives/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import type { PopoverOrigin } from '@mui/material/Popover'
+import type { PopoverOrigin, PopoverProps } from '@mui/material/Popover'
 import Popover from '@mui/material/Popover'
 import type { InjectedProps as PopupStateProps } from 'material-ui-popup-state'
 import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state'
@@ -146,6 +146,11 @@ type DropdownSharedProps = {
    * @see {@link https://mui.com/material-ui/react-popover/#anchor-playground}
    */
   transformOrigin?: PopoverOrigin
+
+  /**
+   * Allow passing custom props to the Popover, including slotProps, style, etc.
+   */
+  popoverProps?: Partial<PopoverProps>
 }
 
 type DropdownVariationButtonProps = DropdownSharedProps & {
@@ -323,7 +328,7 @@ const Dropdown = ({
                 },
               }}
               {...bindPopover(popupState)}
-              {...props}
+              {...props.popoverProps}
             >
               {props.options && (
                 <MenuContainer id={props.id}>


### PR DESCRIPTION
## Description of changes
- Refactored the `Dropdown` component to accept a new `popoverProps` property, allowing full customization of the Popover, including `slotProps` and `paper` styles.
- If `popoverProps` is not provided, the Popover uses a default style to ensure backward compatibility.
- This change replaces the previous `popoverStyle` prop, providing more flexibility while maintaining a consistent default appearance.
- No other behavioral changes were made to the Dropdown or its options.

## GitHub issues resolved by this PR
- [x] N/A

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: Dropdown renders correctly with default styles when `popoverProps` is not provided, and fully respects custom styles when popoverProps is provided, while options, badges, and tooltips continue functioning as before.

## More info
### PopoverProps before
<img width="1867" height="974" alt="Screenshot_72" src="https://github.com/user-attachments/assets/f7ae5096-ec34-412f-b8f0-5605021e5d4a" />

### PopoverProps after
<img width="1866" height="976" alt="Screenshot_73" src="https://github.com/user-attachments/assets/deb7fb76-7011-4bf1-8268-078f69255958" />