### PR TITLE
fix(docs): correct navigation order in Projects section

### DIFF
--- a/docs/docs/projects/add-project.md
+++ b/docs/docs/projects/add-project.md
@@ -4,8 +4,8 @@ intro: Add one or multiple projects to group your infrastructure resources in a 
 links:
     overview:
     quickstart:
-    previous: index
-    next: environments/add-environment
+    previous: projects/index
+    next: projects/view-project
     guides:
     related:
     featured:

--- a/docs/docs/projects/index.md
+++ b/docs/docs/projects/index.md
@@ -5,7 +5,7 @@ links:
     overview:
     quickstart:
     previous:
-    next:
+    next: projects/add-project
     guides:
     related:
     featured:

--- a/docs/docs/projects/list-projects.md
+++ b/docs/docs/projects/list-projects.md
@@ -4,8 +4,8 @@ intro: View your list of projects
 links:
     overview:
     quickstart:
-    previous: index
-    next: projects/add-project
+    previous: projects/view-project
+    next: environments/add-environment
     guides:
     related:
         - projects/add-project

--- a/docs/docs/projects/view-project.md
+++ b/docs/docs/projects/view-project.md
@@ -4,8 +4,8 @@ intro: In this section you will learn how to manage your project.
 links:
     overview:
     quickstart:
-    previous: projects/list-projects
-    next: projects/add-project
+    previous: projects/add-project
+    next: projects/list-projects
     guides:
     related:
         - projects/list-projects


### PR DESCRIPTION
## Description of changes
Fixed navigation buttons in Projects documentation section to follow logical reading order instead of the current broken circular navigation.

- [x] Updated previous/next links in all four project documentation pages (index.md, add-project.md, view-project.md, list-projects.md)
- [x] Established logical flow: Projects overview → Add Project → View Project → List Projects → Add Environment
- [x] Resolved circular navigation where "View Project" incorrectly pointed back to "Add Project"

## GitHub issues resolved by this PR
- [x] closes #1912

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: Users can navigate through the Projects documentation section in a logical learning sequence without encountering circular navigation loops.

## More info
Tested locally using Docusaurus development server to verify the navigation buttons work correctly and follow the intended flow.