### PR TITLE
build(deps-dev): Added dependency grouping configuration to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    storybook:
+      patterns:
+        - "storybook"
+        - "@storybook/*"
+        - "eslint-plugin-storybook"
   ignore:
   - dependency-name: eslint
     versions:
@@ -44,3 +50,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    fumadocs:
+      patterns:
+        - "fumadocs-*"


### PR DESCRIPTION
## Description of changes

Adds dependency grouping to Dependabot so related packages are bumped together in a single PR instead of individually.

PRs like #2686 and #2687 bump fumadocs-core and fumadocs-ui separately, but these packages have peer dependencies on each other. Updating one without the other causes npm install to fail, so both PRs are broken.

- [x] Add fumadocs group to /docs npm ecosystem - matches fumadocs-* so core, UI, and MDX are bumped together
- [x] Add storybook group to / root npm ecosystem - matches storybook, @storybook/*, eslint-plugin-storybook to consolidate 5 PRs per release into 1

## After merging

- Close PRs #2686 and #2687 -  Dependabot will recreate them as a single grouped PR on its next daily run
- Future storybook releases will produce 1 PR instead of 5

## GitHub issues resolved by this PR

- [x] Closes PRs #2686 and #2687

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: Dependabot creates grouped PRs for fumadocs and storybook packages instead of individual PRs per package

## More info

- [Dependabot grouping docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)
