### PR TITLE
docs: refine docs onboarding and concept index pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ __pycache__
 
 # misc
 .DS_Store
+_pull-requests/*

--- a/docs/docs/environments/index.md
+++ b/docs/docs/environments/index.md
@@ -1,31 +1,52 @@
 ---
 title: Environments
-intro: Use environments to organize the infrastructure on which your application will run, provision new cloud resources, manage operating system resources, network configuration and have fine grained control of your application deployments.
+intro: Environments define the stages inside a project.
 links:
   overview:
   quickstart:
-  previous:
-  next:
+  previous: projects/index
+  next: environments/add-environment
   guides:
+    - environments/list-environments
   related:
+    - projects/index
   featured:
 ---
 
-## How environments are used
+## About
+Environments are named work areas inside one project.
+They are usually `Development`, `Staging`, and `Production`.
+Each environment holds apps, servers, and settings used in that stage.
 
-An environment is where your infrastructure, deployments, and configuration live. It can include multiple servers, applications, and virtual hosts.
-
-You can connect multiple repositories to the same environment by creating one application per repository. This is common when a product has:
-
-- A marketing site
-- A demo app
-- A production app
-- An API
-- AI agents
-- MCP servers
+## Start here
+- Confirm you are in the right project.
+- Create a first `Production` environment.
+- Add `Development` and `Staging` when you need separate stages.
+- Add client or hotfix environments only when needed.
 
 ## When to split environments
+Start with one `Production` environment while validating the first release.
+Add more environments when isolation is needed for one of these reasons:
+- separate release flow (`Development`, `Staging`, `Production`)
+- different credentials, web domains, deployment permissions;
+- temporary client-specific work (or hotfix) that should not affect ongoing production releases.
 
-Start with a single environment if you want to move fast and your teams, permissions, and release schedule are the same. Create another environment when you need separate domains, versions, data, or access rules (for example `Demo` and `Production`).
+## Examples
+### Product company / Startup
+- Start with one project in `Production` if you are validating a first version.
+- Add `Development`, `Staging`, or custom environments as the team grows.
 
-You can always add more environments later as your needs grow.
+### Agency or client specific custom software
+- Start with your organization and one project per client.
+- One project per client can include `Production`, `Staging`, and custom environments.
+- Keep each client’s workflow separate from the others.
+
+## Why this matters
+- It reduces accidental changes across stages.
+- It makes it easier to decide what to test and deploy next.
+- It lets teams set safer access per stage.
+
+## Common issues
+- You added too many environments too soon.
+- You can no longer tell which environment is used for what.
+- A production-safe path should use separate stages for risky changes.

--- a/docs/docs/environments/index.md
+++ b/docs/docs/environments/index.md
@@ -14,39 +14,48 @@ links:
 ---
 
 ## About
+
 Environments are named work areas inside one project.
 They are usually `Development`, `Staging`, and `Production`.
 Each environment holds apps, servers, and settings used in that stage.
 
 ## Start here
+
 - Confirm you are in the right project.
 - Create a first `Production` environment.
 - Add `Development` and `Staging` when you need separate stages.
 - Add client or hotfix environments only when needed.
 
 ## When to split environments
+
 Start with one `Production` environment while validating the first release.
 Add more environments when isolation is needed for one of these reasons:
+
 - separate release flow (`Development`, `Staging`, `Production`)
 - different credentials, web domains, deployment permissions;
 - temporary client-specific work (or hotfix) that should not affect ongoing production releases.
 
 ## Examples
+
 ### Product company / Startup
+
 - Start with one project in `Production` if you are validating a first version.
 - Add `Development`, `Staging`, or custom environments as the team grows.
 
 ### Agency or client specific custom software
+
 - Start with your organization and one project per client.
 - One project per client can include `Production`, `Staging`, and custom environments.
 - Keep each client’s workflow separate from the others.
 
 ## Why this matters
+
 - It reduces accidental changes across stages.
 - It makes it easier to decide what to test and deploy next.
 - It lets teams set safer access per stage.
 
 ## Common issues
+
 - You added too many environments too soon.
 - You can no longer tell which environment is used for what.
 - A production-safe path should use separate stages for risky changes.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -14,21 +14,25 @@ links:
 ---
 
 ## About
+
 Devopness is an API-first, AI-assisted platform for provisioning infrastructure and deploying applications.
 Use it with major cloud providers, self-hosted servers, and serverless services.
 
 ## What Devopness gives you
+
 - You can deploy apps and infrastructure for any stack from one platform.
 - You can work with multiple cloud providers without learning each one in depth.
 - You can use RBAC to give teams the exact access they need.
 - You can keep visibility across teams without requiring everyone to connect directly to cloud provider accounts.
 
 ## In 3 moves
+
 - Connect your cloud provider.
 - Link your code source.
 - Ship your first app and scale.
 
 ## How it is organized
+
 - **Organization**: the workspace for ownership, teams, and long-term collaboration.
 - **Project**: where related applications and infrastructure are grouped.
 - **Environment**: where release stages live (`Development`, `Staging`, `Production`).
@@ -36,11 +40,13 @@ Use it with major cloud providers, self-hosted servers, and serverless services.
 This page is the fastest route into the full setup flow.
 
 ## Who this is for
+
 - Developers shipping apps and infrastructure with small teams.
 - Team leads moving from single to multi-environment operations.
 - Founders who want predictable deployment structure early.
 
 ## Start here
+
 1. Create your organization in [`Organizations`](/docs/organizations/) (or select the one you already use).
 2. Confirm it is the organization you want to use.
 3. Create your first project.
@@ -49,6 +55,7 @@ This page is the fastest route into the full setup flow.
 6. Deploy your first app and check it is live 🚀
 
 ## Common issues
+
 - You are in the wrong organization and only see a subset of resources.
 - You cannot edit or add items because your role does not include all required permissions.
 - You need faster, safer onboarding before release: start with one project and one production environment.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,26 +1,62 @@
 ---
 slug: /
 sidebar_position: 1
-title: Welcome to Devopness Documentation
-intro: Devopness aims to drastically change the way software developers manage applications and cloud infrastructure in a secure and performant fashion. By streamlining essential DevOps practices, we're making first class software deployment and cloud infrastructure management tools accessible and affordable to every developer in the world.
+title: Get started with Devopness
+intro: Devopness helps growing teams ship software safely and reduce complexity on cloud, CI/CD and DevOps workflows
 links:
   overview:
   quickstart:
   previous:
-  next: projects/add-project
+  next: organizations/index
   guides:
   related:
   featured:
 ---
 
-## Getting Started
+## About
+Devopness is an API-first, AI-assisted platform for provisioning infrastructure and deploying applications.
+Use it with major cloud providers, self-hosted servers, and serverless services.
 
-To get started with Devopness, follow the guide [/docs/projects/add-project]
+## What Devopness gives you
+- You can deploy apps and infrastructure for any stack from one platform.
+- You can work with multiple cloud providers without learning each one in depth.
+- You can use RBAC to give teams the exact access they need.
+- You can keep visibility across teams without requiring everyone to connect directly to cloud provider accounts.
 
-## Get Help
+## In 3 moves
+- Connect your cloud provider.
+- Link your code source.
+- Ship your first app and scale.
 
-If you run into an issue, contact our [Community Support](https://github.com/devopness/devopness/discussions)
+## How it is organized
+- **Organization**: the workspace for ownership, teams, and long-term collaboration.
+- **Project**: where related applications and infrastructure are grouped.
+- **Environment**: where release stages live (`Development`, `Staging`, `Production`).
 
-## Report a Vulnerability
+This page is the fastest route into the full setup flow.
+
+## Who this is for
+- Developers shipping apps and infrastructure with small teams.
+- Team leads moving from single to multi-environment operations.
+- Founders who want predictable deployment structure early.
+
+## Start here
+1. Create your organization in [`Organizations`](/docs/organizations/) (or select the one you already use).
+2. Confirm it is the organization you want to use.
+3. Create your first project.
+4. Add a first `Production` environment.
+5. Connect your cloud and Git credentials.
+6. Deploy your first app and check it is live 🚀
+
+## Common issues
+- You are in the wrong organization and only see a subset of resources.
+- You cannot edit or add items because your role does not include all required permissions.
+- You need faster, safer onboarding before release: start with one project and one production environment.
+
+## Get help
+
+If you need help, contact us on [GitHub](https://github.com/devopness/devopness/discussions) or join our [Discord](https://devopness.com/discord/).
+
+## Report a vulnerability
 
 If you found a vulnerability in our products, follow the guide [/docs/security/reporting-a-security-vulnerability]

--- a/docs/docs/organizations/index.md
+++ b/docs/docs/organizations/index.md
@@ -17,10 +17,10 @@ links:
 ## About
 
 - An organization is the top-level workspace in Devopness.
-- It is a shared workspace for one company or legal entity
-- Each organizations gets a unique readable URL slug (for example `acme` in `/@acme`).
-- Personal accounts own organizations or can be invited to collaborate to organizations created by other users
-- Organizations to group projects, teams and roles
+- It is a shared workspace for one company or legal entity.
+- Each organization gets a unique readable URL slug (for example `acme` in `/@acme`).
+- Personal accounts can own organizations or be invited to collaborate in organizations created by other users.
+- Organizations group projects, teams, and roles.
 
 ## Who should use this
 

--- a/docs/docs/organizations/index.md
+++ b/docs/docs/organizations/index.md
@@ -15,6 +15,7 @@ links:
 ---
 
 ## About
+
 - An organization is the top-level workspace in Devopness.
 - It is a shared workspace for one company or legal entity
 - Each organizations gets a unique readable URL slug (for example `acme` in `/@acme`).
@@ -22,26 +23,31 @@ links:
 - Organizations to group projects, teams and roles
 
 ## Who should use this
+
 - Developers who want one clean workspace for shared projects.
 - Team leads managing multiple products, clients, or teams.
 - Founders who want predictable collaboration, visibility and productivity from day one.
 
 ## Organization vs Project
+
 - Organization owns projects and sets the top-level permissions management (teams and roles).
 - Project groups multiple related environments.
 - Environment is a container for related cloud infrastructure resources, applications, SSL Certificates, Linux services, databases, etc
 
 Think of it like this:
+
 - **Organization:** your shared workspace, like `/@{slug}`
 - **Project:** a bucket for one product or client
 - **Environment:** stages inside that project, like `Development`, `Staging`, `Production`
 
 ## Why organizations exist
+
 - They keep ownership and team activity in one place.
 - They make team access and responsibilities easier to manage.
 - They provide a predictable path to scale without changing product structure.
 
 ## Start here
+
 - Create a new organization to secure your unique `/@{url_slug}`.
 - Confirm it is the one where the project should live.
 - Create your first project.
@@ -49,20 +55,24 @@ Think of it like this:
 - Add `Roles` to manage delegated access permissions.
 
 ## Who can manage an organization
+
 - Organization owners
 - Team members with an organization role that allows managing organization settings
 - Any member with project-level roles can work in project areas according to permissions.
 - Any member with environment-level roles can contribute to specific environments
 
 ## Common questions at this level
+
 - Can I see all projects from one place? Yes, when you are on the right organization.
 - Why can't I edit org settings? Check your role and permission set first.
 
 ## Common issues
+
 - You only see a subset of projects because your permissions are limited.
 - You are looking at the wrong organization.
 - You cannot edit organization settings because your role is not owner.
 
 ## Next
+
 - Use [`Projects`](/docs/projects/) to create your first scoped workspace.
 - Use [`Teams`](/docs/teams/) and [`Roles`](/docs/roles/) to define access.

--- a/docs/docs/organizations/index.md
+++ b/docs/docs/organizations/index.md
@@ -1,0 +1,68 @@
+---
+title: Organizations
+intro: Organizations are the top-level workspace for your work in Devopness.
+links:
+  overview:
+  quickstart:
+  previous:
+  next: projects/index
+  guides:
+  related:
+    - projects/index
+    - teams/index
+    - roles/index
+  featured:
+---
+
+## About
+- An organization is the top-level workspace in Devopness.
+- It is a shared workspace for one company or legal entity
+- Each organizations gets a unique readable URL slug (for example `acme` in `/@acme`).
+- Personal accounts own organizations or can be invited to collaborate to organizations created by other users
+- Organizations to group projects, teams and roles
+
+## Who should use this
+- Developers who want one clean workspace for shared projects.
+- Team leads managing multiple products, clients, or teams.
+- Founders who want predictable collaboration, visibility and productivity from day one.
+
+## Organization vs Project
+- Organization owns projects and sets the top-level permissions management (teams and roles).
+- Project groups multiple related environments.
+- Environment is a container for related cloud infrastructure resources, applications, SSL Certificates, Linux services, databases, etc
+
+Think of it like this:
+- **Organization:** your shared workspace, like `/@{slug}`
+- **Project:** a bucket for one product or client
+- **Environment:** stages inside that project, like `Development`, `Staging`, `Production`
+
+## Why organizations exist
+- They keep ownership and team activity in one place.
+- They make team access and responsibilities easier to manage.
+- They provide a predictable path to scale without changing product structure.
+
+## Start here
+- Create a new organization to secure your unique `/@{url_slug}`.
+- Confirm it is the one where the project should live.
+- Create your first project.
+- Use `Teams` and invite members to collaborate in the organization
+- Add `Roles` to manage delegated access permissions.
+
+## Who can manage an organization
+- Organization owners
+- Team members with an organization role that allows managing organization settings
+- Any member with project-level roles can work in project areas according to permissions.
+- Any member with environment-level roles can contribute to specific environments
+
+## Common questions at this level
+- Can I see all projects from one place? Yes, when you are on the right organization.
+- Why can't I edit org settings? Check your role and permission set first.
+
+## Common issues
+- You only see a subset of projects because your permissions are limited.
+- You are looking at the wrong organization.
+- You cannot edit organization settings because your role is not owner.
+
+## Next
+- Use [`Projects`](/docs/projects/) to create your first scoped workspace.
+- Use [`Teams`](/docs/teams/) and [`Roles`](/docs/roles/) to define access.

--- a/docs/docs/projects/index.md
+++ b/docs/docs/projects/index.md
@@ -14,11 +14,13 @@ links:
 ---
 
 ## About
+
 Projects are where related applications and infrastructure resources live together.
 Each project belongs to one organization and can start small.
 A project can grow by adding `Development`, `Staging`, `Production`, and custom environments over time.
 
 ## Who should use this
+
 - Developers who ship multiple products.
 - Team leads separating ownership between products and teams.
 - Founders who want a simple permission model as the platform grows.
@@ -29,33 +31,40 @@ At day 1, the same project can start with just a `Production` environment.
 Later, add `Development`, `Staging`, and custom environments when you are ready.
 
 ## Relationship to organization
+
 - Organizations own projects and team memberships.
 - Keep product context inside the organization, then split by project when needed.
 - Each environment belongs to a project and holds deployable resources.
 
 ## Start here
+
 - Confirm the organization.
 - Create your first project.
 - Start with one project unless your have different unrelated products or client-specific environments
 - Add `Development` or `Staging` environments when the release flow grows.
 
 ## When to create a new project
+
 - You have different products, clients, or operational domain.
 - Different teams need separate access boundaries.
 - You need different credentials or release ownership for part of your work.
 
 ## When to keep one project
+
 - One product has multiple environments (`Development`, `Staging`, `Production`) that share ownership.
 - Your team needs a single place for related releases and team setup.
 - You want simpler onboarding before splitting by ownership boundaries.
 
 ## Quick decision rule
+
 Start with one project and expand when one of these becomes true:
+
 - Teams, release ownership, or credentials should be separated.
 - You need dedicated client-level boundaries.
 - You need stronger project-level control than one workspace can provide.
 
 Start with one project until one of these is true:
+
 - Different products need separate ownership in practice.
 - Credentials, permissions, or release ownership should be split.
 - Teams should not all use the same project by default.
@@ -64,6 +73,7 @@ Start with one project until one of these is true:
 You can add more projects later without changing your current setup.
 
 ## Common issues
+
 - You feel everything should be one project: this is fine to start.
 - You are not sure where to split: split when team, credential, or release needs diverge.
 - Too many environments inside one project too early can be slower than it sounds.

--- a/docs/docs/projects/index.md
+++ b/docs/docs/projects/index.md
@@ -1,34 +1,69 @@
 ---
 title: Projects
-intro: Use projects to group and manage an unlimited number of infrastructure resources.
+intro: Projects group related environment stages of a product or client-specific environments
 links:
   overview:
   quickstart:
-  previous:
+  previous: organizations/index
   next: projects/add-project
   guides:
   related:
+    - organizations/index
+    - environments/index
   featured:
 ---
 
-## When to use a new project
+## About
+Projects are where related applications and infrastructure resources live together.
+Each project belongs to one organization and can start small.
+A project can grow by adding `Development`, `Staging`, `Production`, and custom environments over time.
 
-A project is a container for multiple environments and resources, such as servers, applications, SSL certificates, cronjobs, and more. It also holds teams, roles, and permissions.
+## Who should use this
+- Developers who ship multiple products.
+- Team leads separating ownership between products and teams.
+- Founders who want a simple permission model as the platform grows.
 
-Use a new project when:
+Think of a project as one product family or one client delivery.
+Example: a startup might create one project for an API, frontend, background workers, and queues.
+At day 1, the same project can start with just a `Production` environment.
+Later, add `Development`, `Staging`, and custom environments when you are ready.
 
-- The applications belong to different products or different teams.
-- The teams and permissions should be different.
-- You want to use different credentials (for example Git credentials or cloud provider credentials).
+## Relationship to organization
+- Organizations own projects and team memberships.
+- Keep product context inside the organization, then split by project when needed.
+- Each environment belongs to a project and holds deployable resources.
 
-Use the same project when:
+## Start here
+- Confirm the organization.
+- Create your first project.
+- Start with one project unless your have different unrelated products or client-specific environments
+- Add `Development` or `Staging` environments when the release flow grows.
 
-- Multiple applications are part of the same product and are managed by the same teams.
-- You want to manage environments, roles, permissions, and credentials once.
+## When to create a new project
+- You have different products, clients, or operational domain.
+- Different teams need separate access boundaries.
+- You need different credentials or release ownership for part of your work.
 
-Examples:
+## When to keep one project
+- One product has multiple environments (`Development`, `Staging`, `Production`) that share ownership.
+- Your team needs a single place for related releases and team setup.
+- You want simpler onboarding before splitting by ownership boundaries.
 
-- Same project: `www.my-product.ai`, `demo.my-product.ai`, and `agent-server` are parts of the same product and are managed by the same teams.
-- Separate projects: `app-a` and `app-b` are different products with different teams or different credentials.
+## Quick decision rule
+Start with one project and expand when one of these becomes true:
+- Teams, release ownership, or credentials should be separated.
+- You need dedicated client-level boundaries.
+- You need stronger project-level control than one workspace can provide.
 
-You can always add another project later if your needs change.
+Start with one project until one of these is true:
+- Different products need separate ownership in practice.
+- Credentials, permissions, or release ownership should be split.
+- Teams should not all use the same project by default.
+- You have special reasons to keep visibily, ownership and permissions management separated.
+
+You can add more projects later without changing your current setup.
+
+## Common issues
+- You feel everything should be one project: this is fine to start.
+- You are not sure where to split: split when team, credential, or release needs diverge.
+- Too many environments inside one project too early can be slower than it sounds.

--- a/docs/docs/projects/index.md
+++ b/docs/docs/projects/index.md
@@ -40,7 +40,7 @@ Later, add `Development`, `Staging`, and custom environments when you are ready.
 
 - Confirm the organization.
 - Create your first project.
-- Start with one project unless your have different unrelated products or client-specific environments
+- Start with one project unless you have different unrelated products or client-specific environments
 - Add `Development` or `Staging` environments when the release flow grows.
 
 ## When to create a new project
@@ -57,18 +57,12 @@ Later, add `Development`, `Staging`, and custom environments when you are ready.
 
 ## Quick decision rule
 
-Start with one project and expand when one of these becomes true:
+Start with one project unless one of these is true:
 
-- Teams, release ownership, or credentials should be separated.
-- You need dedicated client-level boundaries.
-- You need stronger project-level control than one workspace can provide.
-
-Start with one project until one of these is true:
-
-- Different products need separate ownership in practice.
-- Credentials, permissions, or release ownership should be split.
-- Teams should not all use the same project by default.
-- You have special reasons to keep visibily, ownership and permissions management separated.
+- You run separate products, clients, or operational domains.
+- Teams need different access, release ownership, or visibility boundaries.
+- Credentials, permissions, or release ownership must be split across groups.
+- You need dedicated client-level control outside a shared project setup.
 
 You can add more projects later without changing your current setup.
 

--- a/docs/src/components/required-permissions.tsx
+++ b/docs/src/components/required-permissions.tsx
@@ -21,16 +21,15 @@ export function RequiredPermissions({ permissions }: RequiredPermissionsProps) {
 
   return (
     <div className="mt-4">
-      <h2 className="text-lg font-semibold mb-2">Required Permissions</h2>
+      <h2 className="text-lg font-semibold mb-2">Required permissions</h2>
       <p className="text-sm text-fd-muted-foreground mb-4">
-        To complete the steps in this guide, the user needs the following
-        permissions in the environment:
+        To follow this guide, you need the following permissions in the target environment.
       </p>
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b">
             <th className="text-left py-2 font-medium">Resource Type</th>
-            <th className="text-left py-2 font-medium">Permission</th>
+            <th className="text-left py-2 font-medium">Required Permission</th>
           </tr>
         </thead>
         <tbody>
@@ -51,8 +50,9 @@ export function RequiredPermissions({ permissions }: RequiredPermissionsProps) {
           href="/environments/team-memberships/add-team-membership"
           className="underline"
         >
-          Add team to an Environment
+          Add a team to an environment
         </Link>
+        .
       </p>
     </div>
   );

--- a/docs/src/components/required-permissions.tsx
+++ b/docs/src/components/required-permissions.tsx
@@ -23,7 +23,8 @@ export function RequiredPermissions({ permissions }: RequiredPermissionsProps) {
     <div className="mt-4">
       <h2 className="text-lg font-semibold mb-2">Required permissions</h2>
       <p className="text-sm text-fd-muted-foreground mb-4">
-        To follow this guide, you need the following permissions in the target environment.
+        To follow this guide, you need the following permissions in the target
+        environment.
       </p>
       <table className="w-full text-sm">
         <thead>
@@ -45,7 +46,8 @@ export function RequiredPermissions({ permissions }: RequiredPermissionsProps) {
         </tbody>
       </table>
       <p className="text-sm text-fd-muted-foreground mt-4">
-        For instructions on how to grant user permissions to an environment, please follow the guide{' '}
+        For instructions on how to grant user permissions to an environment,
+        please follow the guide{' '}
         <Link
           href="/environments/team-memberships/add-team-membership"
           className="underline"

--- a/docs/src/components/required-permissions.tsx
+++ b/docs/src/components/required-permissions.tsx
@@ -46,9 +46,9 @@ export function RequiredPermissions({ permissions }: RequiredPermissionsProps) {
         </tbody>
       </table>
       <p className="text-sm text-fd-muted-foreground mt-4">
-        For instructions on how to grant user permissions in an environment, see{' '}
+        For instructions on how to grant user permissions to an environment, please follow the guide{' '}
         <Link
-          href="/docs/environments/team-memberships/add-team-membership"
+          href="/environments/team-memberships/add-team-membership"
           className="underline"
         >
           Add team to an Environment


### PR DESCRIPTION
## Description of changes

**Problem to be fixed**
* Landing and onboarding docs used mixed language and mixed conceptual/action wording that was hard to scan
* Documentation structure needed clearer separation between what Devopness is, who it is for, and how users should start
* The onboarding flow for Organizations/Projects/Environments was not consistent
* The "Welcome" page was not making it clear how to get started

- [x] Rewrite docs home () with a short product-first intro, a benefits section, and a 3-step onboarding flow
- [x] Rewwrite index pages  as concept-first page with practical starter guidance
- [x] Rework  to align with the same structure and clearer setup decision flow and new organization workspaces
- [x] Add documentation process guideline updates in  to capture maintenance and index-page conventions

## GitHub issues resolved by this PR
- N/A

## Quality Assurance
- New visitors of the documentation should be able to get started and created their first environments

## More info

