### PR TITLE
fix: ensure 'Sync - Package Versions' workflow concurrency is handled per PR

### DIFF
--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -21,7 +21,7 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency: ${{ github.workflow }}-${{ github.head_ref }}
 
 jobs:
   detect-changes:


### PR DESCRIPTION
## Description of changes

- [x] Use **github.head_ref** instead of **github.ref** to build the **concurrency** key to ensure each PR has its own unique group for 'Sync - Package Versions' workflow runs

## GitHub issues resolved by this PR

- [x] N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: 'Sync - Package Versions' workflow runs triggered by a PR will no longer interfere with the execution of the same workflow in other PRs

## More info

<img width="1916" height="433" alt="image" src="https://github.com/user-attachments/assets/a33a185b-6766-4aa3-ab9a-ba1b13529ff9" />

The PR https://github.com/devopness/devopness/pull/2112 was blocked from being merged because its 'Sync - Package Versions' workflow run was canceled by a “newer” run of the same workflow in another PR, as detailed here: https://github.com/devopness/devopness/actions/runs/17433127703

<pre>
Annotations - 1 error

Sync - Package Versions

Canceling since a higher priority waiting request for 'Sync - Package Versions-refs/heads/main' exists
<pre>
