### PR TITLE
fix: 'Releases - Packages' load-pypi-projects job

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -20,10 +20,6 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   load-pypi-projects:
     name: Load Python packages matrix
-    needs: detect-changes
-    if: >
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      needs.detect-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
## Problems

The workflow https://github.com/devopness/devopness/actions/runs/22072409036 failed with the following error:

<img width="1525" height="183" alt="image" src="https://github.com/user-attachments/assets/3017f62a-023e-44c4-800e-e82b3b23bff7" />

When editing the file, additional errors appear:

<img width="592" height="246" alt="image" src="https://github.com/user-attachments/assets/66474586-6979-4a62-a64b-f3a127da7589" />

<img width="592" height="246" alt="image" src="https://github.com/user-attachments/assets/4fff28eb-3122-42d6-aa48-7222965f0928" />

## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]
If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.
-->

- [x] Remove unknown job 'detect-changes' from the 'load-pypi-projects' depends-on list
- [x] Remove incorrect 'if' check in 'load-pypi-projects'

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [x] N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: the 'Release - Packages' runs normally.

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
