### PR TITLE
docs: add MCP server installation guides for 6 editors/tools

### DIFF
--- a/docs/docs/mcp/antigravity.md
+++ b/docs/docs/mcp/antigravity.md
@@ -1,0 +1,79 @@
+---
+title: Install Devopness MCP Server on AntiGravity
+---
+
+This guide walks you through installing and configuring the Devopness MCP server on [AntiGravity](https://antigravity.google/) by Google.
+
+## Prerequisites
+
+1. [AntiGravity](https://antigravity.google/) installed on your machine
+2. A Devopness account with a Personal Access Token
+
+## How Devopness integrates with AntiGravity
+
+Devopness provides a remote MCP server that AntiGravity connects to through its native HTTP support. Once configured, the Devopness tools become available in the AntiGravity agent panel.
+
+## Configure the MCP server
+
+1. Open the AntiGravity agent panel
+2. Click the **"..."** dropdown at the top of the editor panel
+3. Select **MCP Servers** to open the MCP Store
+4. Click **Manage MCP Servers**, then select **View raw config**
+5. This opens the configuration file located at:
+    - **macOS/Linux:** `~/.gemini/antigravity/mcp_config.json`
+    - **Windows:** `C:\Users\<USERNAME>\.gemini\antigravity\mcp_config.json`
+
+6. Add the following configuration, replacing `YOUR_PERSONAL_ACCESS_TOKEN` with your Devopness Personal Access Token:
+
+```json
+{
+  "mcpServers": {
+    "devopness": {
+      "serverUrl": "https://mcp.devopness.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_PERSONAL_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+7. Save the file. AntiGravity automatically reloads the configuration.
+
+## Activate and verify the connection
+
+1. Open the **MCP Servers** panel from the **"..."** dropdown
+2. Check the status indicator next to the Devopness server
+3. Verify that the Devopness tools are listed and available
+
+## Use the MCP server
+
+In the AntiGravity agent panel, try a prompt such as:
+
+- "List my Devopness projects"
+- "Show the servers in my production environment"
+- "Deploy my application to staging"
+
+## Troubleshooting
+
+- **Server not appearing:** Verify that the JSON syntax in `mcp_config.json` is valid. Save and reopen the MCP Servers panel.
+- **Authentication errors:** Verify that your Personal Access Token is correct and has not expired.
+- **Tool limit:** For optimal performance, keep the total number of enabled MCP tools under 50.
+- **Alternative configuration:** If the native `serverUrl` approach has issues, try using the `mcp-remote` proxy instead. This requires [Node.js](https://nodejs.org/) to be installed:
+
+```json
+{
+  "mcpServers": {
+    "devopness": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.devopness.com/mcp/",
+        "--header",
+        "Authorization: Bearer YOUR_PERSONAL_ACCESS_TOKEN"
+      ]
+    }
+  }
+}
+```

--- a/docs/docs/mcp/gemini-cli.md
+++ b/docs/docs/mcp/gemini-cli.md
@@ -1,0 +1,77 @@
+---
+title: Install Devopness MCP Server on Gemini CLI
+---
+
+This guide walks you through installing and configuring the Devopness MCP server on [Gemini CLI](https://github.com/google-gemini/gemini-cli) by Google.
+
+## Prerequisites
+
+1. [Gemini CLI](https://github.com/google-gemini/gemini-cli) installed on your machine
+2. A Devopness account with a Personal Access Token
+
+## How Devopness integrates with Gemini CLI
+
+Devopness provides a remote MCP server that Gemini CLI connects to through its native HTTP support. Once configured, the Devopness tools become available in your Gemini CLI sessions.
+
+## Configure the MCP server
+
+### Option A: Edit the settings file
+
+1. Open the Gemini CLI settings file at `~/.gemini/settings.json`
+2. Add the following configuration, replacing `YOUR_PERSONAL_ACCESS_TOKEN` with your Devopness Personal Access Token:
+
+```json
+{
+  "mcpServers": {
+    "devopness": {
+      "httpUrl": "https://mcp.devopness.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_PERSONAL_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+3. Save the file
+
+:::tip
+
+You can also create a project-level configuration by placing a `.gemini/settings.json` file in your project root directory.
+
+:::
+
+### Option B: Use the CLI command
+
+Run the following command, replacing `YOUR_PERSONAL_ACCESS_TOKEN` with your Devopness Personal Access Token:
+
+```bash
+gemini mcp add \
+  --transport http \
+  --header "Authorization: Bearer YOUR_PERSONAL_ACCESS_TOKEN" \
+  -s user \
+  devopness \
+  https://mcp.devopness.com/mcp/
+```
+
+## Activate and verify the connection
+
+1. Start or restart Gemini CLI
+2. Run the `/mcp` command to check the server status
+3. The output displays all configured servers with their connection state: **CONNECTED**, **CONNECTING**, or **DISCONNECTED**
+4. Verify that the Devopness server shows as **CONNECTED** and its tools are listed
+
+## Use the MCP server
+
+In a Gemini CLI session, try a prompt such as:
+
+- "List my Devopness projects"
+- "Show the servers in my production environment"
+- "Deploy my application to staging"
+
+## Troubleshooting
+
+- **Server not connecting:** Test the MCP server endpoint independently with `curl https://mcp.devopness.com/mcp/` to verify connectivity.
+- **Authentication errors:** Verify that your Personal Access Token is correct and has not expired.
+- **Debug mode:** Run Gemini CLI with `--debug` for verbose output, or press **F12** to open the debug console in interactive mode.
+- **Configuration priority:** When both `httpUrl` and `url` are set, `httpUrl` takes priority. Use `httpUrl` for the Devopness MCP server.

--- a/docs/docs/mcp/index.md
+++ b/docs/docs/mcp/index.md
@@ -1,0 +1,16 @@
+---
+title: MCP Servers
+---
+
+The Devopness MCP (Model Context Protocol) server allows AI assistants to manage your cloud infrastructure using natural language. You can deploy applications, create servers, manage environments, and more through your favorite IDE or AI tool.
+
+## Supported editors and tools
+
+Choose your editor or AI tool below for step-by-step installation instructions:
+
+- [AntiGravity](/docs/mcp/antigravity)
+- [Gemini CLI](/docs/mcp/gemini-cli)
+- [JetBrains AI](/docs/mcp/jetbrains)
+- [Trae](/docs/mcp/trae)
+- [Warp](/docs/mcp/warp)
+- [Windsurf](/docs/mcp/windsurf)

--- a/docs/docs/mcp/jetbrains.md
+++ b/docs/docs/mcp/jetbrains.md
@@ -1,0 +1,59 @@
+---
+title: Install Devopness MCP Server on JetBrains AI
+---
+
+This guide walks you through installing and configuring the Devopness MCP server on [JetBrains IDEs](https://www.jetbrains.com/) (IntelliJ IDEA, WebStorm, PyCharm, and others) using the AI Assistant plugin.
+
+## Prerequisites
+
+1. A JetBrains IDE version **2025.1** or later (IntelliJ IDEA, WebStorm, PyCharm, etc.)
+2. The [AI Assistant](https://plugins.jetbrains.com/plugin/22282-ai-assistant) plugin installed and activated
+3. A Devopness account with a Personal Access Token
+
+## How Devopness integrates with JetBrains
+
+Devopness provides a remote MCP server that JetBrains IDEs connect to through the AI Assistant plugin. Once configured, the Devopness tools become available in the AI chat when using Codebase mode.
+
+## Configure the MCP server
+
+1. Open your JetBrains IDE and navigate to **Settings > Tools > AI Assistant > Model Context Protocol (MCP)**
+2. Click the **Add (+)** button and select **As JSON** from the dropdown
+3. Paste the following configuration, replacing `YOUR_PERSONAL_ACCESS_TOKEN` with your Devopness Personal Access Token:
+
+```json
+{
+  "mcpServers": {
+    "devopness": {
+      "url": "https://mcp.devopness.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_PERSONAL_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+4. Click **OK**, then **Apply** to save the configuration
+
+## Activate and verify the connection
+
+1. In the **MCP** settings table, check the **Status** column next to the Devopness server
+2. A connected status indicates the server is running
+3. Click the status icon to view the list of available Devopness tools
+4. In the AI chat, ensure **Codebase mode** is toggled on, as MCP tools are only available in this mode
+
+## Use the MCP server
+
+Open the AI chat in Codebase mode and try a prompt such as:
+
+- "List my Devopness projects"
+- "Show the servers in my production environment"
+- "Deploy my application to staging"
+
+## Troubleshooting
+
+- **Server not connecting:** Click the **Reconnect** button in the MCP settings if the connection drops.
+- **Authentication errors:** Verify that your Personal Access Token is correct and has not expired.
+- **Check logs:** Go to **Help > Show Log in Explorer/Finder** and look in the `mcp` folder within the logs directory.
+- **MCP tools not appearing in chat:** Make sure **Codebase mode** is enabled in the AI chat. MCP tools are not available in the default chat mode.
+- **Plugin version:** Ensure the AI Assistant plugin is version **251.26094.80.5** or later.

--- a/docs/docs/mcp/trae.md
+++ b/docs/docs/mcp/trae.md
@@ -1,0 +1,62 @@
+---
+title: Install Devopness MCP Server on Trae
+---
+
+This guide walks you through installing and configuring the Devopness MCP server on [Trae](https://www.trae.ai/) by ByteDance.
+
+## Prerequisites
+
+1. [Trae](https://www.trae.ai/) installed on your machine
+2. A Devopness account with a Personal Access Token
+
+## How Devopness integrates with Trae
+
+Devopness provides a remote MCP server that Trae connects to through its native HTTP support. Once configured, the Devopness tools become available in the Trae AI assistant.
+
+## Configure the MCP server
+
+1. Click the **Settings** button in the upper-right corner of Trae
+2. Navigate to the **MCP** section under Agent settings
+3. Click **Add MCP Server**, then select **Manual Configuration**
+4. Paste the following configuration, replacing `YOUR_PERSONAL_ACCESS_TOKEN` with your Devopness Personal Access Token:
+
+```json
+{
+  "mcpServers": {
+    "devopness": {
+      "url": "https://mcp.devopness.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_PERSONAL_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+5. Save the configuration
+
+:::tip
+
+You can also configure MCP servers at the project level by creating a `.trae/mcp.json` file in your project root directory. This requires enabling **Settings > Beta > Enable Project MCP** first.
+
+:::
+
+## Activate and verify the connection
+
+1. After saving, the Devopness server should appear in your MCP server list
+2. Verify that the status indicator shows the server is active
+3. The Devopness tools should now be available in your Trae AI sessions
+
+## Use the MCP server
+
+Open a Trae AI session and try a prompt such as:
+
+- "List my Devopness projects"
+- "Show the servers in my production environment"
+- "Deploy my application to staging"
+
+## Troubleshooting
+
+- **Server not connecting:** Ensure the `url` uses the `https://` prefix and the JSON syntax is valid.
+- **Authentication errors:** Verify that your Personal Access Token is correct and has not expired.
+- **Configuration not loading:** Restart Trae if the MCP connection fails after making configuration changes.

--- a/docs/docs/mcp/warp.md
+++ b/docs/docs/mcp/warp.md
@@ -1,0 +1,61 @@
+---
+title: Install Devopness MCP Server on Warp
+---
+
+This guide walks you through installing and configuring the Devopness MCP server on [Warp](https://www.warp.dev/).
+
+## Prerequisites
+
+1. [Warp](https://www.warp.dev/) installed on your machine
+2. [Node.js](https://nodejs.org/) installed (required for the `npx` command)
+3. A Devopness account with a Personal Access Token
+
+## How Devopness integrates with Warp
+
+Warp does not natively support remote HTTP MCP servers with custom headers. The connection is established through `mcp-remote`, a lightweight proxy that bridges Warp to the Devopness remote MCP server.
+
+## Configure the MCP server
+
+1. Open Warp and navigate to **Settings > Personal > MCP Servers**
+2. Click **Add Server**, then select **CLI Server**
+3. Paste the following configuration, replacing `YOUR_PERSONAL_ACCESS_TOKEN` with your Devopness Personal Access Token:
+
+```json
+{
+  "mcpServers": {
+    "devopness": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.devopness.com/mcp/",
+        "--header",
+        "Authorization: Bearer YOUR_PERSONAL_ACCESS_TOKEN"
+      ]
+    }
+  }
+}
+```
+
+4. Save the configuration
+
+## Activate and verify the connection
+
+1. In the MCP Servers settings page, check the box to auto-start the server on launch, or start it manually
+2. Look for **Running** displayed above the MCP server name to confirm the connection is active
+3. The Devopness tools should now be available in your Warp AI sessions
+
+## Use the MCP server
+
+In a Warp AI session, try a prompt such as:
+
+- "List my Devopness projects"
+- "Show the servers in my production environment"
+- "Deploy my application to staging"
+
+## Troubleshooting
+
+- **Server not starting:** Verify that Node.js is installed by running `node --version` in your terminal.
+- **Authentication errors:** Verify that your Personal Access Token is correct and has not expired.
+- **Check logs:** Click the **log file** link in the MCP server settings for detailed error messages.
+- **Cached credentials:** If authentication issues persist after changing your token, try removing cached MCP credentials by running `rm -rf ~/.mcp-auth`.

--- a/docs/docs/mcp/windsurf.md
+++ b/docs/docs/mcp/windsurf.md
@@ -1,0 +1,65 @@
+---
+title: Install Devopness MCP Server on Windsurf
+---
+
+This guide walks you through installing and configuring the Devopness MCP server on [Windsurf](https://windsurf.com/) by Codeium.
+
+## Prerequisites
+
+1. [Windsurf](https://windsurf.com/) installed on your machine
+2. A Devopness account with a Personal Access Token
+
+## How Devopness integrates with Windsurf
+
+Devopness provides a remote MCP server that Windsurf connects to through its native HTTP support. Once configured, the Devopness tools become available in the Cascade AI assistant panel.
+
+## Configure the MCP server
+
+1. Open the MCP configuration file at:
+    - **macOS/Linux:** `~/.codeium/windsurf/mcp_config.json`
+    - **Windows:** `%USERPROFILE%\.codeium\windsurf\mcp_config.json`
+
+    :::tip
+
+    You can also access this file from Windsurf by clicking the **MCP icon** in the top-right of the Cascade panel, then selecting **View raw config (JSON)**.
+
+    :::
+
+2. Add the following configuration, replacing `YOUR_PERSONAL_ACCESS_TOKEN` with your Devopness Personal Access Token:
+
+```json
+{
+  "mcpServers": {
+    "devopness": {
+      "serverUrl": "https://mcp.devopness.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_PERSONAL_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+3. Save the file
+
+## Activate and verify the connection
+
+1. Open Windsurf and navigate to **Windsurf Settings > Cascade > MCP Servers**
+2. Click the **refresh button** to reload the MCP server configuration
+3. Confirm that the **devopness** server appears in the list
+4. Verify that the Devopness tools are listed under the server entry
+
+## Use the MCP server
+
+Open the Cascade panel and try a prompt such as:
+
+- "List my Devopness projects"
+- "Show the servers in my production environment"
+- "Deploy my application to staging"
+
+## Troubleshooting
+
+- **Server not appearing:** Check that the JSON syntax in `mcp_config.json` is valid. A missing comma or bracket can prevent the server from loading.
+- **Authentication errors:** Verify that your Personal Access Token is correct and has not expired.
+- **Check logs:** Review the Windsurf logs at `~/.codeium/windsurf/logs` for detailed error messages.
+- **Tool limit:** Windsurf has a limit of 100 total MCP tools. If you have many MCP servers configured, disable tools you do not need.


### PR DESCRIPTION
## Description of changes

- [ ] Add **MCP Servers index page** (`docs/docs/mcp/index.md`) — landing page listing all supported editors
- [ ] Add **AntiGravity** installation guide (`docs/docs/mcp/antigravity.md`)
- [ ] Add **Gemini CLI** installation guide (`docs/docs/mcp/gemini-cli.md`)
- [ ] Add **JetBrains AI** installation guide (`docs/docs/mcp/jetbrains.md`)
- [ ] Add **Trae** installation guide (`docs/docs/mcp/trae.md`)
- [ ] Add **Warp** installation guide (`docs/docs/mcp/warp.md`)
- [ ] Add **Windsurf** installation guide (`docs/docs/mcp/windsurf.md`)

This PR consolidates the work from PRs #2622, #2623, #2624, #2625, #2626, and #2627 into a single cohesive PR.

## GitHub issues resolved by this PR

- [ ] closes #2560
- [ ] closes #2561
- [ ] closes #2562
- [ ] closes #2563
- [ ] closes #2564
- [ ] closes #2565

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is:
  - [ ] Users can follow each guide on the documentation site and successfully configure the Devopness MCP server in their respective editor/tool
  - [ ] All six guides are accessible from the MCP Servers index page
  - [ ] Internal links between the index and individual guides resolve correctly
  - [ ] All pages render correctly in the Docusaurus build

## More info

### Screenshots

Screenshots of the rendered documentation pages from the local Docusaurus dev server:

- <img width="1212" height="800" alt="mcp-index" src="https://github.com/user-attachments/assets/c081df29-3816-4f72-a6e4-aa6d1b8bb3f8" />

- <img width="1212" height="2593" alt="mcp-antigravity" src="https://github.com/user-attachments/assets/c8b9aff5-75b1-498e-a84d-63f95986db45" />

- <img width="1212" height="2530" alt="mcp-gemini-cli" src="https://github.com/user-attachments/assets/15df5082-6f36-4462-92f2-80d100353c31" />

- <img width="1212" height="2091" alt="mcp-jetbrains" src="https://github.com/user-attachments/assets/b304f1ec-46e1-4e65-88a4-30f283872323" />

- <img width="1212" height="2019" alt="mcp-trae" src="https://github.com/user-attachments/assets/eff1a30b-3a64-459c-91d0-29f7bebfdc8c" />

- <img width="1212" height="2028" alt="mcp-warp" src="https://github.com/user-attachments/assets/d28a7d35-443f-4a36-a0ab-a2d15ff03b6a" />

- <img width="1212" height="2209" alt="mcp-windsurf" src="https://github.com/user-attachments/assets/c13776ab-2408-424d-84f7-c967099117ca" />