### PR TITLE
fix: 'add to cursor' button link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Install the **Devopness MCP Server** in your favorite IDE:
 
-[![Install Devopness MCP Server in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=devopness&config=eyJ1cmwiOiJodHRwczovL21jcC5kZXZvcG5lc3MuY29tL21jcC8ifQ==)
+[![Install Devopness MCP Server in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=devopness&config=eyJ1cmwiOiJodHRwczovL21jcC5kZXZvcG5lc3MuY29tL21jcC8ifQ==)
 
 [![Install Devopness MCP Server in VS Code](https://img.shields.io/badge/VS_Code-000000?style=for-the-badge&label=Add%20to&labelColor=000000&color=000000
 )](https://insiders.vscode.dev/redirect/mcp/install?name=devopness&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.devopness.com%2Fmcp%2F%22%7D)


### PR DESCRIPTION
## Description of changes

- [x] Add the missing `/en` in **https://cursor.com/install-mcp** to correctly fix the link → **https://cursor.com/en/install-mcp**

## GitHub issues resolved by this PR

- [x] N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: when the user clicks on **Add to Cursor**, they are correctly redirected to the installation page of the Devopness MCP Server in Cursor.

## More info

### Before

https://github.com/user-attachments/assets/03af1e48-8ed0-485a-b1a1-71dab684f37e

### After

https://github.com/user-attachments/assets/96b1a8b3-7bfd-47d4-bd03-92fb670fc0e3


