### PR TITLE
feat(design-system): add FormText component

### DIFF
--- a/.changeset/add-form-text-component.md
+++ b/.changeset/add-form-text-component.md
@@ -1,0 +1,19 @@
+---
+"@devopness/ui-react": minor
+---
+
+Add new `FormText` component
+
+### What Changed
+- Introduced the `FormText` component for displaying section titles with an optional subtitle and divider line.
+- Supports optional custom color for subtitle text.
+
+### Example Usage
+```tsx
+<FormText
+  title="Form Section"
+  subTitle="Optional description here"
+  subTitleColor="#ef4444"
+/>
+```
+This component improves form section readability and consistency across the application.

--- a/packages/ui/react/src/components/Forms/FormText/FormText.stories.tsx
+++ b/packages/ui/react/src/components/Forms/FormText/FormText.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { FormText } from './FormText'
+import type { FormTextProps } from './FormText'
+
+const meta: Meta<FormTextProps> = {
+  title: 'Form/FormText',
+  component: FormText,
+  args: {
+    title: 'Main Title',
+  },
+}
+
+type Story = StoryObj<FormTextProps>
+
+const Default: Story = {
+  args: {
+    title: 'Main Title',
+  },
+}
+
+const WithSubtitle: Story = {
+  args: {
+    title: 'Main Title',
+    subTitle: 'This is an optional subtitle',
+  },
+}
+
+const WithCustomSubtitleColor: Story = {
+  args: {
+    title: 'Main Title',
+    subTitle: 'Subtitle with custom color',
+    subTitleColor: '#ef4444',
+  },
+}
+
+export default meta
+export { Default, WithSubtitle, WithCustomSubtitleColor }

--- a/packages/ui/react/src/components/Forms/FormText/FormText.styled.ts
+++ b/packages/ui/react/src/components/Forms/FormText/FormText.styled.ts
@@ -1,0 +1,40 @@
+import { styled } from 'styled-components'
+
+import { getColor } from 'src/colors'
+import { getFont } from 'src/fonts'
+
+const Wrapper = styled.div`
+  width: 100%;
+`
+
+const Line = styled.div`
+  box-sizing: border-box;
+  width: 100%;
+  height: 1px;
+  background-color: ${getColor('slate.300')};
+`
+
+const Title = styled.h1`
+  width: 100%;
+  color: ${getColor('blue.950')};
+  font-family: ${getFont('montserrat')};
+  font-size: 24px;
+  font-weight: 600;
+`
+
+type ParagraphProps = {
+  subtitleColor?: string
+}
+
+const Paragraph = styled.p<ParagraphProps>`
+  width: 100%;
+  color: ${({ subtitleColor }) => subtitleColor ?? getColor('gray.800')};
+  font-family: ${getFont('roboto')};
+  font-size: 13px;
+  line-height: 1.5;
+
+  a {
+    color: ${getColor('purple.800')};
+  }
+`
+export { Wrapper, Line, Title, Paragraph }

--- a/packages/ui/react/src/components/Forms/FormText/FormText.test.tsx
+++ b/packages/ui/react/src/components/Forms/FormText/FormText.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from 'styled-components'
+import { describe, expect, it } from 'vitest'
+
+import { FormText } from './FormText'
+
+const theme = {}
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>)
+
+describe('FormText', () => {
+  it('renders the title', () => {
+    renderWithTheme(<FormText title="Main Title" />)
+    expect(screen.getByText('Main Title')).toBeInTheDocument()
+  })
+
+  it('renders subtitle when provided', () => {
+    renderWithTheme(
+      <FormText
+        title="Main Title"
+        subTitle="Subtitle text"
+      />
+    )
+    expect(screen.getByText('Subtitle text')).toBeInTheDocument()
+  })
+
+  it('does not render subtitle when not provided', () => {
+    renderWithTheme(<FormText title="Main Title" />)
+    expect(screen.queryByText('Subtitle text')).toBeNull()
+  })
+
+  it('applies custom color to subtitle', () => {
+    renderWithTheme(
+      <FormText
+        title="Main Title"
+        subTitle="Custom Color Subtitle"
+        subTitleColor="rgb(239, 68, 68)"
+      />
+    )
+    const subtitle = screen.getByText('Custom Color Subtitle')
+    expect(subtitle).toHaveStyle('color: rgb(239, 68, 68)')
+  })
+})

--- a/packages/ui/react/src/components/Forms/FormText/FormText.tsx
+++ b/packages/ui/react/src/components/Forms/FormText/FormText.tsx
@@ -1,0 +1,38 @@
+import { Wrapper, Line, Title, Paragraph } from './FormText.styled'
+
+type FormTextProps = {
+  /** Main title */
+  title: string
+  /** Optional subtitle, can be text or ReactNode */
+  subTitle?: React.ReactNode
+  /** Optional custom color for subtitle */
+  subTitleColor?: string
+}
+
+/**
+ * FormText Component
+ *
+ * Displays a section with a title, an optional subtitle,
+ * and a divider line.
+ *
+ * @example
+ * ```tsx
+ * <FormText
+ *   title="Form Section"
+ *   subTitle="This is an optional subtitle"
+ *   subTitleColor="red"
+ * />
+ * ```
+ */
+const FormText = ({ title, subTitle, subTitleColor }: FormTextProps) => (
+  <Wrapper>
+    <Title>{title}</Title>
+    {subTitle && (
+      <Paragraph subtitleColor={subTitleColor}>{subTitle}</Paragraph>
+    )}
+    <Line />
+  </Wrapper>
+)
+
+export { FormText }
+export type { FormTextProps }

--- a/packages/ui/react/src/components/Forms/FormText/index.ts
+++ b/packages/ui/react/src/components/Forms/FormText/index.ts
@@ -1,0 +1,1 @@
+export * from './FormText'

--- a/packages/ui/react/src/components/Forms/index.ts
+++ b/packages/ui/react/src/components/Forms/index.ts
@@ -1,3 +1,4 @@
 export * from './Alert'
 export * from './Input'
 export * from './Container'
+export * from './FormText'


### PR DESCRIPTION
## Description of changes
* Adds a new `FormText` component to the application that provides:
  * A section title with optional subtitle.
  * Support for custom subtitle color.
  * An optional divider line for improved visual separation in forms.
  
## GitHub issues resolved by this PR
- [x] N/A

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: The `FormText` component correctly renders titles, subtitles (with and without custom colors), and divider line across all use cases without breaking existing form layouts.

## More info
<img width="1867" height="969" alt="imagem_2025-09-17_164811467" src="https://github.com/user-attachments/assets/5d2a7798-452a-44e8-8322-e27a4be1d8f1" />