### PR TITLE
feat(design-system): add Illustration component

### DIFF
--- a/.changeset/add-illustration-component.md
+++ b/.changeset/add-illustration-component.md
@@ -1,0 +1,18 @@
+---
+"@devopness/ui-react": minor
+---
+
+Add new `Illustration` component
+
+### What Changed
+- Introduced the `Illustration` component that centers its children horizontally and vertically.
+- Provides a fixed height of `126px` and full width.
+- Adds a bottom border using the theme color `slate.300`.
+
+### Example Usage
+```tsx
+<Illustration>
+  <img src="logo.png" alt="Logo" />
+</Illustration>
+```
+This component improves visual consistency across the application and follows Devopness UI guidelines for reusability, type safety, and documentation.

--- a/packages/ui/react/src/components/Forms/Illustration/Illustration.stories.tsx
+++ b/packages/ui/react/src/components/Forms/Illustration/Illustration.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Illustration } from './Illustration'
+import { getColor } from 'src/colors'
+import { getImageAssetUrl } from 'src/icons'
+const EMPTY_APPLICATIONS = getImageAssetUrl('applications_module.svg')
+
+const meta = {
+  title: 'Form/Illustration',
+  component: Illustration,
+  parameters: {
+    backgrounds: {
+      options: {
+        purple: { name: 'Purple', value: getColor('purple.800') },
+      },
+    },
+  },
+  globals: {
+    backgrounds: { value: 'purple' },
+  },
+} satisfies Meta<typeof Illustration>
+
+type Story = StoryObj<typeof meta>
+
+const Default: Story = {
+  args: {
+    children: (
+      <img
+        src={EMPTY_APPLICATIONS}
+        alt="placeholder"
+      />
+    ),
+  },
+}
+
+const WithText: Story = {
+  args: {
+    children: (
+      <p style={{ fontSize: '18px' }}>Centered text inside Illustration</p>
+    ),
+  },
+}
+
+const WithCustomContent: Story = {
+  args: {
+    children: null,
+  },
+  render: () => (
+    <Illustration>
+      <div
+        style={{
+          width: 60,
+          height: 60,
+          background: getColor('blue.600'),
+          borderRadius: '50%',
+        }}
+      />
+    </Illustration>
+  ),
+}
+
+export { Default, WithText, WithCustomContent }
+export default meta

--- a/packages/ui/react/src/components/Forms/Illustration/Illustration.styled.ts
+++ b/packages/ui/react/src/components/Forms/Illustration/Illustration.styled.ts
@@ -1,0 +1,14 @@
+import { styled } from 'styled-components'
+
+import { getColor } from 'src/colors'
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 126px;
+  border-bottom: 1px solid ${getColor('slate.300')};
+`
+export { Wrapper }

--- a/packages/ui/react/src/components/Forms/Illustration/Illustration.test.tsx
+++ b/packages/ui/react/src/components/Forms/Illustration/Illustration.test.tsx
@@ -30,7 +30,7 @@ describe('Illustration', () => {
   })
 
   it('has fixed height and border bottom', () => {
-    render(
+    const { container } = render(
       <Illustration>
         <span>Border test</span>
       </Illustration>
@@ -42,9 +42,6 @@ describe('Illustration', () => {
       width: '100%',
     })
 
-    expect(wrapper).toHaveStyle({
-      'border-bottom-width': '1px',
-      'border-bottom-style': 'solid',
-    })
+    expect(container.firstChild).toMatchSnapshot()
   })
 })

--- a/packages/ui/react/src/components/Forms/Illustration/Illustration.test.tsx
+++ b/packages/ui/react/src/components/Forms/Illustration/Illustration.test.tsx
@@ -1,0 +1,50 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+
+import { Illustration } from './Illustration'
+
+describe('Illustration', () => {
+  it('renders children correctly', () => {
+    render(
+      <Illustration>
+        <p data-testid="child">Hello</p>
+      </Illustration>
+    )
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+    expect(screen.getByText('Hello')).toBeVisible()
+  })
+
+  it('applies flex centering styles', () => {
+    render(
+      <Illustration>
+        <span>Content</span>
+      </Illustration>
+    )
+    const wrapper = screen.getByText('Content').parentElement
+    expect(wrapper).toHaveStyle({
+      display: 'flex',
+      'justify-content': 'center',
+      'align-items': 'center',
+    })
+  })
+
+  it('has fixed height and border bottom', () => {
+    render(
+      <Illustration>
+        <span>Border test</span>
+      </Illustration>
+    )
+    const wrapper = screen.getByText('Border test').parentElement
+
+    expect(wrapper).toHaveStyle({
+      height: '126px',
+      width: '100%',
+    })
+
+    expect(wrapper).toHaveStyle({
+      'border-bottom-width': '1px',
+      'border-bottom-style': 'solid',
+    })
+  })
+})

--- a/packages/ui/react/src/components/Forms/Illustration/Illustration.tsx
+++ b/packages/ui/react/src/components/Forms/Illustration/Illustration.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+import { Wrapper } from './Illustration.styled'
+
+/**
+ * Illustration Component
+ *
+ * A simple flex container to center content horizontally and vertically,
+ * with a fixed height and bottom border.
+ *
+ * @example
+ * ```tsx
+ * <Illustration>
+ *   <img src="logo.png" alt="Logo" />
+ * </Illustration>
+ * ```
+ */
+type IllustrationProps = {
+  /** React children to render inside */
+  children: React.ReactNode
+}
+
+const Illustration = ({ children }: IllustrationProps) => (
+  <Wrapper>{children}</Wrapper>
+)
+
+export { Illustration }
+export type { IllustrationProps }

--- a/packages/ui/react/src/components/Forms/Illustration/__snapshots__/Illustration.test.tsx.snap
+++ b/packages/ui/react/src/components/Forms/Illustration/__snapshots__/Illustration.test.tsx.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Illustration > has fixed height and border bottom 1`] = `
+<div
+  class="sc-bRKDuR laxXAR"
+>
+  <span>
+    Border test
+  </span>
+</div>
+`;

--- a/packages/ui/react/src/components/Forms/Illustration/index.ts
+++ b/packages/ui/react/src/components/Forms/Illustration/index.ts
@@ -1,0 +1,1 @@
+export * from './Illustration'

--- a/packages/ui/react/src/components/Forms/index.ts
+++ b/packages/ui/react/src/components/Forms/index.ts
@@ -1,3 +1,4 @@
 export * from './Alert'
 export * from './Input'
 export * from './Container'
+export * from './Illustration'


### PR DESCRIPTION
## Description of changes
* Adds a new `Illustration` component to the application that provides:
  * A centered layout for its children, both horizontally and vertically.
  * A fixed height of `126px` and full width.
  * A bottom border styled with the theme color `slate.300`.

## GitHub issues resolved by this PR
- [x] N/A

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: The `Illustration` component correctly centers its children, applies the fixed height and full width, and renders the bottom border consistently across the application.

## More info
<img width="1864" height="971" alt="imagem_2025-09-17_172437722" src="https://github.com/user-attachments/assets/170c7126-c551-4ff0-a4b8-2700a5c2ec59" />