### PR TITLE
docs: Add missing view-file documentation and update navigation links

### DIFF
--- a/docs/docs/files/add-file.md
+++ b/docs/docs/files/add-file.md
@@ -8,6 +8,8 @@ links:
     next: applications/link-server-to-application
     guides:
     related:
+        - files/view-file
+        - files/edit-file
     featured:
 required_permissions:
     - application:update

--- a/docs/docs/files/edit-file.md
+++ b/docs/docs/files/edit-file.md
@@ -8,6 +8,8 @@ links:
     next:
     guides:
     related:
+        - files/view-file
+        - files/add-file
     featured:
 required_permissions:
     - application:update

--- a/docs/docs/files/view-file.md
+++ b/docs/docs/files/view-file.md
@@ -1,0 +1,26 @@
+---
+title: View a File
+intro: View details of a configuration file linked to an application.
+links:
+    overview:
+    quickstart:
+    previous: files/edit-file
+    next: files/remove-file
+    guides:
+    related:
+        - files/add-file
+        - files/edit-file
+    featured:
+required_permissions:
+    - application:read
+---
+
+1. On Devopness, navigate to a project then select an environment
+1. Find the `Applications` card
+1. Click `View` in the `Applications` card to see a list of existing `Applications`
+1. In the list of applications, find the application with the configuration file you want to view and click the `NAME` of the application
+1. Click the `CONFIGURATION FILES` tab
+1. In the list of configuration files, click the `NAME` of the configuration file you want to view
+
+  - The details of the configuration file will be displayed, showing the file's name, path, content, and metadata.
+  - On this page, you can also see when the file was created and last updated.


### PR DESCRIPTION
## Description of changes

Fixes issue #1214 by adding the missing view-file.md documentation and updating navigation links in the files section. The documentation was missing a crucial file that users needed to understand how to view configuration files.

- [x] Created `docs/docs/files/view-file.md` with comprehensive documentation
- [x] Updated `docs/docs/files/add-file.md` with proper navigation links
- [x] Updated `docs/docs/files/edit-file.md` with proper navigation links
- [x] Added step-by-step instructions for viewing configuration files
- [x] Enhanced navigation with proper links between documentation pages

## GitHub issues resolved by this PR

- [x] closes #1214

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: Users can now access the "View a File" documentation from the files section, providing clear step-by-step instructions for viewing configuration files with proper navigation links working correctly between documentation pages.

## More info

**BEFORE**: The files section was missing the view-file.md file, causing a documentation gap where users couldn't find information about viewing configuration files.

- Missing view-file.md file causing 404 errors
- Incomplete navigation between files documentation pages
- Users couldn't find how to view configuration files

<img width="1502" height="903" alt="BEFORE-view-file" src="https://github.com/user-attachments/assets/522ec3fd-006e-451f-89a4-db2322d0497e" />

<img width="1505" height="905" alt="BEFORE-add-file" src="https://github.com/user-attachments/assets/486c72e2-7d33-4cab-843b-a53c32c6f395" />

**AFTER**: The documentation now includes complete step-by-step instructions for viewing configuration files with proper navigation.

- New view-file.md file with step-by-step instructions
- Enhanced navigation links in add-file.md and edit-file.md
- Proper navigation flow between all files documentation pages
- Clear instructions for configuration file management

<img width="1505" height="898" alt="AFTER-view-file" src="https://github.com/user-attachments/assets/1beb1a89-737b-4d5c-8dda-98330ce416a0" />

<img width="1509" height="902" alt="AFTER-add-file" src="https://github.com/user-attachments/assets/3063f1ed-b577-480f-aa02-a926f061f871" />

**Files Changed:**
- **Created**: `docs/docs/files/view-file.md`
- **Updated**: `docs/docs/files/add-file.md`
- **Updated**: `docs/docs/files/edit-file.md`

**Key Improvements:**
- Added comprehensive step-by-step instructions for viewing configuration files
- Enhanced navigation with proper cross-references between files documentation pages
- Improved content structure following established documentation patterns
- Resolved documentation gap where users couldn't find file viewing information
- Complete navigation flow between add-file, edit-file, and view-file pages

This resolves the documentation gap where users couldn't find information about viewing configuration files, making the Devopness documentation more complete and user-friendly.