### PR TITLE
ci: enable OIDC trusted publishers for Pypi, fix sync in PRs from forks

### DIFF
--- a/.github/configs/README.md
+++ b/.github/configs/README.md
@@ -1,0 +1,33 @@
+# GitHub Actions Matrix Configurations
+
+This directory contains configuration files shared across multiple GitHub Actions workflows.
+Keep in this README a brief description of each file, as some file formats do not accept code comments (e.g. `.json`).
+
+## python-packages.json
+
+Defines the Python/Pypi packages managed in this repository. Used by:
+- `release-packages.yml` - Publishes packages to PyPI
+- `sync-package-versions.yml` - Syncs versions between package.json and pyproject.toml
+
+### Schema
+
+Each entry in the array represents a Python package with the following fields:
+
+- `name` (string): Human-readable package name for display in workflow logs
+- `path` (string): Relative path from repository root to the package directory
+- `pypi_name` (string): The package name on PyPI (used for version checking)
+- `post_version_sync_commands` (string): Optional bash commands to run after version sync
+
+### Adding a new package to the matrix
+
+1. Add a new entry to `python-packages.json`:
+   ```json
+   {
+     "name": "Your Package Name",
+     "path": "packages/your-package",
+     "pypi_name": "your-package-name",
+     "post_version_sync_commands": ""
+   }
+   ```
+2. Commit the changes
+3. The workflows will automatically include the new package in their matrix in their `load-*` jobs

--- a/.github/configs/python-packages.json
+++ b/.github/configs/python-packages.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Devopness SDK - Python",
+    "path": "packages/sdks/python",
+    "pypi_name": "devopness",
+    "post_version_sync_commands": ""
+  }
+]

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write  # Required for OIDC (npm, PyPi, etc). See https://docs.npmjs.com/trusted-publishers
+  id-token: write # Required for OIDC with trusted publishers. See https://docs.pypi.org/trusted-publishers/
   pull-requests: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -86,6 +86,4 @@ jobs:
         if: steps.version_check.outputs.should_publish == 'true'
         working-directory: ${{ matrix.path }}
         run: make publish
-        env:
-          # TO DO: enable OIDC for PyPI and remove `PYPI_TOKEN`
-          PYPI_TOKEN: ${{ secrets[matrix.pypi_token] }}
+        # Note: we publish to for PyPI using OIDC trusted publishers, so no need to set PYPI_TOKEN

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -18,6 +18,24 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  load-pypi-projects:
+    name: Load Python packages matrix
+    needs: detect-changes
+    if: >
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      needs.detect-changes.outputs.changes == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load matrix of Pypi projects
+        id: set-matrix
+        run: |
+          MATRIX=$(cat .github/configs/python-packages.json | jq -c .)
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
   release-npm-packages:
     name: Release NPM Packages
     runs-on: ubuntu-latest
@@ -44,12 +62,13 @@ jobs:
 
   release-pypi-packages:
     name: Release PyPI Packages
