### PR TITLE
ci: enable trusted publishing for npm packages

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write  # Required for OIDC (npm, PyPi, etc). See https://docs.npmjs.com/trusted-publishers
   pull-requests: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -23,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
 
       - name: Install SDK dependencies
         run: npm ci --ignore-scripts
@@ -40,7 +41,6 @@ jobs:
           publish: npx changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   release-pypi-packages:
     name: Release PyPI Packages
@@ -87,4 +87,5 @@ jobs:
         working-directory: ${{ matrix.path }}
         run: make publish
         env:
+          # TO DO: enable OIDC for PyPI and remove `PYPI_TOKEN`
           PYPI_TOKEN: ${{ secrets[matrix.pypi_token] }}


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->

Updated GitHub Actions package release workflow to publish NPM packages using OIDC instead of a token saved to an environment variable.

This PR also:

- [x] Added id-token permission for OIDC support
- [x] Remove references to `NPM_TOKEN` environment variable that will no longer be needed
- [x] Bump required Node.js version to 24
- [x] Update to recent versions of actions `checkout` and `setup-node`

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: newer versions of `ui-react` package are changed to NPM without using a "hard coded" NOM_TOKEN

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->

For motivation and impact see [1] and [2] below:

[1] https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/
[2] https://docs.npmjs.com/trusted-publishers