+    needs: load-pypi-projects
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(vars.DEVOPNESS_PYPI_PACKAGES) }}
+        include: ${{ fromJSON(needs.load-pypi-projects.outputs.matrix) }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -42,9 +42,27 @@ jobs:
               - 'package-lock.json'
               - 'packages/**/package.json'
 
+  load-pypi-projects:
+    name: Load Python packages matrix
+    needs: detect-changes
+    if: >
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      needs.detect-changes.outputs.changes == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load matrix of Pypi projects
+        id: set-matrix
+        run: |
+          MATRIX=$(cat .github/configs/python-packages.json | jq -c .)
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
   sync-pypi-package-versions:
     name: Sync pyproject.toml
-    needs: detect-changes
+    needs: [detect-changes, load-pypi-projects]
     if: >
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       needs.detect-changes.outputs.changes == 'true'
@@ -52,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(vars.DEVOPNESS_PYPI_PACKAGES || '[]') }}
+        include: ${{ fromJSON(needs.load-pypi-projects.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           filters: |
             changes:
+              - 'package.json'
+              - 'package-lock.json'
               - 'packages/**/package.json'
 
   sync-pypi-package-versions:
@@ -47,23 +49,22 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       needs.detect-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(vars.DEVOPNESS_PYPI_PACKAGES) }}
+        include: ${{ fromJSON(vars.DEVOPNESS_PYPI_PACKAGES || '[]') }}
 
     steps:
       - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: "3.13"
 
       - name: Sync '${{ matrix.name }}' version
         run: |
@@ -78,7 +79,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore: sync '${{ matrix.name }}' version"
-          file_pattern: '${{ matrix.path }}/pyproject.toml ${{ matrix.path }}/*.lock'
+          file_pattern: "${{ matrix.path }}/pyproject.toml ${{ matrix.path }}/*.lock"
           commit_user_name: ${{ vars.DEVOPNESS_AUTOMATIONS_USERNAME }}
           commit_user_email: ${{ vars.DEVOPNESS_AUTOMATIONS_EMAIL }}
 
@@ -89,26 +90,25 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       needs.detect-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
+          node-version: "24.x"
 
       - name: Sync workspace versions in lockfile
         run: npm install --workspaces
 
       - uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: 'chore: update package-lock.json'
-          file_pattern: 'package-lock.json'
+          commit_message: "chore: update package-lock.json"
+          file_pattern: "package-lock.json"
           commit_user_name: ${{ vars.DEVOPNESS_AUTOMATIONS_USERNAME }}
           commit_user_email: ${{ vars.DEVOPNESS_AUTOMATIONS_EMAIL }}
 
@@ -119,12 +119,12 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]'
       && always()
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fail if sync-pypi-package-versions did not succeed
         run: |

--- a/packages/sdks/python/Makefile
+++ b/packages/sdks/python/Makefile
@@ -54,7 +54,14 @@ build-sdk-python: build-image ## ⚙️  Build the Devopness SDK for Python
 			echo "✅  Devopness SDK - Python Build Completed"; \
 		'
 
-publish: build-image ## 🚀 Publish the SDK to PyPI (requires PYPI_TOKEN)
+# Publishes the SDK to PyPI. Configures PyPI token if PYPI_TOKEN is provided,
+# otherwise uses existing Poetry config or OIDC trusted publishers.
+# See: https://docs.pypi.org/trusted-publishers/
+#
+# Usage:
+#   make publish PYPI_TOKEN=pypi-xxxx  # With token authentication
+#   make publish                       # Uses Poetry config or OIDC
+publish: build-image ## 🚀 Publish the SDK to PyPI
 	$(info 📦 Publishing SDK to PyPI...)
 	@docker run --rm \
 		-v $(PWD):/$(WORKDIR) \
@@ -62,7 +69,9 @@ publish: build-image ## 🚀 Publish the SDK to PyPI (requires PYPI_TOKEN)
 		--name devopness-sdk-python-publish \
 		$(IMAGE):$(TAG) \
 		/bin/bash -cex ' \
-			poetry config pypi-token.pypi "$$DEVOPNESS_SDK_PYTHON_PYPI_TOKEN" &> /dev/null; \
+			if [ -n "$$DEVOPNESS_SDK_PYTHON_PYPI_TOKEN" ]; then \
+				poetry config pypi-token.pypi "$$DEVOPNESS_SDK_PYTHON_PYPI_TOKEN" &> /dev/null; \
+			fi; \
 			poetry publish --build; \
 		'
 


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->

Enable OIDC trusted publishers for Pypi packages and fix CI to sync packages in PRs coming from forks of this repo.

The changes in https://github.com/devopness/devopness/pull/2576 changed the workflow scope from `pull_request_target` to `pull_request`.
However, as the workflow depends on variables and secrets defined in this upstream repo [](https://github.com/devopness/devopness/pull/2576)

From GitHub docs:
```
Note:

With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.
```

- [x] Enable OIDC trusted publishers for Pypi
- [x] Adjust Makefile publish task to work with or without a PYPI_TOKEN
- [x] Move matrix of python packages to static file, for compatibility with forked repo's PRs
- [x] Update workflows to read from config file instead of env vars
- [x] Use `GITHUB_TOKEN` instead of a private/personal access token not accessible by forks

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [x] N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: CI jobs will run without env vars/tokens errors for PRs coming for repo forks

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
