### PR TITLE
docs: improve docs for orgs, projects, envs, tokens & cronjobs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,15 @@ Here are some **bad examples** of pull request titles we're trying to avoid:
 
 **Remember:** Even if your PR is a work in progress (DRAFT), a good description helps maintainers understand your direction and provide early feedback!
 
+### Documentation contributors
+
+If you are changing docs under `docs/docs/*`, follow:
+
+- `docs/docs/authoring-guidelines.md` for writing style and structure
+- `docs/docs/README.md` for frontmatter and markdown metadata rules
+
+When you update text only, use the docs guidelines section as your source of truth.
+
 ### Feature Work
 
 **When to open an issue first:**

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -13,6 +13,8 @@ Make sure all files created in this folder adhere to the following basic rules:
 
 # Documentation authoring guidelines
 
+Use `docs/docs/authoring-guidelines.md` for writing structure, voice, and operational-vs-concept page conventions.
+
 ## What to document?
 
 We should document use cases that will help our users successfully achieve their goals while using Devopness platform.

--- a/docs/docs/api-tokens/index.md
+++ b/docs/docs/api-tokens/index.md
@@ -1,37 +1,50 @@
 ---
 title: API Tokens
-intro: API Tokens are the primary way to authenticate when interacting with the Devopness API.
 links:
   overview:
   quickstart:
   previous:
   next:
   guides:
-  related:
+    related:
     - api-tokens/personal-access-tokens/index
     - api-tokens/project-api-tokens/index
   featured:
 ---
 
+API Tokens let tools and automations authenticate securely when working with the Devopness API.
+
 ## Types of API Tokens
-
-Two types of API Tokens are currently supported: `Project API Tokens` and `Personal Access Tokens`.
-
-Whenever possible, Devopness recommends the usage of `Project API Tokens` for fine-grained permission management.
 
 ### Personal Access Tokens
 
-A token has the same capabilities to access resources and perform actions on those resources that the owner of the token has, allowing a user to perform any operation using Devopness API, including:
+A Personal Access Token uses your user identity and inherits your permissions.
+Use it when automation should behave like a user.
 
-1. Create and manage Projects
-2. Create and manage Environments in a project
-3. Accept user Team Invitations
-4. Create and manage Personal Access Tokens
+- It can access resources your user can access
+- It is useful for quick scripts and local tooling
+- It can work across multiple projects where the user has access
 
 ### Project API Tokens
 
-Project API Tokens have several security advantages over personal access tokens, such as:
+Project API Tokens are scoped to one project and safer for shared automation.
 
-1. Scope limited to access resources in the project where the token was created
-1. Fine-grained permission management using RBAC (Role-based Access Control)
-1. Do not allow access to `/users` specific endpoints, such as user details, activity and invitations
+- Access is limited to resources in that project
+- RBAC controls what each token can do
+- User-level endpoints, such as `/users` details and invitations, are not included
+
+## Which token should I use
+
+Use Personal Access Tokens when:
+- You need one-off user-like access
+- A task is personal and temporary
+
+Use Project API Tokens when:
+- A service needs recurring access to one project
+- Multiple people share the automation
+- You want least-privilege production-safe access
+
+:::note
+When you can, prefer `Project API Tokens` to keep permission scope small.
+
+:::

--- a/docs/docs/api-tokens/index.md
+++ b/docs/docs/api-tokens/index.md
@@ -35,10 +35,12 @@ Project API Tokens are scoped to one project and safer for shared automation.
 ## Which token should I use
 
 Use Personal Access Tokens when:
+
 - You need one-off user-like access
 - A task is personal and temporary
 
 Use Project API Tokens when:
+
 - A service needs recurring access to one project
 - Multiple people share the automation
 - You want least-privilege production-safe access

--- a/docs/docs/api-tokens/index.md
+++ b/docs/docs/api-tokens/index.md
@@ -6,9 +6,8 @@ links:
   previous:
   next:
   guides:
-    related:
-      - api-tokens/personal-access-tokens/index
-      - api-tokens/project-api-tokens/index
+    - api-tokens/personal-access-tokens/index
+    - api-tokens/project-api-tokens/index
   featured:
 ---
 
@@ -36,12 +35,10 @@ Project API Tokens are scoped to one project and safer for shared automation.
 ## Which token should I use
 
 Use Personal Access Tokens when:
-
 - You need one-off user-like access
 - A task is personal and temporary
 
 Use Project API Tokens when:
-
 - A service needs recurring access to one project
 - Multiple people share the automation
 - You want least-privilege production-safe access

--- a/docs/docs/api-tokens/index.md
+++ b/docs/docs/api-tokens/index.md
@@ -7,8 +7,8 @@ links:
   next:
   guides:
     related:
-    - api-tokens/personal-access-tokens/index
-    - api-tokens/project-api-tokens/index
+      - api-tokens/personal-access-tokens/index
+      - api-tokens/project-api-tokens/index
   featured:
 ---
 
@@ -36,10 +36,12 @@ Project API Tokens are scoped to one project and safer for shared automation.
 ## Which token should I use
 
 Use Personal Access Tokens when:
+
 - You need one-off user-like access
 - A task is personal and temporary
 
 Use Project API Tokens when:
+
 - A service needs recurring access to one project
 - Multiple people share the automation
 - You want least-privilege production-safe access

--- a/docs/docs/api-tokens/personal-access-tokens/add-personal-access-token.md
+++ b/docs/docs/api-tokens/personal-access-tokens/add-personal-access-token.md
@@ -5,8 +5,6 @@ links:
   quickstart:
   previous: api-tokens/personal-access-tokens/list-personal-access-tokens
   next: api-tokens/personal-access-tokens/view-personal-access-token
-  guides:
-    related:
   featured:
 ---
 

--- a/docs/docs/api-tokens/personal-access-tokens/add-personal-access-token.md
+++ b/docs/docs/api-tokens/personal-access-tokens/add-personal-access-token.md
@@ -1,26 +1,39 @@
 ---
 title: Add a Personal Access Token
-intro: Learn how to create a Personal Access Token to authenticate with the Devopness API using your account's permissions.
 links:
   overview:
   quickstart:
   previous: api-tokens/personal-access-tokens/list-personal-access-tokens
   next: api-tokens/personal-access-tokens/view-personal-access-token
   guides:
-  related:
+    related:
   featured:
 ---
 
-Follow these steps to generate a new Personal Access Token:
+Create a Personal Access Token for user-level automations.
 
-1. On Devopness, in the upper-right corner of any page, click your profile icon then click `Personal Access Tokens`
-2. On the upper-right corner of the list click `ADD PERSONAL ACCESS TOKEN`
-3. Follow the prompts and click `CONFIRM`
-4. In the `Personal Access Tokens` details, the recently created `Personal Access Token` can be seen
+## Goal
 
-:::warning
+Generate a token that can do actions your user account can perform.
 
-For security reasons, tokens are only shown once at creation time.
-Be sure to copy and store the token securely, as it cannot be retrieved again.
+## Steps
+
+1. Open your user profile menu
+2. Select `Personal Access Tokens`
+3. Click `ADD PERSONAL ACCESS TOKEN`
+4. Follow the prompts and confirm
+
+## Result
+
+- A new token is created for your account
+- You can use it according to your user permissions
+
+## Common issues
+
+- You cannot see the token menu: confirm you are logged in and authorized
+- Token is not created: confirm required fields and retry
+
+:::note
+For security reasons, tokens are only shown once. Copy and store it securely.
 
 :::

--- a/docs/docs/api-tokens/personal-access-tokens/index.md
+++ b/docs/docs/api-tokens/personal-access-tokens/index.md
@@ -6,8 +6,6 @@ links:
   quickstart:
   previous: api-tokens/index
   next: api-tokens/personal-access-tokens/list-personal-access-tokens
-  guides:
-  related:
   featured:
 ---
 

--- a/docs/docs/api-tokens/personal-access-tokens/list-personal-access-tokens.md
+++ b/docs/docs/api-tokens/personal-access-tokens/list-personal-access-tokens.md
@@ -7,7 +7,7 @@ links:
   next: api-tokens/personal-access-tokens/add-personal-access-token
   guides:
     related:
-    - api-tokens/personal-access-tokens/view-personal-access-token
+      - api-tokens/personal-access-tokens/view-personal-access-token
   featured:
 ---
 

--- a/docs/docs/api-tokens/personal-access-tokens/list-personal-access-tokens.md
+++ b/docs/docs/api-tokens/personal-access-tokens/list-personal-access-tokens.md
@@ -1,17 +1,34 @@
 ---
 title: List Personal Access Tokens
-intro: Find and view all Personal Access Tokens you have created for your account.
 links:
   overview:
   quickstart:
   previous: api-tokens/personal-access-tokens/index
   next: api-tokens/personal-access-tokens/add-personal-access-token
   guides:
-  related:
+    related:
+    - api-tokens/personal-access-tokens/view-personal-access-token
   featured:
 ---
 
-Follow these steps to list all Personal Access Tokens:
+Review all Personal Access Tokens for your account.
 
-1. On Devopness, in the upper-right corner of any page, click your profile icon then click `Personal Access Tokens`
-2. The `Personal Access Tokens` list will be displayed, containing all tokens you have created.
+## Goal
+
+Find active tokens and verify which one is being used.
+
+## Steps
+
+1. Open your user profile menu
+2. Select `Personal Access Tokens`
+3. Review the token list and status
+
+## Result
+
+- You can see all personal access tokens you own
+- You can jump to view or revoke a token
+
+## Common issues
+
+- The list is empty: create a token first
+- Missing expected token: confirm you are using the right account

--- a/docs/docs/api-tokens/personal-access-tokens/list-personal-access-tokens.md
+++ b/docs/docs/api-tokens/personal-access-tokens/list-personal-access-tokens.md
@@ -6,8 +6,7 @@ links:
   previous: api-tokens/personal-access-tokens/index
   next: api-tokens/personal-access-tokens/add-personal-access-token
   guides:
-    related:
-      - api-tokens/personal-access-tokens/view-personal-access-token
+    - api-tokens/personal-access-tokens/view-personal-access-token
   featured:
 ---
 

--- a/docs/docs/api-tokens/personal-access-tokens/revoke-personal-access-token.md
+++ b/docs/docs/api-tokens/personal-access-tokens/revoke-personal-access-token.md
@@ -1,28 +1,35 @@
 ---
 title: Revoke a Personal Access Token
-intro: Revoke a Personal Access Token to immediately prevent it from being used for future requests.
 links:
   overview:
   quickstart:
   previous: api-tokens/personal-access-tokens/list-personal-access-tokens
   next: api-tokens/personal-access-tokens/add-personal-access-token
   guides:
-  related:
+    related:
+    - api-tokens/personal-access-tokens/view-personal-access-token
   featured:
 ---
 
-You should revoke a personal access token if it is no longer needed or was exposed to unauthorised access.
+Revoke a Personal Access Token immediately.
 
-:::warning
-Once revoked, a Personal Access Token **cannot be restored**.
-A revoked token will no longer work for authentication in any future requests.
-:::
+## Goal
 
-Follow these steps to revoke a Personal Access Token:
+Stop a token from being used after it is no longer needed or has been exposed.
 
-1. On Devopness, in the upper-right corner of any page, click your profile icon then click `Personal Access Tokens`
-2. The `Personal Access Tokens` list will be displayed
-3. Find the `Personal Access Token` you want to revoke and click on `Name` of the token
-4. On the upper-right corner click `REVOKE`
-5. Follow the prompts then click `REVOKE TOKEN`
-6. The revoked token will appear in the list of `Personal Access Tokens` with the status **Revoked**
+## Steps
+
+1. Open `Personal Access Tokens`
+2. Select the token you want to revoke
+3. Click `REVOKE`
+4. Confirm `REVOKE TOKEN`
+
+## Result
+
+- The token can no longer authenticate requests
+- Its status changes to revoked
+
+## Common issues
+
+- You cannot revoke it: confirm you have permission to manage the token
+- Revoked token still appears active: refresh the list

--- a/docs/docs/api-tokens/personal-access-tokens/revoke-personal-access-token.md
+++ b/docs/docs/api-tokens/personal-access-tokens/revoke-personal-access-token.md
@@ -16,6 +16,10 @@ Revoke a Personal Access Token immediately.
 
 Stop a token from being used after it is no longer needed or has been exposed.
 
+:::warning
+Revoking a token is permanent. A revoked token cannot be restored.
+:::
+
 ## Steps
 
 1. Open `Personal Access Tokens`

--- a/docs/docs/api-tokens/personal-access-tokens/revoke-personal-access-token.md
+++ b/docs/docs/api-tokens/personal-access-tokens/revoke-personal-access-token.md
@@ -7,7 +7,7 @@ links:
   next: api-tokens/personal-access-tokens/add-personal-access-token
   guides:
     related:
-    - api-tokens/personal-access-tokens/view-personal-access-token
+      - api-tokens/personal-access-tokens/view-personal-access-token
   featured:
 ---
 

--- a/docs/docs/api-tokens/personal-access-tokens/revoke-personal-access-token.md
+++ b/docs/docs/api-tokens/personal-access-tokens/revoke-personal-access-token.md
@@ -6,8 +6,7 @@ links:
   previous: api-tokens/personal-access-tokens/list-personal-access-tokens
   next: api-tokens/personal-access-tokens/add-personal-access-token
   guides:
-    related:
-      - api-tokens/personal-access-tokens/view-personal-access-token
+    - api-tokens/personal-access-tokens/view-personal-access-token
   featured:
 ---
 

--- a/docs/docs/api-tokens/personal-access-tokens/view-personal-access-token.md
+++ b/docs/docs/api-tokens/personal-access-tokens/view-personal-access-token.md
@@ -6,8 +6,7 @@ links:
   previous: api-tokens/personal-access-tokens/list-personal-access-tokens
   next: api-tokens/personal-access-tokens/revoke-personal-access-token
   guides:
-    related:
-      - api-tokens/personal-access-tokens/list-personal-access-tokens
+    - api-tokens/personal-access-tokens/list-personal-access-tokens
   featured:
 ---
 

--- a/docs/docs/api-tokens/personal-access-tokens/view-personal-access-token.md
+++ b/docs/docs/api-tokens/personal-access-tokens/view-personal-access-token.md
@@ -1,23 +1,34 @@
 ---
 title: View Personal Access Token
-intro: Learn how to access and review the details of a Personal Access Token you have created.
 links:
   overview:
   quickstart:
   previous: api-tokens/personal-access-tokens/list-personal-access-tokens
   next: api-tokens/personal-access-tokens/revoke-personal-access-token
   guides:
+    related:
+    - api-tokens/personal-access-tokens/list-personal-access-tokens
   featured:
 ---
 
-Follow these steps to view a Personal Access Token:
+Review one token's key details before using it.
 
-1. On Devopness, in the upper-right corner of any page, click your profile icon then click `Personal Access Tokens`
-2. The `Personal Access Tokens` list will be displayed
-3. Find the token you want to view and click on the `Name` of the token
-4. The token details page will show information such as:
-   - **Name**
-   - **Status**
-   - **Expiration date**
-   - **Last used date**
-   - and other relevant details.
+## Goal
+
+Confirm token identity, state, and intended usage.
+
+## Steps
+
+1. Open `Personal Access Tokens`
+2. Find the token you want to review
+3. Open it by name
+4. Confirm name, status, expiry, and last used date
+
+## Expected result
+
+- You know whether the token is valid and currently usable
+- You can decide if it should be updated or revoked
+
+## Common issues
+
+- You cannot open the token: confirm token permissions and ownership

--- a/docs/docs/api-tokens/personal-access-tokens/view-personal-access-token.md
+++ b/docs/docs/api-tokens/personal-access-tokens/view-personal-access-token.md
@@ -7,7 +7,7 @@ links:
   next: api-tokens/personal-access-tokens/revoke-personal-access-token
   guides:
     related:
-    - api-tokens/personal-access-tokens/list-personal-access-tokens
+      - api-tokens/personal-access-tokens/list-personal-access-tokens
   featured:
 ---
 

--- a/docs/docs/api-tokens/project-api-tokens/add-project-api-token.md
+++ b/docs/docs/api-tokens/project-api-tokens/add-project-api-token.md
@@ -7,7 +7,7 @@ links:
   next: api-tokens/project-api-tokens/view-project-api-token
   guides:
     related:
-    - api-tokens/project-api-tokens/list-project-api-tokens
+      - api-tokens/project-api-tokens/list-project-api-tokens
   featured:
 ---
 

--- a/docs/docs/api-tokens/project-api-tokens/add-project-api-token.md
+++ b/docs/docs/api-tokens/project-api-tokens/add-project-api-token.md
@@ -6,8 +6,7 @@ links:
   previous: api-tokens/project-api-tokens/list-project-api-tokens
   next: api-tokens/project-api-tokens/view-project-api-token
   guides:
-    related:
-      - api-tokens/project-api-tokens/list-project-api-tokens
+    - api-tokens/project-api-tokens/list-project-api-tokens
   featured:
 ---
 

--- a/docs/docs/api-tokens/project-api-tokens/add-project-api-token.md
+++ b/docs/docs/api-tokens/project-api-tokens/add-project-api-token.md
@@ -1,29 +1,41 @@
 ---
 title: Add a Project API Token
-intro: Learn how to generate a new Project API Token to enable secure, project-scoped access for automation, integrations, or scripts.
 links:
   overview:
   quickstart:
   previous: api-tokens/project-api-tokens/list-project-api-tokens
   next: api-tokens/project-api-tokens/view-project-api-token
   guides:
-  related:
+    related:
+    - api-tokens/project-api-tokens/list-project-api-tokens
   featured:
 ---
 
-Follow these steps to create a new Project API Token:
+Generate a new project-scoped token for tools and automations.
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-2. Select a `Project`
-3. Find the `API Tokens` card
-4. Click `VIEW ALL` in the `API Tokens` card to see a list of existing `API Tokens`
-5. On the upper-right corner click `ADD API TOKEN`
-6. Follow the prompts and click `CONFIRM`
-7. In the `API Tokens` details, the recently created `API Token` can be seen
+## Goal
 
-:::warning
+Create a token that can only access one project.
 
-For security reasons, tokens are only shown once at creation time.
-Be sure to copy and store the token securely, as it cannot be retrieved again.
+## Steps
+
+1. Open the target project
+2. Open `API Tokens`
+3. Click `VIEW ALL`
+4. Click `ADD API TOKEN`
+5. Follow prompts and confirm
+
+## Result
+
+- A new project API token is created
+- It can be used by automation with project-limited scope
+
+## Common issues
+
+- You cannot add token: confirm your role in the project
+- You cannot copy token now: token is shown once at creation time
+
+:::note
+Copy and store the token immediately; it cannot be retrieved later.
 
 :::

--- a/docs/docs/api-tokens/project-api-tokens/index.md
+++ b/docs/docs/api-tokens/project-api-tokens/index.md
@@ -7,7 +7,7 @@ links:
   next: api-tokens/project-api-tokens/list-project-api-tokens
   guides:
     related:
-    - api-tokens/personal-access-tokens/index
+      - api-tokens/personal-access-tokens/index
   featured:
 ---
 

--- a/docs/docs/api-tokens/project-api-tokens/index.md
+++ b/docs/docs/api-tokens/project-api-tokens/index.md
@@ -1,16 +1,28 @@
 ---
 title: Project API Tokens
-intro: Project API Tokens are used as a secure way to authenticate into Devopness API with the scope limited to a single project.
 links:
   overview:
   quickstart:
   previous: api-tokens/index
   next: api-tokens/project-api-tokens/list-project-api-tokens
   guides:
-  related:
+    related:
+    - api-tokens/personal-access-tokens/index
   featured:
 ---
 
-Project API Tokens provide RBAC (Role-based Access Control) to resources within a single project.
+Project API Tokens are scoped to one project.
 
-They allow fine grained permission management using RBAC (Role-based Access Control) and are a secure way to interact with Devopness API from external tools, automation scripts, and from any integrations that should only be allowed access to resources of a specific Devopness project.
+## About
+
+Use this token type for service-to-service and CI/CD flows where least-privilege access is required.
+
+## Why this matters
+
+- Access is limited to the selected project
+- RBAC controls what each token can do
+- User-level account data is not exposed
+
+## Next
+
+- Use [`List Project API Tokens`](/docs/api-tokens/project-api-tokens/list-project-api-tokens) to review existing tokens

--- a/docs/docs/api-tokens/project-api-tokens/index.md
+++ b/docs/docs/api-tokens/project-api-tokens/index.md
@@ -6,8 +6,7 @@ links:
   previous: api-tokens/index
   next: api-tokens/project-api-tokens/list-project-api-tokens
   guides:
-    related:
-      - api-tokens/personal-access-tokens/index
+    - api-tokens/personal-access-tokens/index
   featured:
 ---
 

--- a/docs/docs/api-tokens/project-api-tokens/list-project-api-tokens.md
+++ b/docs/docs/api-tokens/project-api-tokens/list-project-api-tokens.md
@@ -7,7 +7,7 @@ links:
   next: api-tokens/project-api-tokens/add-project-api-token
   guides:
     related:
-    - api-tokens/project-api-tokens/add-project-api-token
+      - api-tokens/project-api-tokens/add-project-api-token
   featured:
 ---
 

--- a/docs/docs/api-tokens/project-api-tokens/list-project-api-tokens.md
+++ b/docs/docs/api-tokens/project-api-tokens/list-project-api-tokens.md
@@ -6,8 +6,7 @@ links:
   previous: api-tokens/project-api-tokens/index
   next: api-tokens/project-api-tokens/add-project-api-token
   guides:
-    related:
-      - api-tokens/project-api-tokens/add-project-api-token
+    - api-tokens/project-api-tokens/add-project-api-token
   featured:
 ---
 

--- a/docs/docs/api-tokens/project-api-tokens/list-project-api-tokens.md
+++ b/docs/docs/api-tokens/project-api-tokens/list-project-api-tokens.md
@@ -1,20 +1,30 @@
 ---
 title: List Project API Tokens
-intro: Find and view all Project API Tokens you have access to within a specific project.
 links:
   overview:
   quickstart:
   previous: api-tokens/project-api-tokens/index
   next: api-tokens/project-api-tokens/add-project-api-token
   guides:
-  related:
+    related:
+    - api-tokens/project-api-tokens/add-project-api-token
   featured:
 ---
 
-Follow these steps to list all Project API Tokens:
+Find all project-scoped API Tokens for one project.
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-2. Select a `Project`
-3. Find the `API Tokens` card
-4. Click `VIEW ALL` in the `API Tokens` card to see a list of existing `API Tokens`
-5. The `API Tokens` list will be displayed, containing all API tokens you have access to.
+## Goal
+
+Pick the right token for a given automation run or service.
+
+## Steps
+
+1. Open the target project
+2. Open `API Tokens`
+3. Click `VIEW ALL`
+4. Review the token list
+
+## Result
+
+- You can see token status, scope, and usage per token
+- You can open one token for details

--- a/docs/docs/api-tokens/project-api-tokens/revoke-project-api-token.md
+++ b/docs/docs/api-tokens/project-api-tokens/revoke-project-api-token.md
@@ -16,6 +16,10 @@ Revoke a project token you no longer trust or need.
 
 Stop token authentication for that project immediately.
 
+:::warning
+Revoking a token is permanent. A revoked token cannot be restored.
+:::
+
 ## Steps
 
 1. Open the target project

--- a/docs/docs/api-tokens/project-api-tokens/revoke-project-api-token.md
+++ b/docs/docs/api-tokens/project-api-tokens/revoke-project-api-token.md
@@ -7,7 +7,7 @@ links:
   next: api-tokens/project-api-tokens/add-project-api-token
   guides:
     related:
-    - api-tokens/project-api-tokens/view-project-api-token
+      - api-tokens/project-api-tokens/view-project-api-token
   featured:
 ---
 

--- a/docs/docs/api-tokens/project-api-tokens/revoke-project-api-token.md
+++ b/docs/docs/api-tokens/project-api-tokens/revoke-project-api-token.md
@@ -1,30 +1,34 @@
 ---
 title: Revoke a Project API Token
-intro: Revoke a Project API Token to immediately prevent it from being used for future requests.
 links:
   overview:
   quickstart:
   previous: api-tokens/project-api-tokens/view-project-api-token
   next: api-tokens/project-api-tokens/add-project-api-token
   guides:
-  related:
+    related:
+    - api-tokens/project-api-tokens/view-project-api-token
   featured:
 ---
 
-:::warning
+Revoke a project token you no longer trust or need.
 
-Once revoked, a Project API Token **cannot be restored**.
+## Goal
 
-A revoked token will no longer work for authentication in any future requests.
-:::
+Stop token authentication for that project immediately.
 
-Follow these steps to revoke a Project API Token:
+## Steps
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-2. Select a `Project`
-3. Find the `API Tokens` card
-4. Click `VIEW ALL` in the `API Tokens` card to see a list of existing `API Tokens`
-5. Find the `API Token` you want to revoke and click on `Name` of the token
-6. On the upper-right corner click `REVOKE`
-7. Follow the prompts then click `REVOKE TOKEN`
-8. The revoked token will appear in the list of `API Tokens` with the status **Revoked**
+1. Open the target project
+2. Open `API Tokens` and `VIEW ALL`
+3. Select the token to revoke
+4. Click `REVOKE` and confirm
+
+## Result
+
+- The token stops authenticating requests
+- The list updates with revoked status
+
+## Common issues
+
+- You cannot revoke the token: confirm your permissions in the project

--- a/docs/docs/api-tokens/project-api-tokens/revoke-project-api-token.md
+++ b/docs/docs/api-tokens/project-api-tokens/revoke-project-api-token.md
@@ -6,8 +6,7 @@ links:
   previous: api-tokens/project-api-tokens/view-project-api-token
   next: api-tokens/project-api-tokens/add-project-api-token
   guides:
-    related:
-      - api-tokens/project-api-tokens/view-project-api-token
+    - api-tokens/project-api-tokens/view-project-api-token
   featured:
 ---
 

--- a/docs/docs/api-tokens/project-api-tokens/view-project-api-token.md
+++ b/docs/docs/api-tokens/project-api-tokens/view-project-api-token.md
@@ -7,7 +7,7 @@ links:
   next: api-tokens/project-api-tokens/revoke-project-api-token
   guides:
     related:
-    - api-tokens/project-api-tokens/list-project-api-tokens
+      - api-tokens/project-api-tokens/list-project-api-tokens
   featured:
 ---
 

--- a/docs/docs/api-tokens/project-api-tokens/view-project-api-token.md
+++ b/docs/docs/api-tokens/project-api-tokens/view-project-api-token.md
@@ -6,8 +6,7 @@ links:
   previous: api-tokens/project-api-tokens/list-project-api-tokens
   next: api-tokens/project-api-tokens/revoke-project-api-token
   guides:
-    related:
-      - api-tokens/project-api-tokens/list-project-api-tokens
+    - api-tokens/project-api-tokens/list-project-api-tokens
   featured:
 ---
 

--- a/docs/docs/api-tokens/project-api-tokens/view-project-api-token.md
+++ b/docs/docs/api-tokens/project-api-tokens/view-project-api-token.md
@@ -1,27 +1,30 @@
 ---
 title: View Project API Token
-intro: Learn how to access and review the details of a Project API Token within a specific project.
 links:
   overview:
   quickstart:
   previous: api-tokens/project-api-tokens/list-project-api-tokens
   next: api-tokens/project-api-tokens/revoke-project-api-token
   guides:
-  related:
+    related:
+    - api-tokens/project-api-tokens/list-project-api-tokens
   featured:
 ---
 
-Follow these steps to view a Project API Token:
+Review one project token's settings and status.
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-2. Select a `Project`
-3. Find the `API Tokens` card
-4. Click `VIEW ALL` in the `API Tokens` card to see a list of existing `API Tokens`
-5. Find the `API Token` you want to view and click on the `Name` of the token
-6. The `API Token` page will be displayed, showing information such as:
-   - **Name**
-   - **Status**
-   - **Role**
-   - **Expiration date**
-   - **Last used date**
-   - and other relevant details.
+## Goal
+
+Validate what a token can access before using it in production.
+
+## Steps
+
+1. Open the target project
+2. Open `API Tokens` and `VIEW ALL`
+3. Select the token you want to inspect
+4. Review name, role, expiration, and usage details
+
+## Result
+
+- You can confirm whether the token has the right scope
+- You can decide whether to keep it or revoke it

--- a/docs/docs/authoring-guidelines.md
+++ b/docs/docs/authoring-guidelines.md
@@ -1,0 +1,130 @@
+---
+title: Devopness documentation authoring guidelines
+---
+
+Devopness docs are used by people deploying infrastructure and apps, and by AI agents that support that work.
+This guide is for human contributors, including:
+
+- developers
+- team leads
+- founders
+
+Use this guide for writing style, structure, and clarity across `docs/docs/*`.
+It helps keep docs clear for readers and easy to process by documentation tools and AI agents.
+
+## Scope
+
+- Apply this guide to all files under `docs/docs/`
+- Goal: clear pages, faster scanning, and predictable outcomes
+
+## 1) Document structure
+
+### Index pages (`index.md`)
+
+- Keep index pages conceptual
+- Make them complete enough for a first-time visitor: what the concept is, when to use it, and how it relates
+- Do not make concept pages "too short": include a brief introduction + 2-4 bullets that add context, examples, and practical use cases
+- Recommended sections:
+  - About
+  - Who this is for
+  - Why this exists
+  - Relationship to other concepts
+  - Start here / Next
+- Do not use procedural `Goal`, `Steps`, or `Common issues` on index pages
+
+### Operation pages (`add-*`, `edit-*`, `list-*`, `view-*`, `archive-*`, `deploy-*`, etc.)
+
+- Keep operation pages outcome-driven
+- Recommended sections:
+  - Goal (or About)
+  - Who should use this
+  - You need
+  - Steps
+  - Expected result
+  - Common issues
+  - Next
+- Group steps by decision and outcome first, not by UI positions
+
+## 2) Intro and frontmatter behavior
+
+- Do not add `intro` in frontmatter. Write page context in the markdown body
+- `index.md`: use the first paragraph for one conceptual sentence
+- Operation pages: use the first paragraph to state the outcome of the action
+- Keep one clear meaning for each core concept:
+  - organization
+  - project
+  - environment
+  - team
+  - role
+  - permission
+  - etc
+
+## 3) Language rules
+
+- Use clear verbs: set, create, add, configure, select, verify, confirm, save
+- Avoid abstract jargon and enterprise language
+- Use plain English and familiar words
+- Use `access` for user-facing outcomes and `permission(s)` for RBAC rules
+- Avoid UI position phrases unless they are required by the product design
+  - Examples: top bar, upper-right, lower-left
+- Keep button labels exactly as they appear in the UI
+- Prefer `deploy` when writing actions tied to release, rollout, or platform operations
+- Use `ship` only for high-level, product-level outcomes outside UI action language
+
+## 4) Decision and clarity
+
+- Lead with outcomes:
+  - what people can do next
+  - what changes after the action
+  - what to check next
+- Add decision support where needed:
+  - when to start a new project
+  - when to split environments
+  - when to use one token type vs another
+- Keep examples concrete:
+  - API, web app, worker, background queue, production flow
+- Explain the result before long detail
+
+## 5) LLM-friendly format
+
+- Keep sections predictable and clear
+- Prefer clarity over extreme brevity; write enough detail so a newcomer can act without asking follow-up questions
+- Keep sentences short and direct
+- End each operation page with a clear expected result
+- Keep naming, meaning, and sequence consistent across sibling pages
+
+## 6) List style and punctuation
+
+- For short bullet items and checklist items, skip the final period
+- Use a period only for full sentences with more than one clause
+- Keep list length short
+- Start every checklist item with action verbs when possible
+- Do not add trailing colons to Markdown headings (`## About:` is invalid style; use `## About`)
+- Use colons in prose only when they introduce examples, ranges, or key/value clauses, not as heading punctuation
+
+## 7) Minimum checklist (every doc change)
+
+- [ ] one clear outcome
+- [ ] simple words for core concepts
+- [ ] one verification sentence
+- [ ] one common issues section on operation pages
+- [ ] links to next action or next relevant doc
+
+## 8) What to include
+
+- Document user tasks and outcomes, not menu paths
+- For concept pages, keep enough context for first-time readers and discovery (including practical examples and decision signals)
+- Add what changes after each action
+- Add one practical example for each major concept
+- Add what to verify after the action
+
+## 9) What to avoid
+
+- Avoid repeating API validation details already shown by the API
+- Avoid long policy essays in setup guides
+- Avoid abstract terms without a concrete example
+
+## 10) Canonical location
+
+- This file is the canonical guide for documentation writing
+- Keep `/docs/docs/README.md` for frontmatter, markdown, and metadata rules

--- a/docs/docs/cronjobs/add-cronjob.md
+++ b/docs/docs/cronjobs/add-cronjob.md
@@ -1,21 +1,39 @@
 ---
 title: Add a Cron Job
-intro: Add a Cron Job to automate your server and application management routine with scheduled tasks running automatically at a specified frequency.
 links:
   overview:
   quickstart:
   previous:
   next: cronjobs/edit-cronjob
   guides:
-  related:
+    related:
   featured:
 required_permissions:
   - cronjob:create
 ---
 
-1. On Devopness, navigate to a project, then select an environment
-1. Find the `Cron Jobs` card
-1. Click `View` in the `Cron Jobs` card to see a list of existing `Cron Jobs`
-1. On the upper-right corner of the list, click `ADD CRON JOB`
-1. Follow the prompts then click `CONFIRM`
-1. In the `Cron Job` details view, the recently created `Cron Job` details can be seen
+Add a cron job to run a recurring task.
+
+## Goal
+
+Automate a schedule-based operation safely from the UI.
+
+## Steps
+
+1. Open the environment where the job should run
+2. Open the `Cron Jobs` card
+3. Click `View`
+4. Click `ADD CRON JOB`
+5. Set name, schedule, and command
+6. Save
+
+## Expected result
+
+- The new cron job appears in the cron jobs list
+- The schedule starts according to the defined interval
+
+## Common issues
+
+- Missing permissions for cron jobs
+- Invalid cron expression
+- Job command references unavailable resource

--- a/docs/docs/cronjobs/add-cronjob.md
+++ b/docs/docs/cronjobs/add-cronjob.md
@@ -5,8 +5,7 @@ links:
   quickstart:
   previous:
   next: cronjobs/edit-cronjob
-  guides:
-    related:
+  guides: []
   featured:
 required_permissions:
   - cronjob:create

--- a/docs/docs/cronjobs/edit-cronjob.md
+++ b/docs/docs/cronjobs/edit-cronjob.md
@@ -1,22 +1,37 @@
 ---
 title: Edit a Cron Job
-intro: Edit a Cron Job to modify the schedule, command, or other settings of an existing Cron Job.
 links:
   overview:
   quickstart:
   previous: cronjobs/add-cronjob
   next: cronjobs/remove-cronjob
   guides:
-  related:
+    related:
   featured:
 required_permissions:
   - cronjob:update
 ---
 
-1. On Devopness, navigate to a project, then select an environment
-1. Find the `Cron Jobs` card
-1. Click `View` in the `Cron Jobs` card to see a list of existing `Cron Jobs`
-1. In the list of Cron Jobs, find the cron job you want to edit and click the `NAME` of the cron job
-1. On the Cron Job details page, click `EDIT` in the upper-right corner
-1. Follow the prompts then click `CONFIRM`
-1. In the `Cron Job` details view, the recently updated `Cron Job` details can be seen
+Change schedule, command, or metadata for one cron job.
+
+## Goal
+
+Adjust automation behavior without recreating the job.
+
+## Steps
+
+1. Open the environment with the cron job
+2. Open `Cron Jobs`
+3. Open the target cron job
+4. Click `EDIT`
+5. Update settings and confirm
+
+## Expected result
+
+- The cron job reflects the new settings
+- Next executions follow the updated schedule
+
+## Common issues
+
+- You do not see edit action: confirm `cronjob:update` permission
+- Schedule parse error: verify the cron expression

--- a/docs/docs/cronjobs/edit-cronjob.md
+++ b/docs/docs/cronjobs/edit-cronjob.md
@@ -5,8 +5,7 @@ links:
   quickstart:
   previous: cronjobs/add-cronjob
   next: cronjobs/remove-cronjob
-  guides:
-    related:
+  guides: []
   featured:
 required_permissions:
   - cronjob:update

--- a/docs/docs/cronjobs/index.md
+++ b/docs/docs/cronjobs/index.md
@@ -1,6 +1,5 @@
 ---
 title: Cron Jobs
-intro: Many applications rely on scheduled tasks to perform recurring actions, such as sending notifications or cleaning up data. Devopness simplifies the management of these tasks by providing a centralized platform, allowing you to configure, monitor, and maintain all scheduled jobs in one place.
 links:
   overview:
   quickstart:
@@ -10,3 +9,11 @@ links:
   related:
   featured:
 ---
+
+## About
+
+Cron jobs let you automate recurring actions for both applications and servers.
+
+Use cron jobs in Devopness to schedule routine work like sending notifications, running maintenance scripts, cleaning up old files, and refreshing app or server resources.
+
+You can configure, monitor, and maintain all your scheduled jobs from one place.

--- a/docs/docs/cronjobs/remove-cronjob.md
+++ b/docs/docs/cronjobs/remove-cronjob.md
@@ -1,22 +1,37 @@
 ---
 title: Remove a Cron Job
-intro: Remove a Cron Job when it is no longer needed.
 links:
   overview:
   quickstart:
   previous: cronjobs/edit-cronjob
   next:
   guides:
-  related:
+    related:
   featured:
 required_permissions:
   - cronjob:delete
 ---
 
-1. On Devopness, navigate to a project, then select an environment
-1. Find the `Cron Jobs` card
-1. Click `View` in the `Cron Jobs` card to see a list of existing `Cron Jobs`
-1. In the list of Cron Jobs, find the cron job you want to remove and click the `NAME` of the cron job
-1. On the upper-right corner of the cron job details view, click `REMOVE`
-1. Follow the prompts then click `REMOVE CRON JOB`
-1. In the list of Cron Jobs, the recently removed `Cron Job` will be gone
+Remove a cron job when you no longer need scheduled execution.
+
+## Goal
+
+Stop and delete a recurring automation cleanly.
+
+## Steps
+
+1. Open the environment with the cron job
+2. Open `Cron Jobs`
+3. Open the cron job to remove
+4. Click `REMOVE`
+5. Confirm `REMOVE CRON JOB`
+
+## Expected result
+
+- The cron job disappears from the list
+- No new executions will be scheduled from this job
+
+## Common issues
+
+- You cannot remove the job: confirm delete permissions
+- Removal is blocked because of background state

--- a/docs/docs/cronjobs/remove-cronjob.md
+++ b/docs/docs/cronjobs/remove-cronjob.md
@@ -5,8 +5,7 @@ links:
   quickstart:
   previous: cronjobs/edit-cronjob
   next:
-  guides:
-    related:
+  guides: []
   featured:
 required_permissions:
   - cronjob:delete

--- a/docs/docs/environments/add-environment.md
+++ b/docs/docs/environments/add-environment.md
@@ -1,27 +1,49 @@
 ---
 title: Add an Environment
-intro: Add environments to manage the different stages of your application lifecycle or control infrastructure resources and software versions for individual customers.
 links:
   overview:
   quickstart:
   previous: projects/add-project
-  next: servers/add-server
+  next: environments/list-environments
   guides:
-  related:
+    related:
+    - environments/list-environments
+    - environments/remove-environment
   featured:
 ---
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-1. Select a `Project`
-1. Find the `Environments` card
-1. Click `View` in the `Environments` card to see a list of existing `Environments`
-1. On the upper-right corner click `ADD ENVIRONMENT`
-1. Provide a name to the `Environment`
-1. Choose the `Environment Type`
-1. Click `CONFIRM`
+Create a new environment to separate release flow and resources.
 
-Notes:
+## Goal
 
-- Use `Production` for live customer traffic.
-- If you started with a single environment (for example `Demo`) and do not need separation yet, you can keep using it while you get started.
-- When you are ready to separate production, add a new `Production` environment and deploy your applications there.
+Prepare one stage for test, staging, production, or custom deployment flow.
+
+## Who should use this
+
+- Developers creating initial project structure
+- Team leads separating release flows
+
+## You need
+
+- Permission to add environments in the target project
+- A project selected in the correct organization
+
+## Steps
+
+1. Go to the project where the environment should live
+2. Go to `Environments`
+3. Select `Add Environment`
+4. Set a clear environment name
+5. Set the environment type
+6. Save
+
+## Expected result
+
+- The environment appears in the environments list
+- You can manage resources and deployments under that environment
+
+## Common issues
+
+- You do not see `Add Environment`: check your project permissions
+- Environment name is already used in this project
+- You do not have enough permissions to save changes

--- a/docs/docs/environments/add-environment.md
+++ b/docs/docs/environments/add-environment.md
@@ -7,8 +7,8 @@ links:
   next: environments/list-environments
   guides:
     related:
-    - environments/list-environments
-    - environments/remove-environment
+      - environments/list-environments
+      - environments/remove-environment
   featured:
 ---
 

--- a/docs/docs/environments/add-environment.md
+++ b/docs/docs/environments/add-environment.md
@@ -6,9 +6,8 @@ links:
   previous: projects/add-project
   next: environments/list-environments
   guides:
-    related:
-      - environments/list-environments
-      - environments/remove-environment
+    - environments/list-environments
+    - environments/remove-environment
   featured:
 ---
 

--- a/docs/docs/environments/archive-environment.md
+++ b/docs/docs/environments/archive-environment.md
@@ -5,8 +5,7 @@ links:
   quickstart:
   previous:
   next:
-  guides:
-    related:
+  guides: []
   featured:
 ---
 

--- a/docs/docs/environments/archive-environment.md
+++ b/docs/docs/environments/archive-environment.md
@@ -1,34 +1,54 @@
 ---
 title: Archive an Environment
-intro: You can archive an environment to make it read-only for all users as a way to indicate that it's no longer actively maintained. When an environment is archived all its data is preserved, including the environment settings, team memberships and environment resources. Archived environments can be unarchived at any time.
 links:
   overview:
   quickstart:
   previous:
   next:
   guides:
-  related:
+    related:
   featured:
 ---
 
+Pause an environment and keep all setup and history.
+
+## Goal
+
+Keep historical environments visible while preventing active changes.
+
+## Who should use this
+
+- Project owners with many environments
+- Teams freezing old release flows
+
+## You need
+
+- Permission to archive environments
+- The target environment to archive
+
+## Steps
+
+1. Go to the project and choose the environment to pause
+2. Open environment settings
+3. Go to `Archived environments`
+4. Confirm archive
+
+## Expected result
+
+- The environment becomes read-only
+- Settings, history, and team memberships remain preserved
+
+## Common issues
+
+- You cannot archive: check for resources that still need manual cleanup
+- You do not have permission to archive this environment
+
 :::note
-
-Archiving an environment does not remove its cloud resources from the corresponding cloud providers where they were provisioned. For cost savings, if an environment has cloud resources that are no longer needed, it's recommended that you remove the resources using Devopness **before** archiving an environment.
-
+Archiving does not remove cloud resources.
+Remove unused resources before archive to avoid extra cost.
 :::
 
 :::note
-
-Archived environments can only be accessible, in read-only mode, by the user who owns the project to which the environment belongs to.
-
-The project owner can unarchive an archived environment, making it active and accessible to other team members. For more information, see [/docs/environments/unarchive-environment]
-
+Archived environments are read-only.
+Only project owners can restore them.
 :::
-
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-1. In the list of `Projects` find the Project with the Team you want to manage and click View
-1. Click `View` in the `Environments` card to see a list of existing `Environments`
-1. Find the `Environment` you want to archive and click `View`
-1. On the upper-right corner of the `Environment` resources list, click `SETTINGS`
-1. Select the option `Archived environments`
-1. Follow the instructions in the form then click `Archive`

--- a/docs/docs/environments/find-archived-environment.md
+++ b/docs/docs/environments/find-archived-environment.md
@@ -1,23 +1,38 @@
 ---
 title: Find an Archived Environment
-intro: Sometimes you may need to access the details of an archived environment or see a list of environments in a project that have been archived. You can access details of all archived environments in a project owned by you.
 links:
   overview:
   quickstart:
   previous:
   next:
   guides:
-  related:
+    related:
+    - environments/list-environments
   featured:
 ---
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-1. Select a `Project`
-1. Find the `Environments` card
-1. On the upper-left corner click `Active environments` to view a list of options
-1. Select the option `Archived environments`
+Find environments that are not currently active.
 
-- A list of archived environments will be displayed
+## Goal
 
-1. Find the archived environment you want to inspect and click `View`
-1. The `Environment` resources list will be displayed containing all the environment's resources
+Locate archived environments and review their resources when needed.
+
+## Who should use this
+
+- Teams needing context on past environments
+
+## Steps
+
+1. Go to the project you want to inspect
+2. Open **Environments**
+3. Switch to `Archived environments`
+
+## Expected result
+
+- Archived environments are listed separately
+- You can review one archived environment before restoring or deleting
+
+## Common issues
+
+- The archived list is empty: confirm the environment is archived first
+- You cannot view details: confirm your role and permission set

--- a/docs/docs/environments/find-archived-environment.md
+++ b/docs/docs/environments/find-archived-environment.md
@@ -7,7 +7,7 @@ links:
   next:
   guides:
     related:
-    - environments/list-environments
+      - environments/list-environments
   featured:
 ---
 

--- a/docs/docs/environments/find-archived-environment.md
+++ b/docs/docs/environments/find-archived-environment.md
@@ -6,8 +6,7 @@ links:
   previous:
   next:
   guides:
-    related:
-      - environments/list-environments
+    - environments/list-environments
   featured:
 ---
 

--- a/docs/docs/environments/index.md
+++ b/docs/docs/environments/index.md
@@ -1,6 +1,5 @@
 ---
 title: Environments
-intro: Environments define the stages inside a project.
 links:
   overview:
   quickstart:
@@ -13,49 +12,52 @@ links:
   featured:
 ---
 
+Environments define the deployment stages and runtime target for one project.
+
 ## About
 
-Environments are named work areas inside one project.
-They are usually `Development`, `Staging`, and `Production`.
-Each environment holds apps, servers, and settings used in that stage.
+Use environments to separate deployment flow, resource settings, and access levels inside one project.
+
+Each environment is a named work area in one project.
+Most teams start with `Production`, then add `Development` and `Staging`.
+Each environment has its own credentials, resources, deployment settings, and team access.
 
 ## Start here
 
-- Confirm you are in the right project.
-- Create a first `Production` environment.
-- Add `Development` and `Staging` when you need separate stages.
-- Add client or hotfix environments only when needed.
+- Confirm you are in the right project
+- Create a first `Production` environment
+- Add `Development` and `Staging` when you need separate stages
+- Add client or hotfix environments only when needed
+  - Example: a security hotfix environment with separate credentials
+  - Example: a staging environment for demoing work in progress
 
 ## When to split environments
 
 Start with one `Production` environment while validating the first release.
-Add more environments when isolation is needed for one of these reasons:
+Split environments when you need stronger isolation:
 
-- separate release flow (`Development`, `Staging`, `Production`)
-- different credentials, web domains, deployment permissions;
-- temporary client-specific work (or hotfix) that should not affect ongoing production releases.
+- Release moves through separate stages (`Development`, `Staging`, `Production`)
+- Different credentials, web domains, and deployment permissions
+- Temporary client-specific work or hotfix work that should not affect ongoing production releases
+- Different infrastructure per team, region, or compliance requirement
 
 ## Examples
 
 ### Product company / Startup
 
-- Start with one project in `Production` if you are validating a first version.
-- Add `Development`, `Staging`, or custom environments as the team grows.
+- Start with one project in `Production` if you are validating a first version
+- Add `Development`, `Staging`, or custom environments as the team grows
+- Use each environment to test before moving work to production
 
 ### Agency or client specific custom software
 
-- Start with your organization and one project per client.
-- One project per client can include `Production`, `Staging`, and custom environments.
-- Keep each client’s workflow separate from the others.
+- Start with your organization and one project per client
+- One project per client can include `Production`, `Staging`, and custom environments
+- Keep each client’s workflow separate from the others
+- Use custom environments for one-off client changes without touching other releases
 
 ## Why this matters
 
-- It reduces accidental changes across stages.
-- It makes it easier to decide what to test and deploy next.
-- It lets teams set safer access per stage.
-
-## Common issues
-
-- You added too many environments too soon.
-- You can no longer tell which environment is used for what.
-- A production-safe path should use separate stages for risky changes.
+- It reduces accidental changes across stages
+- It makes it easier to decide what to test and deploy next
+- It lets teams set safer access per stage

--- a/docs/docs/environments/list-environments.md
+++ b/docs/docs/environments/list-environments.md
@@ -7,8 +7,8 @@ links:
   next: environments/view-environment
   guides:
     related:
-    - environments/add-environment
-    - environments/find-archived-environment
+      - environments/add-environment
+      - environments/find-archived-environment
   featured:
 ---
 

--- a/docs/docs/environments/list-environments.md
+++ b/docs/docs/environments/list-environments.md
@@ -6,9 +6,8 @@ links:
   previous:
   next: environments/view-environment
   guides:
-    related:
-      - environments/add-environment
-      - environments/find-archived-environment
+    - environments/add-environment
+    - environments/find-archived-environment
   featured:
 ---
 

--- a/docs/docs/environments/list-environments.md
+++ b/docs/docs/environments/list-environments.md
@@ -1,20 +1,45 @@
 ---
 title: List Environments
-intro: Find and view details of project environments you have access to.
 links:
   overview:
   quickstart:
   previous:
-  next:
+  next: environments/view-environment
   guides:
-  related:
+    related:
     - environments/add-environment
     - environments/find-archived-environment
   featured:
 ---
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-1. Select a `Project`
-1. Find the `Environments` card
-1. Click `View` in the `Environments` card to see a list of existing `Environments`
-1. The `Environments` list will be displayed, containing all environments you have access to.
+Find and review environments you can use for deployments and management.
+
+## Goal
+
+Select the right environment before adding resources or making changes.
+
+## Who should use this
+
+- Engineers checking current environment setup
+- Teams managing multi-stage release flows
+
+## Steps
+
+1. Select the project you want to work with
+2. Open `Environments`
+3. Review the environment list and their types
+4. Select one environment to continue
+
+## Expected result
+
+- You can see available environments with names and roles
+- You can open the chosen environment for details
+
+## Common issues
+
+- Empty list: confirm your role allows environment visibility
+- Wrong project selected: switch to the intended project
+
+## Next
+
+- Open [`View Environment`](/docs/environments/view-environment)

--- a/docs/docs/environments/remove-environment.md
+++ b/docs/docs/environments/remove-environment.md
@@ -1,0 +1,54 @@
+---
+title: Remove an Environment
+links:
+  overview:
+  quickstart:
+  previous: environments/view-environment
+  next: environments/list-environments
+  guides:
+    - environments/list-environments
+    - environments/archive-environment
+  related:
+  featured:
+---
+
+Delete an environment when you no longer need that deployment stage.
+
+## Goal
+
+Clean up old stages and stop working from it after deployment flow changes.
+
+Warning:
+Removed environments no longer keep an active deployment target.
+
+## Who should use this
+
+- Project owners
+- Team members with environment delete permission
+
+## You need
+
+- Permission to edit and remove environments
+- A target environment that is safe to delete
+
+## Steps
+
+1. Go to the environment you want to remove
+2. Go to environment settings
+3. Select `Remove Environment`
+4. Confirm removal
+
+## Result
+
+- The environment no longer appears in the environment list
+- The environment is no longer deployable until it is recreated
+
+## Common issues
+
+- Remove is disabled: check if there are active resources still linked to the environment
+- You do not have permission to remove this environment: ask a project owner for access
+- You need one environment for current workload: remove only after creating a replacement
+
+## Next
+
+- Use [`List Environments`](/docs/environments/list-environments) to continue with the remaining stages

--- a/docs/docs/environments/remove-environment.md
+++ b/docs/docs/environments/remove-environment.md
@@ -18,7 +18,10 @@ Delete an environment when you no longer need that deployment stage.
 
 Clean up old stages and stop working from it after deployment flow changes.
 
-Warning:
+:::warning
+Removing this environment is permanent. Confirm this stage is no longer needed before you continue.
+:::
+
 Removed environments no longer keep an active deployment target.
 
 ## Who should use this

--- a/docs/docs/environments/team-memberships/add-team-membership.md
+++ b/docs/docs/environments/team-memberships/add-team-membership.md
@@ -1,26 +1,45 @@
 ---
 title: Add team membership
-intro: Set team memberships to give team members permissions to access and manage an environment and its resources based on the assigned role.
 links:
-  overview: Project owners can establish team memberships, granting access to team members based on the assigned role.
+  overview:
   quickstart:
   previous: environments/team-memberships/index
-  next:
+  next: environments/team-memberships/list-team-memberships
   guides:
-  related:
+    related:
   featured:
 ---
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-1. Select a `Project`
-1. Find the `Environments` card
-1. Click `View` in the `Environments` card to see a list of existing `Environments`
-1. Find the `Environment` you want to add a team and click `View`
-1. On the upper-right corner of the `Environment` resources list, click `TEAM MEMBERSHIPS`
-1. On the upper-right corner of the `Team memberships` list, click `ADD TEAM MEMBERSHIP`
-1. Select a `Team`
-1. Assign a `Role` to the team to grant team members permissions on the environment
-   - To check a role's details, please follow the guide [/docs/roles/view-role]
-   - If no role listed satisfies the permissions needed for the team, please follow the guide [/docs/roles/add-role]
-1. Click `CONFIRM`
-   - In the `Team memberships` list, the recently created `Team membership` can be seen
+Add one team to an environment with a role.
+
+## Goal
+
+Grant team access to environment resources.
+
+## Who should use this
+
+- Project owners configuring environment access
+
+## You need
+
+- Project roles and team memberships available
+- Permission to manage team memberships
+
+## Steps
+
+1. Go to the environment that needs access
+2. Open `TEAM MEMBERSHIPS`
+3. Select `ADD TEAM MEMBERSHIP`
+4. Choose a team
+5. Choose a role
+6. Save
+
+## Expected result
+
+- The team can access the environment based on role
+- The new membership appears in the list
+
+## Common issues
+
+- Role not sufficient: check role details and permissions
+- Team not listed: verify team is created in the project

--- a/docs/docs/environments/team-memberships/add-team-membership.md
+++ b/docs/docs/environments/team-memberships/add-team-membership.md
@@ -9,11 +9,11 @@ links:
   featured:
 ---
 
-Add a team to an environment with a role.
+Add a team to an environment with a role so team members can collaborate with shared access.
 
 ## Goal
 
-Grant a team access to an environment using a role.
+Grant all members of the team the same access to that environment through one role assignment.
 
 ## Who should use this
 

--- a/docs/docs/environments/team-memberships/add-team-membership.md
+++ b/docs/docs/environments/team-memberships/add-team-membership.md
@@ -5,8 +5,7 @@ links:
   quickstart:
   previous: environments/team-memberships/index
   next: environments/team-memberships/list-team-memberships
-  guides:
-    related:
+  guides: []
   featured:
 ---
 

--- a/docs/docs/environments/team-memberships/add-team-membership.md
+++ b/docs/docs/environments/team-memberships/add-team-membership.md
@@ -1,19 +1,19 @@
 ---
-title: Add team membership
+title: Add a Team Membership
 links:
   overview:
   quickstart:
-  previous: environments/team-memberships/index
+  previous: environments/team-memberships/list-team-memberships
   next: environments/team-memberships/list-team-memberships
   guides: []
   featured:
 ---
 
-Add one team to an environment with a role.
+Add a team to an environment with a role.
 
 ## Goal
 
-Grant team access to environment resources.
+Grant a team access to an environment using a role.
 
 ## Who should use this
 
@@ -21,13 +21,13 @@ Grant team access to environment resources.
 
 ## You need
 
-- Project roles and team memberships available
+- Team and role created in the organization
 - Permission to manage team memberships
 
 ## Steps
 
 1. Go to the environment that needs access
-2. Open `TEAM MEMBERSHIPS`
+2. Open `TEAM MEMBERSHIPS` (project admins can find it from the project tab; environment admins in environment details)
 3. Select `ADD TEAM MEMBERSHIP`
 4. Choose a team
 5. Choose a role
@@ -41,4 +41,4 @@ Grant team access to environment resources.
 ## Common issues
 
 - Role not sufficient: check role details and permissions
-- Team not listed: verify team is created in the project
+- Team not listed: verify team is created in the organization

--- a/docs/docs/environments/team-memberships/index.md
+++ b/docs/docs/environments/team-memberships/index.md
@@ -6,10 +6,9 @@ links:
   previous:
   next:
   guides:
-    related:
-      - teams/index
-      - environments/index
-      - roles/index
+    - teams/index
+    - environments/index
+    - roles/index
   featured:
 ---
 

--- a/docs/docs/environments/team-memberships/index.md
+++ b/docs/docs/environments/team-memberships/index.md
@@ -1,23 +1,41 @@
 ---
 title: Team Memberships
-intro: Team Memberships are the primary way to link a Team to a specific Environment, granting permissions based on an assigned Role.
 links:
   overview:
   quickstart:
   previous:
   next:
   guides:
-  related:
+    related:
     - teams/index
     - environments/index
     - roles/index
   featured:
 ---
 
-Each membership acts as a link between three key components:
+Team Memberships link teams to one environment with a role.
 
-1.  **Team:** The group of users receiving access.
-2.  **Environment:** The resource being accessed.
-3.  **Role:** The set of permissions the team will have within that specific environment.
+## About
 
-Before you can create a team membership, you must ensure your project has the necessary teams and roles already configured.
+Use membership to define who can access an environment and what they can do.
+
+## Who should use this
+
+- Project owners managing team-level environment access
+- Team leads assigning permissions per environment
+
+## Key terms
+
+- **Team**: users who receive access
+- **Environment**: the resource being accessed
+- **Role**: what that team can do in the environment
+
+## Expected result
+
+- Teams can be managed with explicit role-based access
+- Access behavior becomes predictable across environments
+
+## Common issues
+
+- Memberships missing: confirm roles and teams exist first
+- Permissions look wrong: verify role assignment and environment context

--- a/docs/docs/environments/team-memberships/index.md
+++ b/docs/docs/environments/team-memberships/index.md
@@ -5,11 +5,11 @@ links:
   quickstart:
   previous:
   next: environments/team-memberships/list-team-memberships
-guides:
-  - teams/index
-  - roles/index
-  - environments/team-memberships/list-team-memberships
-featured:
+  guides:
+    - teams/index
+    - roles/index
+    - environments/team-memberships/list-team-memberships
+  featured:
 ---
 
 Team memberships connect a team to an environment with a role.

--- a/docs/docs/environments/team-memberships/index.md
+++ b/docs/docs/environments/team-memberships/index.md
@@ -7,9 +7,9 @@ links:
   next:
   guides:
     related:
-    - teams/index
-    - environments/index
-    - roles/index
+      - teams/index
+      - environments/index
+      - roles/index
   featured:
 ---
 

--- a/docs/docs/environments/team-memberships/index.md
+++ b/docs/docs/environments/team-memberships/index.md
@@ -4,37 +4,40 @@ links:
   overview:
   quickstart:
   previous:
-  next:
-  guides:
-    - teams/index
-    - environments/index
-    - roles/index
-  featured:
+  next: environments/team-memberships/list-team-memberships
+guides:
+  - teams/index
+  - roles/index
+  - environments/team-memberships/list-team-memberships
+featured:
 ---
 
-Team Memberships link teams to one environment with a role.
+Team memberships connect a team to an environment with a role.
 
 ## About
 
-Use membership to define who can access an environment and what they can do.
+- Memberships are configured per environment
+- Teams and roles are managed at the organization level
+- The role controls what the team can do in that environment
 
 ## Who should use this
 
-- Project owners managing team-level environment access
-- Team leads assigning permissions per environment
+- Project admins controlling project-wide collaboration
+- Environment admins setting per-environment access
 
-## Key terms
+## Why this exists
 
-- **Team**: users who receive access
-- **Environment**: the resource being accessed
-- **Role**: what that team can do in the environment
+- It is how you invite a team to contribute in an environment
+- It gives that team a clear role so people can collaborate safely
 
-## Expected result
+## Relationship to other concepts
 
-- Teams can be managed with explicit role-based access
-- Access behavior becomes predictable across environments
+- Teams group people
+- Roles define actions
+- Memberships attach a team and role to a specific environment
 
-## Common issues
+## Start here
 
-- Memberships missing: confirm roles and teams exist first
-- Permissions look wrong: verify role assignment and environment context
+- Review existing team links in [List Team Memberships](/docs/environments/team-memberships/list-team-memberships)
+- Add a new access link with [Add a Team Membership](/docs/environments/team-memberships/add-team-membership)
+- Manage teams and roles first in [Teams](/docs/teams) and [Roles](/docs/roles)

--- a/docs/docs/environments/team-memberships/list-team-memberships.md
+++ b/docs/docs/environments/team-memberships/list-team-memberships.md
@@ -1,36 +1,49 @@
 ---
 title: List Team Memberships
 links:
-  overview:
+  overview: environments/team-memberships/index
   quickstart:
-  previous: environments/index
+  previous: environments/team-memberships/index
   next: environments/team-memberships/add-team-membership
-  guides: []
-  featured:
+guides:
+  - environments/team-memberships/add-team-membership
+  - environments/team-memberships/index
+featured:
 ---
 
-Review which teams can access one environment.
+Review which teams can access an environment and at what permission level.
 
 ## Goal
 
-Validate access setup before deploying or changing roles.
+Validate current team access before deploying or changing roles.
 
 ## Who should use this
 
-- Team leads checking environment permissions
+- Environment admins checking team access
+- Project admins checking team grants
+
+## You need
+
+- Access to the target environment
+- Permission to view environment memberships
 
 ## Steps
 
-1. Select a project
-2. Select an environment in that project
-3. Open the `TEAM MEMBERSHIPS` section
+1. Open the target environment
+2. Open `TEAM MEMBERSHIPS`
+3. Review all listed teams and roles
+4. Open a membership when you need to verify details
 
 ## Expected result
 
-- You can see teams and roles for the selected environment
-- You can confirm who has what access
+- You can see each team and its assigned role for the environment
+- You can confirm whether current access matches expectations
 
 ## Common issues
 
-- List is empty: confirm there are memberships configured
-- You cannot open the list: check your environment permissions
+- List is empty: confirm teams and roles exist in the organization
+- You cannot open the list: check environment permissions
+
+## Next
+
+- Assign more access in [Add a Team Membership](/docs/environments/team-memberships/add-team-membership)

--- a/docs/docs/environments/team-memberships/list-team-memberships.md
+++ b/docs/docs/environments/team-memberships/list-team-memberships.md
@@ -11,11 +11,11 @@ guides:
 featured:
 ---
 
-Review which teams can access an environment and at what permission level.
+Review which teams currently have shared access in an environment.
 
 ## Goal
 
-Validate current team access before deploying or changing roles.
+Confirm current team access and role assignments before you add or change anything.
 
 ## Who should use this
 
@@ -36,8 +36,8 @@ Validate current team access before deploying or changing roles.
 
 ## Expected result
 
-- You can see each team and its assigned role for the environment
-- You can confirm whether current access matches expectations
+- You can confirm each team's assigned role and shared access
+- You can verify current permissions are what you expect
 
 ## Common issues
 

--- a/docs/docs/environments/team-memberships/list-team-memberships.md
+++ b/docs/docs/environments/team-memberships/list-team-memberships.md
@@ -5,8 +5,7 @@ links:
   quickstart:
   previous: environments/index
   next: environments/team-memberships/add-team-membership
-  guides:
-    related:
+  guides: []
   featured:
 ---
 

--- a/docs/docs/environments/team-memberships/list-team-memberships.md
+++ b/docs/docs/environments/team-memberships/list-team-memberships.md
@@ -1,18 +1,37 @@
 ---
 title: List Team Memberships
-intro: View the list of team memberships linked to a project environment and check which teams have access and their assigned roles.
 links:
   overview:
   quickstart:
   previous: environments/index
   next: environments/team-memberships/add-team-membership
   guides:
-  related:
+    related:
   featured:
 ---
 
-1. Select a `Project` from the Devopness dashboard
-1. Select an `Environment` linked to the chosen project
-1. On the `Environment` page, click the **TEAM MEMBERSHIPS** button located at the top-right corner of the screen
+Review which teams can access one environment.
 
-- The list of existing team memberships will be displayed, showing teams and their assigned roles
+## Goal
+
+Validate access setup before deploying or changing roles.
+
+## Who should use this
+
+- Team leads checking environment permissions
+
+## Steps
+
+1. Select a project
+2. Select an environment in that project
+3. Open the `TEAM MEMBERSHIPS` section
+
+## Expected result
+
+- You can see teams and roles for the selected environment
+- You can confirm who has what access
+
+## Common issues
+
+- List is empty: confirm there are memberships configured
+- You cannot open the list: check your environment permissions

--- a/docs/docs/environments/team-memberships/list-team-memberships.md
+++ b/docs/docs/environments/team-memberships/list-team-memberships.md
@@ -5,10 +5,10 @@ links:
   quickstart:
   previous: environments/team-memberships/index
   next: environments/team-memberships/add-team-membership
-guides:
-  - environments/team-memberships/add-team-membership
-  - environments/team-memberships/index
-featured:
+  guides:
+    - environments/team-memberships/add-team-membership
+    - environments/team-memberships/index
+  featured:
 ---
 
 Review which teams currently have shared access in an environment.

--- a/docs/docs/environments/unarchive-environment.md
+++ b/docs/docs/environments/unarchive-environment.md
@@ -1,18 +1,44 @@
 ---
 title: Unarchive an Environment
-intro: Some environments may need to be unarchived to manage a service included in the environment. Unarchive an Environment to view its linked resources.
 links:
   overview:
   quickstart:
   previous:
   next:
   guides:
-  related:
+    related:
+    - environments/find-archived-environment
   featured:
 ---
 
-1. On Devopness, access the `Environment` resources list of the archived `Environment` you want to unarchive
-   > Follow the [/docs/environments/find-archived-environment] guide
-1. On the upper-right corner of the `Environment` resources list, click `SETTINGS`
-1. Select the option `Archived environments`
-1. Follow the instructions in the form then click `Unarchive`
+Bring a paused environment back to active use.
+
+## Goal
+
+Restore access and allow deployment operations again.
+
+## Who should use this
+
+- Project owners after incident windows are over
+
+## You need
+
+- Permission to unarchive environments
+- An environment currently in archived state
+
+## Steps
+
+1. Go to the archived environment you want to restore
+2. Open environment settings
+3. Select `Archived environments`
+4. Confirm unarchive
+
+## Expected result
+
+- The environment becomes active again
+- Team members can access it based on current roles
+
+## Common issues
+
+- Unarchive is disabled: confirm the environment is truly archived
+- You do not have permission to unarchive this environment

--- a/docs/docs/environments/unarchive-environment.md
+++ b/docs/docs/environments/unarchive-environment.md
@@ -7,7 +7,7 @@ links:
   next:
   guides:
     related:
-    - environments/find-archived-environment
+      - environments/find-archived-environment
   featured:
 ---
 

--- a/docs/docs/environments/unarchive-environment.md
+++ b/docs/docs/environments/unarchive-environment.md
@@ -6,8 +6,7 @@ links:
   previous:
   next:
   guides:
-    related:
-      - environments/find-archived-environment
+    - environments/find-archived-environment
   featured:
 ---
 

--- a/docs/docs/environments/view-environment.md
+++ b/docs/docs/environments/view-environment.md
@@ -7,10 +7,10 @@ links:
   next: environments/add-environment
   guides:
     related:
-    - environments/list-environments
-    - environments/add-environment
-    - environments/archive-environment
-    - environments/find-archived-environment
+      - environments/list-environments
+      - environments/add-environment
+      - environments/archive-environment
+      - environments/find-archived-environment
   featured:
 ---
 

--- a/docs/docs/environments/view-environment.md
+++ b/docs/docs/environments/view-environment.md
@@ -6,11 +6,10 @@ links:
   previous: environments/list-environments
   next: environments/add-environment
   guides:
-    related:
-      - environments/list-environments
-      - environments/add-environment
-      - environments/archive-environment
-      - environments/find-archived-environment
+    - environments/list-environments
+    - environments/add-environment
+    - environments/archive-environment
+    - environments/find-archived-environment
   featured:
 ---
 

--- a/docs/docs/environments/view-environment.md
+++ b/docs/docs/environments/view-environment.md
@@ -1,13 +1,12 @@
 ---
 title: View Environment
-intro: Learn how to view and manage the details of an environment, including its resources, settings, and team memberships.
 links:
   overview:
   quickstart:
   previous: environments/list-environments
   next: environments/add-environment
   guides:
-  related:
+    related:
     - environments/list-environments
     - environments/add-environment
     - environments/archive-environment
@@ -15,21 +14,36 @@ links:
   featured:
 ---
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-1. Select a `Project`
-1. Find the `Environments` card
-1. Click `View all` in the `Environments` card to see a list of existing `Environments`
-1. Find the `Environment` you want to view and click `View`
-1. The `Environment` page will be displayed, showing:
-   - Environment name and type
-   - Resource summary (servers, applications, etc.)
-   - Team memberships
-   - Actions history
-   - Settings and configuration options
+Inspect one environment and confirm resources, settings, and access.
 
-You can perform various actions from the environment view page:
+## About
 
-- Add new resources (servers, applications, etc.)
-- Manage team memberships
-- Archive/unarchive the environment
-- View and manage environment settings
+Use this page to check what is active and what still needs setup.
+
+## Who should use this
+
+- Operators preparing deployments
+- Team members validating resource and access configuration
+
+## Steps
+
+1. Go to the environments list for the project
+2. Select the environment you want to inspect
+3. Review resource summary, team memberships, and settings
+
+## What you can do from here
+
+- Add resources to this environment
+- Add or change team memberships
+- Archive or unarchive the environment
+- Update environment settings
+
+## Expected result
+
+- You can see a complete snapshot of the environment state
+- You can continue with one of the available environment actions
+
+## Common issues
+
+- Missing resources on the page: configure resources first
+- You cannot edit settings: your role may be read-only for this environment

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,15 +1,17 @@
 ---
+
 slug: /
 sidebar_position: 1
 title: Get started with Devopness
 links:
-  overview:
-  quickstart:
-  previous:
-  next: organizations/index
-  guides:
-  related:
-  featured:
+overview:
+quickstart:
+previous:
+next: organizations/index
+guides:
+related:
+featured:
+
 ## About:
 
 Devopness is an API-first, AI-assisted platform for provisioning infrastructure and deploying applications.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -2,7 +2,6 @@
 slug: /
 sidebar_position: 1
 title: Get started with Devopness
-intro: Devopness helps growing teams ship software safely and reduce complexity on cloud, CI/CD and DevOps workflows
 links:
   overview:
   quickstart:
@@ -11,41 +10,39 @@ links:
   guides:
   related:
   featured:
----
-
-## About
+## About:
 
 Devopness is an API-first, AI-assisted platform for provisioning infrastructure and deploying applications.
 Use it with major cloud providers, self-hosted servers, and serverless services.
 
-## What Devopness gives you
+## What Devopness gives you:
 
-- You can deploy apps and infrastructure for any stack from one platform.
-- You can work with multiple cloud providers without learning each one in depth.
-- You can use RBAC to give teams the exact access they need.
-- You can keep visibility across teams without requiring everyone to connect directly to cloud provider accounts.
+- Deploy apps and infrastructure for any stack from one platform
+- Work with multiple cloud providers without becoming expert in each one
+- Use RBAC to give teams the exact access they need
+- Keep visibility across teams without forcing everyone to connect directly to cloud provider accounts
 
-## In 3 moves
+## In 3 moves:
 
-- Connect your cloud provider.
-- Link your code source.
-- Ship your first app and scale.
+- Connect your cloud provider
+- Link your code source
+- Deploy your first app and scale 🚀
 
-## How it is organized
+## How it is organized:
 
-- **Organization**: the workspace for ownership, teams, and long-term collaboration.
-- **Project**: where related applications and infrastructure are grouped.
-- **Environment**: where release stages live (`Development`, `Staging`, `Production`).
+- **Organization**: the workspace for teams, projects, and long-term collaboration
+- **Project**: where related applications and infrastructure are grouped
+- **Environment**: where release stages live (`Development`, `Staging`, `Production`)
 
 This page is the fastest route into the full setup flow.
 
-## Who this is for
+## Who this is for:
 
 - Developers shipping apps and infrastructure with small teams.
 - Team leads moving from single to multi-environment operations.
 - Founders who want predictable deployment structure early.
 
-## Start here
+## Start here:
 
 1. Create your organization in [`Organizations`](/docs/organizations/) (or select the one you already use).
 2. Confirm it is the organization you want to use.
@@ -54,16 +51,16 @@ This page is the fastest route into the full setup flow.
 5. Connect your cloud and Git credentials.
 6. Deploy your first app and check it is live 🚀
 
-## Common issues
+## Common issues:
 
 - You are in the wrong organization and only see a subset of resources.
 - You cannot edit or add items because your role does not include all required permissions.
 - You need faster, safer onboarding before release: start with one project and one production environment.
 
-## Get help
+## Get help:
 
 If you need help, contact us on [GitHub](https://github.com/devopness/devopness/discussions) or join our [Discord](https://devopness.com/discord/).
 
-## Report a vulnerability
+## Report a vulnerability:
 
-If you found a vulnerability in our products, follow the guide [/docs/security/reporting-a-security-vulnerability]
+If you found a vulnerability in our products, follow the guide [/docs/security/reporting-a-security-vulnerability].

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,36 +1,35 @@
 ---
-
 slug: /
 sidebar_position: 1
 title: Get started with Devopness
 links:
-overview:
-quickstart:
-previous:
-next: organizations/index
-guides:
-related:
-featured:
+  overview:
+  quickstart:
+  previous:
+  next: organizations/index
+  guides: []
+  featured:
+---
 
-## About:
+## About
 
 Devopness is an API-first, AI-assisted platform for provisioning infrastructure and deploying applications.
 Use it with major cloud providers, self-hosted servers, and serverless services.
 
-## What Devopness gives you:
+## What Devopness gives you
 
 - Deploy apps and infrastructure for any stack from one platform
 - Work with multiple cloud providers without becoming expert in each one
 - Use RBAC to give teams the exact access they need
 - Keep visibility across teams without forcing everyone to connect directly to cloud provider accounts
 
-## In 3 moves:
+## In 3 steps
 
-- Connect your cloud provider
-- Link your code source
-- Deploy your first app and scale 🚀
+1. Connect your cloud provider
+2. Link your code source
+3. Deploy your first app and scale 🚀
 
-## How it is organized:
+## How it is organized
 
 - **Organization**: the workspace for teams, projects, and long-term collaboration
 - **Project**: where related applications and infrastructure are grouped
@@ -38,13 +37,13 @@ Use it with major cloud providers, self-hosted servers, and serverless services.
 
 This page is the fastest route into the full setup flow.
 
-## Who this is for:
+## Who this is for
 
 - Developers shipping apps and infrastructure with small teams.
 - Team leads moving from single to multi-environment operations.
 - Founders who want predictable deployment structure early.
 
-## Start here:
+## Start here
 
 1. Create your organization in [`Organizations`](/docs/organizations/) (or select the one you already use).
 2. Confirm it is the organization you want to use.
@@ -53,16 +52,16 @@ This page is the fastest route into the full setup flow.
 5. Connect your cloud and Git credentials.
 6. Deploy your first app and check it is live 🚀
 
-## Common issues:
+## Common issues
 
 - You are in the wrong organization and only see a subset of resources.
 - You cannot edit or add items because your role does not include all required permissions.
 - You need faster, safer onboarding before release: start with one project and one production environment.
 
-## Get help:
+## Get help
 
 If you need help, contact us on [GitHub](https://github.com/devopness/devopness/discussions) or join our [Discord](https://devopness.com/discord/).
 
-## Report a vulnerability:
+## Report a vulnerability
 
 If you found a vulnerability in our products, follow the guide [/docs/security/reporting-a-security-vulnerability].

--- a/docs/docs/organizations/add-organization.md
+++ b/docs/docs/organizations/add-organization.md
@@ -5,8 +5,7 @@ links:
   quickstart:
   previous: organizations/index
   next: organizations/edit-organization
-  guides:
-    related:
+  guides: []
   featured:
 ---
 

--- a/docs/docs/organizations/add-organization.md
+++ b/docs/docs/organizations/add-organization.md
@@ -9,33 +9,33 @@ links:
   featured:
 ---
 
-Create a new workspace for one legal entity or team.
+Create a new organization for one company, team, or client.
 
 ## Goal
 
-Set up your first workspace before you create projects and invite your team.
+Set up the organization before creating projects and inviting your team.
 
 ## Who should use this
 
-- Founders setting up a new company workspace
+- Founders setting up a first company workspace
 - Teams moving from multiple old setups
-- Consultants managing more than one client workspace
+- Consultants managing more than one client organization
 
 ## You need
 
 - Permission to create organizations
-- A clear organization name
+- A valid organization name
 
 ## Steps
 
-1. Go to the organization selector
+1. Open the organization selector
 2. Select `Add Organization`
 3. Enter a unique organization name
 4. Save
 
 ## Result
 
-- A new organization appears in your workspace list
+- A new organization appears in your organization list
 - You can create projects, invite members, and manage roles there
 
 ## Common issues

--- a/docs/docs/organizations/add-organization.md
+++ b/docs/docs/organizations/add-organization.md
@@ -1,0 +1,49 @@
+---
+title: Add an Organization
+links:
+  overview:
+  quickstart:
+  previous: organizations/index
+  next: organizations/edit-organization
+  guides:
+    related:
+  featured:
+---
+
+Create a new workspace for one legal entity or team.
+
+## Goal
+
+Set up your first workspace before you create projects and invite your team.
+
+## Who should use this
+
+- Founders setting up a new company workspace
+- Teams moving from multiple old setups
+- Consultants managing more than one client workspace
+
+## You need
+
+- Permission to create organizations
+- A clear organization name
+
+## Steps
+
+1. Go to the organization selector
+2. Select `Add Organization`
+3. Enter a unique organization name
+4. Save
+
+## Result
+
+- A new organization appears in your workspace list
+- You can create projects, invite members, and manage roles there
+
+## Common issues
+
+- You do not see `Add Organization`: confirm you have enough account permissions
+- The organization name is already taken: choose a unique name
+
+## Next
+
+- Use [`Organizations`](/docs/organizations/) to review the new setup

--- a/docs/docs/organizations/edit-organization.md
+++ b/docs/docs/organizations/edit-organization.md
@@ -5,8 +5,7 @@ links:
   quickstart:
   previous: organizations/add-organization
   next: organizations/remove-organization
-  guides:
-    related:
+  guides: []
   featured:
 ---
 

--- a/docs/docs/organizations/edit-organization.md
+++ b/docs/docs/organizations/edit-organization.md
@@ -1,0 +1,48 @@
+---
+title: Edit an Organization
+links:
+  overview:
+  quickstart:
+  previous: organizations/add-organization
+  next: organizations/remove-organization
+  guides:
+    related:
+  featured:
+---
+
+Update an existing organization without replacing it.
+
+## Goal
+
+Keep workspace details current after ownership or team changes.
+
+## Who should use this
+
+- Organization owners
+- Team leads managing shared setups for long-running products
+
+## You need
+
+- Permission to edit organization settings
+- Access to the target organization
+
+## Steps
+
+1. Go to the organization you want to update
+2. Go to `Organization Settings`
+3. Update name or editable details
+4. Save
+
+## Result
+
+- The organization shows the updated details
+- Existing projects and members remain linked to the same organization
+
+## Common issues
+
+- You cannot save changes: confirm you still have edit permission
+- Updated fields do not save: check required fields and try again
+
+## Next
+
+- Use [`Projects`](/docs/projects/) to keep product setup aligned with your updated organization

--- a/docs/docs/organizations/edit-organization.md
+++ b/docs/docs/organizations/edit-organization.md
@@ -9,16 +9,16 @@ links:
   featured:
 ---
 
-Update an existing organization without replacing it.
+Update an existing organization without creating a new one.
 
 ## Goal
 
-Keep workspace details current after ownership or team changes.
+Keep organization details current after ownership, team, or permissions changes.
 
 ## Who should use this
 
 - Organization owners
-- Team leads managing shared setups for long-running products
+- Team leads managing shared setups across multiple products
 
 ## You need
 
@@ -44,4 +44,4 @@ Keep workspace details current after ownership or team changes.
 
 ## Next
 
-- Use [`Projects`](/docs/projects/) to keep product setup aligned with your updated organization
+- Use [`Projects`](/docs/projects/) to keep product setup aligned with the updated organization

--- a/docs/docs/organizations/index.md
+++ b/docs/docs/organizations/index.md
@@ -7,9 +7,9 @@ links:
   next: projects/index
   guides:
     related:
-    - projects/index
-    - teams/index
-    - roles/index
+      - projects/index
+      - teams/index
+      - roles/index
   featured:
 ---
 

--- a/docs/docs/organizations/index.md
+++ b/docs/docs/organizations/index.md
@@ -6,10 +6,9 @@ links:
   previous:
   next: projects/index
   guides:
-    related:
-      - projects/index
-      - teams/index
-      - roles/index
+    - projects/index
+    - teams/index
+    - roles/index
   featured:
 ---
 

--- a/docs/docs/organizations/index.md
+++ b/docs/docs/organizations/index.md
@@ -12,20 +12,21 @@ links:
   featured:
 ---
 
-Organizations are the top-level workspace where you group teams, roles, and projects in Devopness.
+Organizations are the top level workspace in Devopness.
+They group teams, roles, and projects in one place.
 
 ## About
 
-- An organization is a dedicated workspace for one company, legal entity, or client portfolio
+- An organization is a dedicated space for one company, legal entity, or client portfolio
 - Every organization has a readable URL slug, like `acme` in `/@acme`
-- Members join through ownership, invitation, or team membership
-- It is the first place where team access and project ownership are set
+- People join through invitation, or team membership
+- It is where team access and project setup are set
 
 ## Who should use this
 
-- Developers who want one clean workspace for shared projects
+- Developers who want one simple place for shared projects
 - Team leads managing multiple products, clients, or teams
-- Founders who want a predictable setup before adding many environments
+- Founders who want a clear setup before adding many environments
 
 ## Organization vs Project
 
@@ -35,15 +36,15 @@ Organizations are the top-level workspace where you group teams, roles, and proj
 
 Think of it like this:
 
-- **Organization:** the shared folder for everyone in one workspace, like `/@acme`
-- **Project:** one product or client inside that workspace
+- **Organization:** the shared home for everyone in one company, like `/@acme`
+- **Project:** one product or client inside that organization
 - **Environment:** one stage inside that project, like `Development`, `Staging`, `Production`
 
 ## Why organizations exist
 
 - They keep teams, roles, and projects in one place
 - They give founders one place to control who can see and change what
-- They let the workspace grow from one project to many without redesigning structure
+- They let you grow from one project to many without redesigning structure
 
 ## Start here
 
@@ -51,7 +52,7 @@ Think of it like this:
 - Confirm it is the one where the project should live
 - Create your first project
 - Use `Teams` and invite members to collaborate in the organization
-- Add `Roles` to manage delegated access permissions
+- Add `Roles` to control access
 
 ## Who can manage an organization
 
@@ -73,5 +74,5 @@ Think of it like this:
 
 ## Next
 
-- Use [`Projects`](/docs/projects/) to create your first workspace
+- Use [`Projects`](/docs/projects/) to create your first project
 - Use [`Teams`](/docs/teams/) and [`Roles`](/docs/roles/) to define access

--- a/docs/docs/organizations/index.md
+++ b/docs/docs/organizations/index.md
@@ -1,78 +1,78 @@
 ---
 title: Organizations
-intro: Organizations are the top-level workspace for your work in Devopness.
 links:
   overview:
   quickstart:
   previous:
   next: projects/index
   guides:
-  related:
+    related:
     - projects/index
     - teams/index
     - roles/index
   featured:
 ---
 
+Organizations are the top-level workspace where you group teams, roles, and projects in Devopness.
+
 ## About
 
-- An organization is the top-level workspace in Devopness.
-- It is a shared workspace for one company or legal entity.
-- Each organization gets a unique readable URL slug (for example `acme` in `/@acme`).
-- Personal accounts can own organizations or be invited to collaborate in organizations created by other users.
-- Organizations group projects, teams, and roles.
+- An organization is a dedicated workspace for one company, legal entity, or client portfolio
+- Every organization has a readable URL slug, like `acme` in `/@acme`
+- Members join through ownership, invitation, or team membership
+- It is the first place where team access and project ownership are set
 
 ## Who should use this
 
-- Developers who want one clean workspace for shared projects.
-- Team leads managing multiple products, clients, or teams.
-- Founders who want predictable collaboration, visibility and productivity from day one.
+- Developers who want one clean workspace for shared projects
+- Team leads managing multiple products, clients, or teams
+- Founders who want a predictable setup before adding many environments
 
 ## Organization vs Project
 
-- Organization owns projects and sets the top-level permissions management (teams and roles).
-- Project groups multiple related environments.
-- Environment is a container for related cloud infrastructure resources, applications, SSL Certificates, Linux services, databases, etc
+- Organizations hold one or more projects
+- A project groups environments for one product or client
+- An environment is a container for deployable resources, such as an app, server setup, or data store
 
 Think of it like this:
 
-- **Organization:** your shared workspace, like `/@{slug}`
-- **Project:** a bucket for one product or client
-- **Environment:** stages inside that project, like `Development`, `Staging`, `Production`
+- **Organization:** the shared folder for everyone in one workspace, like `/@acme`
+- **Project:** one product or client inside that workspace
+- **Environment:** one stage inside that project, like `Development`, `Staging`, `Production`
 
 ## Why organizations exist
 
-- They keep ownership and team activity in one place.
-- They make team access and responsibilities easier to manage.
-- They provide a predictable path to scale without changing product structure.
+- They keep teams, roles, and projects in one place
+- They give founders one place to control who can see and change what
+- They let the workspace grow from one project to many without redesigning structure
 
 ## Start here
 
-- Create a new organization to secure your unique `/@{url_slug}`.
-- Confirm it is the one where the project should live.
-- Create your first project.
+- Create your first organization and get a stable `/@{slug}`
+- Confirm it is the one where the project should live
+- Create your first project
 - Use `Teams` and invite members to collaborate in the organization
-- Add `Roles` to manage delegated access permissions.
+- Add `Roles` to manage delegated access permissions
 
 ## Who can manage an organization
 
 - Organization owners
 - Team members with an organization role that allows managing organization settings
-- Any member with project-level roles can work in project areas according to permissions.
-- Any member with environment-level roles can contribute to specific environments
+- Members with project roles can work in project areas
+- Members with environment roles can contribute to specific environments
+
+## Typical setup flow
+
+- Start with one organization for the main legal entity or one agency account
+- Add one project per major product, portfolio, or client
+- Use separate environments (`Production`, `Staging`, `Development`) inside each project
 
 ## Common questions at this level
 
-- Can I see all projects from one place? Yes, when you are on the right organization.
-- Why can't I edit org settings? Check your role and permission set first.
-
-## Common issues
-
-- You only see a subset of projects because your permissions are limited.
-- You are looking at the wrong organization.
-- You cannot edit organization settings because your role is not owner.
+- Can I see all projects in one place? Yes, by selecting the right organization
+- Why can't I edit org settings? Check your role and permissions first
 
 ## Next
 
-- Use [`Projects`](/docs/projects/) to create your first scoped workspace.
-- Use [`Teams`](/docs/teams/) and [`Roles`](/docs/roles/) to define access.
+- Use [`Projects`](/docs/projects/) to create your first workspace
+- Use [`Teams`](/docs/teams/) and [`Roles`](/docs/roles/) to define access

--- a/docs/docs/organizations/remove-organization.md
+++ b/docs/docs/organizations/remove-organization.md
@@ -9,11 +9,11 @@ links:
   featured:
 ---
 
-Delete an organization when you no longer want to keep that workspace.
+Delete an organization when you no longer want to keep it.
 
 ## Goal
 
-Stop all team, project, and token activity under this workspace in one action.
+Stop all team, project, and token activity under this organization in one action.
 
 :::warning
 Removing an organization is permanent. This action cannot be undone.
@@ -24,7 +24,7 @@ Confirm this organization is no longer needed before you continue.
 ## Who should use this
 
 - Organization owners
-- Admins closing a client workspace
+- Admins closing a client organization
 
 ## You need
 
@@ -41,7 +41,7 @@ Confirm this organization is no longer needed before you continue.
 
 ## Result
 
-- The organization no longer appears in your workspace list
+- The organization no longer appears in your organization list
 - Teams and projects inside the organization are no longer accessible
 
 ## Common issues
@@ -52,4 +52,4 @@ Confirm this organization is no longer needed before you continue.
 
 ## Next
 
-- Return to [`Organizations`](/docs/organizations/) for your next workspace
+- Return to [`Organizations`](/docs/organizations/) for your next organization

--- a/docs/docs/organizations/remove-organization.md
+++ b/docs/docs/organizations/remove-organization.md
@@ -5,8 +5,7 @@ links:
   quickstart:
   previous: organizations/edit-organization
   next: organizations/index
-  guides:
-    related:
+  guides: []
   featured:
 ---
 
@@ -16,8 +15,11 @@ Delete an organization when you no longer want to keep that workspace.
 
 Stop all team, project, and token activity under this workspace in one action.
 
-Warning:
-This action is permanent and removes the organization, its projects, and memberships.
+:::warning
+Removing an organization is permanent. This action cannot be undone.
+:::
+
+Confirm this organization is no longer needed before you continue.
 
 ## Who should use this
 

--- a/docs/docs/organizations/remove-organization.md
+++ b/docs/docs/organizations/remove-organization.md
@@ -1,0 +1,53 @@
+---
+title: Remove an Organization
+links:
+  overview:
+  quickstart:
+  previous: organizations/edit-organization
+  next: organizations/index
+  guides:
+    related:
+  featured:
+---
+
+Delete an organization when you no longer want to keep that workspace.
+
+## Goal
+
+Stop all team, project, and token activity under this workspace in one action.
+
+Warning:
+This action is permanent and removes the organization, its projects, and memberships.
+
+## Who should use this
+
+- Organization owners
+- Admins closing a client workspace
+
+## You need
+
+- Permission to delete organizations
+- Confirmation that all required project data is migrated or backed up
+
+## Steps
+
+1. Go to the organization to remove
+2. Go to `Organization Settings`
+3. Select `Remove Organization`
+4. Confirm deletion as required by the UI
+5. Confirm final deletion
+
+## Result
+
+- The organization no longer appears in your workspace list
+- Teams and projects inside the organization are no longer accessible
+
+## Common issues
+
+- You cannot remove the organization: confirm all required project data is archived first
+- Deletion is blocked: confirm you have global delete permission for this organization
+- You need to delete dependent resources first: check for active projects, tokens, or integrations
+
+## Next
+
+- Return to [`Organizations`](/docs/organizations/) for your next workspace

--- a/docs/docs/projects/add-project.md
+++ b/docs/docs/projects/add-project.md
@@ -6,8 +6,7 @@ links:
   previous: projects/index
   next: projects/view-project
   guides:
-    related:
-      - projects/list-projects
+    - projects/list-projects
   featured:
 ---
 

--- a/docs/docs/projects/add-project.md
+++ b/docs/docs/projects/add-project.md
@@ -1,26 +1,55 @@
 ---
 title: Add a Project
-intro: Add one or multiple projects to group your infrastructure resources in a logical and organized way.
 links:
   overview:
   quickstart:
   previous: projects/index
   next: projects/view-project
   guides:
-  related:
+    related:
+    - projects/list-projects
   featured:
 ---
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-1. On the upper-right corner of the list click `ADD PROJECT`
-1. Provide a name to the `Project` being added. For example, "My Product"
-1. Click `CONFIRM`
+Create a new project inside an organization for each product or client-specific setup.
 
-- You will be redirected to the `Project resources` page, with details of your newly created project
-- You can now manage `Environments`, `Teams` and `Roles` in your new project
+## Goal
 
-Tips:
+Set up a workspace before adding environments, teams, and roles.
 
-- Create a new project for each product when teams and permissions should be kept separate.
-- Use a new project if you need different Git or cloud provider credentials.
-- Keep multiple applications in the same project when they belong to the same product and are managed by the same teams.
+## Who should use this
+
+- Developers creating a new workspace for one product or client
+- Team leads splitting work by delivery area
+
+## You need
+
+- Permission to create projects in the selected organization
+- Organization selected where the project should live
+
+## Steps
+
+1. Go to the organization where the project will live
+2. Select `Add Project`
+3. Set a clear project name
+4. Save
+
+## Expected result
+
+- Your new project appears in the project list
+- You can create environments, teams, and roles inside the project
+
+## Why this page
+
+- Keep related products or clients in separate projects when needed
+- Separate ownership boundaries with clean project scopes
+
+## Common issues
+
+- You cannot see `Add Project`: confirm your organization-level permissions
+- The organization you selected is not the one you intended
+- The project name is already taken or invalid
+
+## Next
+
+- Use [`List Projects`](/docs/projects/list-projects) to verify it appears

--- a/docs/docs/projects/add-project.md
+++ b/docs/docs/projects/add-project.md
@@ -7,7 +7,7 @@ links:
   next: projects/view-project
   guides:
     related:
-    - projects/list-projects
+      - projects/list-projects
   featured:
 ---
 

--- a/docs/docs/projects/add-project.md
+++ b/docs/docs/projects/add-project.md
@@ -10,16 +10,16 @@ links:
   featured:
 ---
 
-Create a new project inside an organization for each product or client-specific setup.
+Create a new project inside an organization for one product or client.
 
 ## Goal
 
-Set up a workspace before adding environments, teams, and roles.
+Set up the project before adding environments, teams, and roles.
 
 ## Who should use this
 
-- Developers creating a new workspace for one product or client
-- Team leads splitting work by delivery area
+- Developers creating a new project for one product or client
+- Project leads separating work by product area
 
 ## You need
 
@@ -41,7 +41,7 @@ Set up a workspace before adding environments, teams, and roles.
 ## Why this page
 
 - Keep related products or clients in separate projects when needed
-- Separate ownership boundaries with clean project scopes
+- Keep project owners and permissions separate per project scope
 
 ## Common issues
 

--- a/docs/docs/projects/edit-project.md
+++ b/docs/docs/projects/edit-project.md
@@ -11,11 +11,11 @@ links:
   featured:
 ---
 
-Update an existing project when details changed.
+Update an existing project without creating a new one.
 
 ## Goal
 
-Update the project name, metadata, or settings without creating a new one.
+Update the project name, metadata, or settings after team requirements change.
 
 ## Who should use this
 
@@ -32,7 +32,7 @@ Update the project name, metadata, or settings without creating a new one.
 
 1. Go to the project you want to update
 2. Go to project settings
-3. Change the fields you need, for example name or metadata
+3. Change the fields you need, such as name or metadata
 4. Save the updates
 
 ## Result

--- a/docs/docs/projects/edit-project.md
+++ b/docs/docs/projects/edit-project.md
@@ -1,0 +1,51 @@
+---
+title: Edit a Project
+links:
+  overview:
+  quickstart:
+  previous: projects/add-project
+  next: projects/remove-project
+  guides:
+    - projects/view-project
+  related:
+  featured:
+---
+
+Update an existing project when details changed.
+
+## Goal
+
+Update the project name, metadata, or settings without creating a new one.
+
+## Who should use this
+
+- Project owners
+- Team leads managing multiple active products
+- Developers with project edit permissions
+
+## You need
+
+- Permission to edit project settings in the selected organization
+- Access to the target project
+
+## Steps
+
+1. Go to the project you want to update
+2. Go to project settings
+3. Change the fields you need, for example name or metadata
+4. Save the updates
+
+## Result
+
+- The project reflects the updated details
+- Existing environments, teams, and roles remain linked to the same project
+
+## Common issues
+
+- You do not see edit actions: confirm your project role allows updates
+- A new project name conflicts with existing naming rules: use a unique name
+- Changes are not visible yet: refresh the project view
+
+## Next
+
+- Use [`View a Project`](/docs/projects/view-project) to verify the updated setup

--- a/docs/docs/projects/index.md
+++ b/docs/docs/projects/index.md
@@ -1,73 +1,63 @@
 ---
 title: Projects
-intro: Projects group related environment stages of a product or client-specific environments
 links:
   overview:
   quickstart:
   previous: organizations/index
   next: projects/add-project
   guides:
-  related:
+    related:
     - organizations/index
     - environments/index
   featured:
 ---
 
+Projects group all environments for one product, client, or stack in a single place.
+
 ## About
 
-Projects are where related applications and infrastructure resources live together.
-Each project belongs to one organization and can start small.
-A project can grow by adding `Development`, `Staging`, `Production`, and custom environments over time.
+Projects are how you organize deployment work for one business outcome.
+Each project belongs to one organization.
+A project can include multiple environments, apps, and resources.
+You can start with one project and add another later as your team grows.
 
 ## Who should use this
 
-- Developers who ship multiple products.
-- Team leads separating ownership between products and teams.
-- Founders who want a simple permission model as the platform grows.
+- Developers who ship multiple products
+- Team leads who want each product to stay in one clear location
+- Founders who want a simple permission model as the platform grows
 
-Think of a project as one product family or one client delivery.
-Example: a startup might create one project for an API, frontend, background workers, and queues.
+Think of a project as one product or one client delivery.
+A startup can start one project that includes:
+- one API
+- one frontend
+- one worker or queue process
+
 At day 1, the same project can start with just a `Production` environment.
-Later, add `Development`, `Staging`, and custom environments when you are ready.
+Add `Development` and `Staging` when your release flow grows.
 
 ## Relationship to organization
 
-- Organizations own projects and team memberships.
-- Keep product context inside the organization, then split by project when needed.
-- Each environment belongs to a project and holds deployable resources.
+- Organizations hold all projects and core team settings
+- Keep related products inside one organization, then split by project when they have separate owners
+- Each environment belongs to one project and holds deployable resources
 
 ## Start here
 
-- Confirm the organization.
-- Create your first project.
-- Start with one project unless you have different unrelated products or client-specific environments
-- Add `Development` or `Staging` environments when the release flow grows.
-
-## When to create a new project
-
-- You have different products, clients, or operational domain.
-- Different teams need separate access boundaries.
-- You need different credentials or release ownership for part of your work.
-
-## When to keep one project
-
-- One product has multiple environments (`Development`, `Staging`, `Production`) that share ownership.
-- Your team needs a single place for related releases and team setup.
-- You want simpler onboarding before splitting by ownership boundaries.
+- Confirm the organization
+- Create your first project
+- Start with one `Production` environment
+- Add `Development` or `Staging` when your release flow grows
+- Add client or compliance-isolated work as separate projects, not extra ad-hoc environments
 
 ## Quick decision rule
 
-Start with one project unless one of these is true:
+Start with one project until one of these is true
+- You run separate unrelated products
+- You need client-specific teams, permissions, or ownership boundaries
+- You need independent release schedules for different stacks or clients
 
-- You run separate products, clients, or operational domains.
-- Teams need different access, release ownership, or visibility boundaries.
-- Credentials, permissions, or release ownership must be split across groups.
-- You need dedicated client-level control outside a shared project setup.
+## Practical example
 
-You can add more projects later without changing your current setup.
-
-## Common issues
-
-- You feel everything should be one project: this is fine to start.
-- You are not sure where to split: split when team, credential, or release needs diverge.
-- Too many environments inside one project too early can be slower than it sounds.
+- Team creates one project for API + frontend + workers at launch
+- The same team adds another project for internal tooling after adding a second product owner

--- a/docs/docs/projects/index.md
+++ b/docs/docs/projects/index.md
@@ -7,8 +7,8 @@ links:
   next: projects/add-project
   guides:
     related:
-    - organizations/index
-    - environments/index
+      - organizations/index
+      - environments/index
   featured:
 ---
 
@@ -29,6 +29,7 @@ You can start with one project and add another later as your team grows.
 
 Think of a project as one product or one client delivery.
 A startup can start one project that includes:
+
 - one API
 - one frontend
 - one worker or queue process
@@ -53,6 +54,7 @@ Add `Development` and `Staging` when your release flow grows.
 ## Quick decision rule
 
 Start with one project until one of these is true
+
 - You run separate unrelated products
 - You need client-specific teams, permissions, or ownership boundaries
 - You need independent release schedules for different stacks or clients

--- a/docs/docs/projects/index.md
+++ b/docs/docs/projects/index.md
@@ -11,14 +11,14 @@ links:
   featured:
 ---
 
-Projects group all environments for one product, client, or stack in a single place.
+Projects group all environments for one product, client, or stack.
 
 ## About
 
-Projects are how you organize deployment work for one business outcome.
+A project is where you organize work for one product or client.
 Each project belongs to one organization.
 A project can include multiple environments, apps, and resources.
-You can start with one project and add another later as your team grows.
+You can start with one project and add another when your team grows.
 
 ## Who should use this
 
@@ -26,19 +26,19 @@ You can start with one project and add another later as your team grows.
 - Team leads who want each product to stay in one clear location
 - Founders who want a simple permission model as the platform grows
 
-Think of a project as one product or one client delivery.
+Think of a project as one product or one client.
 A startup can start one project that includes:
 
 - one API
 - one frontend
 - one worker or queue process
 
-At day 1, the same project can start with just a `Production` environment.
+At day 1, a project can start with one `Production` environment.
 Add `Development` and `Staging` when your release flow grows.
 
 ## Relationship to organization
 
-- Organizations hold all projects and core team settings
+- Organizations hold all projects and team settings
 - Keep related products inside one organization, then split by project when they have separate owners
 - Each environment belongs to one project and holds deployable resources
 
@@ -52,10 +52,10 @@ Add `Development` and `Staging` when your release flow grows.
 
 ## Quick decision rule
 
-Start with one project until one of these is true
+Start with one project until one of these is true:
 
 - You run separate unrelated products
-- You need client-specific teams, permissions, or ownership boundaries
+- You need client-specific teams, permissions, or separate owners
 - You need independent release schedules for different stacks or clients
 
 ## Practical example

--- a/docs/docs/projects/index.md
+++ b/docs/docs/projects/index.md
@@ -6,9 +6,8 @@ links:
   previous: organizations/index
   next: projects/add-project
   guides:
-    related:
-      - organizations/index
-      - environments/index
+    - organizations/index
+    - environments/index
   featured:
 ---
 

--- a/docs/docs/projects/list-projects.md
+++ b/docs/docs/projects/list-projects.md
@@ -7,7 +7,7 @@ links:
   next: environments/add-environment
   guides:
     related:
-    - projects/add-project
+      - projects/add-project
   featured:
 ---
 

--- a/docs/docs/projects/list-projects.md
+++ b/docs/docs/projects/list-projects.md
@@ -6,8 +6,7 @@ links:
   previous: projects/view-project
   next: environments/add-environment
   guides:
-    related:
-      - projects/add-project
+    - projects/add-project
   featured:
 ---
 

--- a/docs/docs/projects/list-projects.md
+++ b/docs/docs/projects/list-projects.md
@@ -1,18 +1,44 @@
 ---
 title: List Projects
-intro: View your list of projects
 links:
   overview:
   quickstart:
   previous: projects/view-project
   next: environments/add-environment
   guides:
-  related:
+    related:
     - projects/add-project
   featured:
 ---
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-2. If you don't have any projects yet, create one. You can see how to create a project in the Add Project documentation page.
-3. Once created, the project should be seen displayed on a table, showing it's name, owner and how many environments, teams and roles there are in that project.
-4. You can also click on the project's name to see details about it.
+See the projects you have access to in the current organization.
+
+## About
+
+Use the list to verify project access and navigate into the one you want to manage.
+
+## Who should use this
+
+- Team members checking access across many projects
+- Admins validating organization setup
+
+## Steps
+
+1. Confirm you are in the right organization
+2. Go to the `Projects` page
+3. Confirm the list matches what you expect
+4. Pick one project to continue
+
+## Expected result
+
+- You can identify each project and who owns it
+- You can jump to project details from one list item
+
+## Common issues
+
+- No projects appear: confirm you are in the right organization
+- You may need extra permissions to see all projects
+
+## Next
+
+- Open a project with [`View a Project`](/docs/projects/view-project)

--- a/docs/docs/projects/remove-project.md
+++ b/docs/docs/projects/remove-project.md
@@ -1,0 +1,56 @@
+---
+title: Remove a Project
+links:
+  overview:
+  quickstart:
+  previous: projects/edit-project
+  next: projects/list-projects
+  guides:
+    - projects/list-projects
+    - projects/index
+  related:
+  featured:
+---
+
+Delete a project when it is no longer needed.
+
+## Goal
+
+Stop managing a project and remove it from the workspace.
+
+Warning:
+This action is permanent and removes project-level resources.
+
+Removing a project deletes its resources and cannot be undone.
+
+## Who should use this
+
+- Project owners
+- Organization owners with permission to delete project resources
+
+## You need
+
+- Permission to remove projects
+- Confirmation that team members are aware of the deletion
+
+## Steps
+
+1. Go to the project you want to remove
+2. Go to `Project Settings`
+3. Select `Remove Project`
+4. Confirm the removal in the final dialog
+
+## Result
+
+- The project disappears from the project list
+- Team access to that project is revoked
+
+## Common issues
+
+- You cannot remove the project: check if you have delete permission for the project
+- Environments are still active: remove or archive them first
+- You do not have permission to remove resources in this organization
+
+## Next
+
+- Check remaining projects in [`List Projects`](/docs/projects/list-projects)

--- a/docs/docs/projects/remove-project.md
+++ b/docs/docs/projects/remove-project.md
@@ -12,19 +12,17 @@ links:
   featured:
 ---
 
-Delete a project when it is no longer needed.
+Delete a project when you no longer need it.
 
 ## Goal
 
-Stop managing a project and remove it from the workspace.
+Stop managing a project and remove it from your setup.
 
 :::warning
 Removing a project is permanent. This action cannot be undone.
 :::
 
-This action removes project-level resources.
-
-Removing a project deletes its resources and cannot be undone.
+Deleting a project removes project resources (including all its environments) and cannot be undone.
 
 ## Who should use this
 

--- a/docs/docs/projects/remove-project.md
+++ b/docs/docs/projects/remove-project.md
@@ -18,8 +18,11 @@ Delete a project when it is no longer needed.
 
 Stop managing a project and remove it from the workspace.
 
-Warning:
-This action is permanent and removes project-level resources.
+:::warning
+Removing a project is permanent. This action cannot be undone.
+:::
+
+This action removes project-level resources.
 
 Removing a project deletes its resources and cannot be undone.
 

--- a/docs/docs/projects/view-project.md
+++ b/docs/docs/projects/view-project.md
@@ -6,9 +6,8 @@ links:
   previous: projects/add-project
   next: projects/list-projects
   guides:
-    related:
-      - projects/list-projects
-      - projects/add-project
+    - projects/list-projects
+    - projects/add-project
   featured:
 ---
 

--- a/docs/docs/projects/view-project.md
+++ b/docs/docs/projects/view-project.md
@@ -1,18 +1,46 @@
 ---
 title: View a Project
-intro: In this section you will learn how to manage your project.
 links:
   overview:
   quickstart:
   previous: projects/add-project
   next: projects/list-projects
   guides:
-  related:
+    related:
     - projects/list-projects
     - projects/add-project
+  featured:
 ---
 
-1. In your selected project page, you will see 3 sections: Environments, Teams and Roles. If you don't have any projects created, see the Add Project documentation page.
-2. On Environments section, you can create and manage different environments for your software.
-3. On Teams section, you can create different teams for your company or organization.
-4. On Roles section, you can create different roles each with specific permissions for specific resource types attributed to it.
+Review one project setup quickly in Devopness.
+
+## About
+
+Use this page to confirm environments, teams, roles, and API tokens for one project.
+
+## Who should use this
+
+- Project owners checking if setup is ready
+- Team members validating access before deployment
+
+## Steps
+
+1. Go to the project you want to review
+2. Open **Environments** to check deployment stages
+3. Open **Teams** to see who can work there
+4. Open **Roles** to verify permissions
+5. Open **API Tokens** when you need token-level checks
+
+## Expected result
+
+- You can confirm environment and access settings
+- You know what teams, roles, and tokens are active
+
+## Common issues
+
+- You cannot view project details: confirm your project permission in the selected organization
+- API tokens are missing: confirm the project has tokens enabled or create one
+
+## Next
+
+- Use [`Remove a Project`](/docs/projects/remove-project) if this is no longer needed

--- a/docs/docs/projects/view-project.md
+++ b/docs/docs/projects/view-project.md
@@ -7,8 +7,8 @@ links:
   next: projects/list-projects
   guides:
     related:
-    - projects/list-projects
-    - projects/add-project
+      - projects/list-projects
+      - projects/add-project
   featured:
 ---
 

--- a/docs/docs/projects/view-project.md
+++ b/docs/docs/projects/view-project.md
@@ -11,7 +11,7 @@ links:
   featured:
 ---
 
-Review one project setup quickly in Devopness.
+Review one project setup in Devopness.
 
 ## About
 
@@ -20,14 +20,14 @@ Use this page to confirm environments, teams, roles, and API tokens for one proj
 ## Who should use this
 
 - Project owners checking if setup is ready
-- Team members validating access before deployment
+- Team members validating access before deploy
 
 ## Steps
 
 1. Go to the project you want to review
-2. Open **Environments** to check deployment stages
+2. Open **Environments** to check each environment
 3. Open **Teams** to see who can work there
-4. Open **Roles** to verify permissions
+4. Open **Roles** to verify access
 5. Open **API Tokens** when you need token-level checks
 
 ## Expected result

--- a/docs/docs/roles/add-role.md
+++ b/docs/docs/roles/add-role.md
@@ -1,24 +1,51 @@
 ---
 title: Add a Role
-intro: Add roles to organize permissions that can be re-used on environments team memberships.
 links:
-  overview: Project owners can create roles to be used when managing environments team permissions.
+  overview: roles/index
   quickstart:
-  previous:
+  previous: roles/list-roles
   next: teams/add-team
   guides:
+    - roles/list-roles
+    - roles/view-role
   related:
   featured:
 ---
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-1. Select a `Project`
-1. Find the `Roles` card
-1. Click View in the `Roles` card to see a list of existing `Roles`
-1. On the upper-right corner of the list click `ADD ROLE`
-1. Provide a name to the `Role`
-1. Optionally type a `Description` explaining the purpose of the role
-1. Click `NEXT`
-1. In the `Permissions` step select the permissions for each resource type
-1. Click `CONFIRM`
-   - In the `Roles` list, the recently created `Role` can be seen
+Create a permission set you can reuse across multiple team memberships.
+
+## Goal
+
+Define what teams can do before granting access.
+
+## Who should use this
+
+- Organization admins creating reusable access sets
+- Team leads setting access rules
+
+## You need
+
+- Permission to create roles in the organization
+
+## Steps
+
+1. Open the organization role settings
+2. Open `Roles`
+3. Click `ADD ROLE`
+4. Enter a name and optional description
+5. Select the permissions you want the role to allow
+6. Click `CONFIRM`
+
+## Expected result
+
+- The new role is saved in the organization
+- You can attach it when creating team memberships
+
+## Common issues
+
+- Save fails: verify permission to manage roles
+- Missing permission options: ensure you have role configuration access
+
+## Next
+
+- Attach the role through [Team Memberships](/docs/environments/team-memberships/add-team-membership)

--- a/docs/docs/roles/index.md
+++ b/docs/docs/roles/index.md
@@ -1,12 +1,44 @@
 ---
 title: Roles
-intro: Use Roles to give people and teams the appropriate access to resources, features and tasks they need permissions to collaborate in project environments.
 links:
   overview:
   quickstart:
   previous:
-  next:
+  next: roles/list-roles
   guides:
+    - roles/list-roles
+    - roles/add-role
+    - teams/index
   related:
   featured:
 ---
+
+Roles are permission sets for role-based access control (RBAC).  
+They define what a team can do when that role is applied at the organization, project, or environment level.
+
+## About
+
+- Roles are permission sets that control team actions across Devopness
+- A role can apply to an organization, a project, or an environment
+- Teams use roles to grant access with the right level of permission
+
+## Who should use this
+
+- Organization owners who standardize access policy
+- Project and environment admins assigning team access
+
+## Why this exists
+
+- Roles reduce repeated permission setup for many teams
+- Roles make it easier to review security behavior during audits
+
+## Relationship to other concepts
+
+- Teams hold people
+- Roles hold allowed actions
+- Team Memberships attach a role to a team in an environment
+
+## Start here
+
+- Create roles in [Add a Role](/docs/roles/add-role)
+- Attach a role when creating [Team Memberships](/docs/environments/team-memberships/add-team-membership)

--- a/docs/docs/roles/list-roles.md
+++ b/docs/docs/roles/list-roles.md
@@ -1,17 +1,48 @@
 ---
 title: List Roles
-intro: Learn how to view the list of roles available to manage access and permissions across your project environments.
 links:
-  overview:
+  overview: roles/index
   quickstart:
   previous: roles/index
   next: roles/view-role
   guides:
-  related:
+    - roles/add-role
+    - roles/view-role
   featured:
 ---
 
-1. On Devopness, navigate to a project then select an environment
-1. Click the `Roles` section to view all available roles
-1. Use the list to understand each role’s purpose and permissions
-1. Click the `NAME` of a role to view its details
+Review all roles defined in your organization.
+
+## Goal
+
+Find the right role before granting a team access in environment settings.
+
+## Who should use this
+
+- Organization admins checking available permission sets
+- Environment admins assigning team access
+
+## You need
+
+- Permission to view organization roles
+
+## Steps
+
+1. Open the organization where roles are managed
+2. Open `Roles`
+3. Open the role list
+4. Select a role to inspect details
+
+## Expected result
+
+- You can confirm all available roles and what they allow
+- You can open one role to verify permissions before assigning it
+
+## Common issues
+
+- List is empty: confirm roles exist in this organization
+- You cannot open details: check role read permission
+
+## Next
+
+- Inspect a role in [Check a Role's Permissions](/docs/roles/view-role)

--- a/docs/docs/roles/view-role.md
+++ b/docs/docs/roles/view-role.md
@@ -1,19 +1,48 @@
 ---
 title: Check a Role's Permissions
-intro: Check a role's permissions to understand the role's access level on the associated project.
 links:
-  overview:
+  overview: roles/index
   quickstart:
-  previous:
+  previous: roles/list-roles
   next:
   guides:
-  related:
+    - roles/list-roles
+    - roles/add-role
   featured:
 ---
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-1. Select a `Project`
-1. Find the `Roles` card
-1. Click `View` in the `Roles` card to see a list of existing `Roles`
-1. In the list of roles, find the role you want to check the permissions and click the `NAME` of the role
-1. In the role details view, you will see the list of permissions granted by this role
+Inspect what a role can do before assigning it to a team.
+
+## Goal
+
+Understand the exact permissions a role grants in an environment.
+
+## Who should use this
+
+- Team owners reviewing security impact
+- Environment admins choosing a safe access level
+
+## You need
+
+- Permission to view role definitions
+
+## Steps
+
+1. Open the organization and go to `Roles`
+2. Select the role you want to verify
+3. Review each permission group and action in the role details
+4. Confirm it matches the access you expect before using it in memberships
+
+## Expected result
+
+- You can decide whether the role is safe for the target environment
+- You can avoid giving teams more access than needed
+
+## Common issues
+
+- You cannot see permissions: confirm organization-level read access
+- Permission list is unclear: reopen from list to view the latest definition
+
+## Next
+
+- Update access by assigning roles through [Team Memberships](/docs/environments/team-memberships)

--- a/docs/docs/teams/add-team.md
+++ b/docs/docs/teams/add-team.md
@@ -1,21 +1,49 @@
 ---
 title: Add a Team
-intro: Add teams to organize groups of people in any way that makes it more convenient to grant and revoke project permissions.
 links:
-  overview: Project owners can create teams as a initial step to manage permissions and collaboration on environment resources.
+  overview:
   quickstart:
-  previous: ssl-certificates/add-ssl-certificate
+  previous: teams/list-teams
   next: teams/invitations/add-invitation
   guides:
-  related:
+    - teams/list-teams
+    - teams/members/index
   featured:
 ---
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-1. Select a `Project`
-1. Find the `Teams` card
-1. Click `View` in the `Teams` card to see a list of existing `Teams`
-1. On the upper-right corner of the list click `ADD TEAM`
-1. Provide a name to the `Team` being added. Example: "Backend Developers"
-1. Click `CONFIRM`
-   - In the `Teams` list, the recently created `Team` can be seen
+Create a new team inside an organization so many people can share access settings.
+
+## Goal
+
+Set up a team to reuse the same role setup for project and environment access.
+
+## Who should use this
+
+- Organization admins creating reusable access setup
+- Project owners assigning teams to environments and projects
+
+## You need
+
+- Permission to create teams in the organization
+
+## Steps
+
+1. Open the organization that owns the new team
+2. Open `Teams`
+3. Click `ADD TEAM`
+4. Enter a clear team name
+5. Click `CONFIRM`
+
+## Expected result
+
+- The new team appears in the team list
+- You can invite people to it and later assign it to environments
+
+## Common issues
+
+- You cannot save: confirm team creation permission
+- Name is rejected: choose a unique and readable team name
+
+## Next
+
+- Add members with [Invite Team Member](/docs/teams/invitations/add-invitation)

--- a/docs/docs/teams/index.md
+++ b/docs/docs/teams/index.md
@@ -1,12 +1,49 @@
 ---
 title: Teams
-intro: Use Teams to group people in a project to ensure they all can collaborate on the same environment resources while sharing a common set of access permissions.
 links:
   overview:
   quickstart:
-  previous: projects/index
-  next:
+  previous:
+  next: teams/list-teams
   guides:
+    - teams/list-teams
+    - teams/add-team
+    - organizations/index
   related:
   featured:
 ---
+
+Teams are groups of people in an organization so multiple people can share the same access setup in one place.
+
+## About
+
+- Teams are created at organization level, not inside one project
+- Members get access from the team role that is set on each environment
+- Teams keep access behavior the same as people are added or removed
+
+## Who this is for
+
+- Organization owners who want one place to manage people access
+- Team leads sharing work on environments and projects
+- Project admins adding or removing many people at once
+
+## Why this exists
+
+- It helps you add people to a team once instead of editing each person
+- It keeps access consistent when people join or leave the team
+
+## Relationship to other concepts
+
+- Organization owns teams and roles
+- Project admins can link teams to project and environment workflows
+- Environment admins can use Team Memberships to grant a team role in an environment
+
+## Start here
+
+- Use [Add a Team](/docs/teams/add-team) to create the group
+- Open the team in [List Teams](/docs/teams/list-teams) to confirm members
+- Link teams to environments from [Team Memberships](/docs/environments/team-memberships)
+
+## Next
+
+- Review [Roles](/docs/roles) before assigning environment access

--- a/docs/docs/teams/invitations/add-invitation.md
+++ b/docs/docs/teams/invitations/add-invitation.md
@@ -1,22 +1,60 @@
 ---
 title: Invite Team Member
-intro: Invite members to a team so people can collaborate to all project environments on which the team has permissions.
 links:
-  overview: Project owners can add members to multiple teams and invite non-members to join a project team.
+  overview: teams/invitations/index
   quickstart:
-  previous: teams/add-team
+  previous: teams/invitations/list-invitations
   next: environments/team-memberships/add-team-membership
   guides:
-  related:
+    - teams/invitations/list-invitations
+    - teams/list-teams
   featured:
 ---
 
-1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
-1. In the list of `Projects` find the `Project` with the `Team` you want to manage and click `View`
-1. In the list of Project resources find the `Teams` card and click `View`
-1. In the list of `Teams` find the `Team` you want to add a member and click `View`
-1. On the upper-right corner of the team details view, click `INVITATIONS`
-1. On the upper-right corner of the `Invitations` list, click `INVITE MEMBER`
-1. Provide the email of the member to be invited
-1. Click `CONFIRM`
-   - In the `Invitations` list, the recently created `Invitation` can be seen
+Invite one person to a team, or create a public link to share with a group.
+
+## Goal
+
+Add one person through a private invite, or generate a public link for a wider audience.
+
+## Who should use this
+
+- Team admins adding new collaborators
+- Owners managing team setup
+
+## You need
+
+- Team admin access in the target organization
+- Permission to send team invitations
+
+## Steps
+
+1. Open the organization that owns the team
+2. Open `Teams` and select the target team
+3. Open `Invitations`
+4. Choose one path:
+   - Private invite: enter one email address
+   - Public invite: open the public invite flow
+5. For private: enter the person's email address
+6. For public: generate the invitation link and copy it
+7. Confirm to create the invitation
+
+## Expected result
+
+- A new private invite or public link is created
+- The recipient can accept and join the team
+
+### Security note
+
+Use private invites by default.
+Use a public link only when you want to add many people from a known group at once.
+
+## Common issues
+
+- Invite is rejected: confirm the email is valid for private invitations
+- Public link is missing or expired: generate a new link and share it again
+- Invite is blocked: verify sender permissions for team invitations
+
+## Next
+
+- Grant team access to environments in [Team Memberships](/docs/environments/team-memberships)

--- a/docs/docs/teams/invitations/index.md
+++ b/docs/docs/teams/invitations/index.md
@@ -1,11 +1,10 @@
 ---
-title: Invitations
-intro: Manage team invitations to control who can join your project teams and collaborate on your infrastructure.
+title: Team invitations
 links:
-  overview: Team invitations allow project owners to invite new members to join their teams and collaborate on project environments.
+  overview:
   quickstart: teams/invitations/add-invitation
-  previous: teams/add-team
-  # next: teams/members/add-team-member
+  previous: teams/index
+  # next: teams/members
   guides:
     - teams/invitations/add-invitation
     - teams/invitations/list-invitations
@@ -14,22 +13,34 @@ links:
   featured:
 ---
 
-## Team Invitations
+Team invitations are how you add people to a team so the team can access resources in one organization, project, or environment.
+You can use two invitation types:
 
-Team invitations are a way to invite new members to join your project teams. When you invite someone to a team, they receive an email invitation that allows them to join the project and collaborate on the environments that the team has access to.
+- Public invitation: Devopness creates a join link you can share with many people. This is useful for communities or team channels where you want fast onboarding.
+- Private invitation: you enter one email address, and the invite is sent only to that person.
 
-### Available Actions
+If you want the tighter security default, use private invitations. Use public links only when you are intentionally opening team access to a wider audience.
 
-- **[Add Team Member](add-invitation.md)**: Send an invitation to a new team member
-- **[List Team Invitations](list-invitations.md)**: View all pending and completed invitations
+## About
 
-### Invitation Process
+- Invitations are sent to people not yet in the team
+- Private invites go to one email address, while public invites use a shared link
+- Once accepted, the member joins the team and gets that team’s access
+- Team access still depends on roles assigned at organization, project, or environment scope
 
-1. **Send Invitation**: Project owners can invite new members by providing their email address
-2. **Email Notification**: The invited member receives an email with a link to accept the invitation
-3. **Accept Invitation**: The member clicks the link and creates their Devopness account
-4. **Team Access**: Once accepted, the member gains access to all environments the team has permissions for
+## Who this is for
 
-### Managing Invitations
+## Why this exists
 
-You can view all invitations for a team, including their status (Pending, Accepted, Expired) and take actions like resending or canceling invitations as needed.
+- It keeps invite flow clear as organizations grow
+- It helps avoid giving people direct environment access before the team role is set
+
+## Relationship to other concepts
+
+- Invitations apply to teams in an organization
+- Team memberships apply role-based permissions at organization, project, or environment level
+
+## Start here
+
+- Send one invitation in [Invite Team Member](/docs/teams/invitations/add-invitation)
+- Review invite status in [List Team Invitations](/docs/teams/invitations/list-invitations)

--- a/docs/docs/teams/invitations/index.md
+++ b/docs/docs/teams/invitations/index.md
@@ -30,6 +30,9 @@ If you want the tighter security default, use private invitations. Use public li
 
 ## Who this is for
 
+- Team admins adding collaborators
+- Organization owners onboarding users in bulk or in groups
+
 ## Why this exists
 
 - It keeps invite flow clear as organizations grow

--- a/docs/docs/teams/invitations/list-invitations.md
+++ b/docs/docs/teams/invitations/list-invitations.md
@@ -1,15 +1,52 @@
 ---
 title: List Team Invitations
-intro: View all pending and completed invitations for a team to track team member onboarding status.
 links:
-  overview: Project owners and team administrators can view all invitations sent to potential team members.
+  overview: teams/invitations/index
   quickstart:
   previous: teams/invitations/add-invitation
   # next: teams/members/add-team-member
   guides:
-  related:
+    - teams/invitations/add-invitation
+    - teams/invitations/index
   featured:
 ---
+
+Track the status of team invites, both private and public, before they are accepted.
+
+## Goal
+
+Know which invites are pending, accepted, or expired before you grant broader access.
+
+## Who should use this
+
+- Team admins adding collaborators
+- Organization owners checking invitation workflow
+
+## You need
+
+- Team admin access in the organization
+- Invite sending enabled for the team
+
+## Steps
+
+1. Open the organization and the team you manage
+2. Open `Invitations`
+3. Review pending, accepted, and expired items
+4. Open an invite if you need to resend or revoke it
+
+## Expected result
+
+- You can see current invite state for the team
+- You can clean up stale invites before they become confusing
+
+## Common issues
+
+- No invite list: confirm you are on the correct team
+- Missing status: refresh the page after changing invite state
+
+## Next
+
+- Send a new invite in [Invite Team Member](/docs/teams/invitations/add-invitation)
 
 1. On Devopness upper-left corner, click the Devopness logo to see a list of existing projects
 1. In the list of `Projects` find the `Project` with the `Team` you want to manage and click `View`
@@ -18,6 +55,7 @@ links:
 1. On the upper-right corner of the team details view, click `INVITATIONS`
 1. In the `Invitations` list, you can see:
    - **Email**: The email address of the invited member
+   - **Type**: `private` for one-email invites, `public` for link invites
    - **Status**: Current status of the invitation (Pending, Accepted, Expired)
    - **Invited by**: Who sent the invitation
    - **Invited at**: When the invitation was sent

--- a/docs/docs/teams/list-teams.md
+++ b/docs/docs/teams/list-teams.md
@@ -1,19 +1,51 @@
 ---
 title: List Teams
-intro: View your list of teams
 links:
-  overview:
+  overview: teams/index
   quickstart:
-  previous: teams/add-team
+  previous: teams/index
   next: teams/view-team
   guides:
-  related:
     - teams/add-team
+    - teams/view-team
+  related:
   featured:
 ---
 
-1. When accessing Devopness, existing projects are automatically listed on the home screen. To navigate between projects, click the Devopness logo in the top-left corner.
-2. Select a project.
-3. Find the Teams card.
-4. Click view all on the Teams card to see a list of existing teams.
-5. All teams you have created will be displayed.
+View all teams in an organization and confirm who is available for access.
+
+## Goal
+
+Use this page to verify team structure before you use them for access.
+
+## Who should use this
+
+- Organization owners planning role-based access
+- Project admins checking team availability
+- Environment admins setting up environment grants
+
+## You need
+
+- Access to the target organization
+- Permission to view teams
+
+## Steps
+
+1. Open the target organization
+2. Open `Teams`
+3. Open the full team list
+4. Confirm each team name and status
+
+## Expected result
+
+- You can see all teams in the organization
+- You can open a team to assign members or invitations
+
+## Common issues
+
+- No teams appear: verify you are in the right organization
+- Missing actions: confirm team read permissions
+
+## Next
+
+- Open a team in [View a Team](/docs/teams/view-team) to manage its members and settings

--- a/docs/docs/teams/members/index.md
+++ b/docs/docs/teams/members/index.md
@@ -1,12 +1,40 @@
 ---
 title: Members
-intro: Add members to a Team so people can collaborate to all Environments on which the Team has permissions.
 links:
   overview:
   quickstart:
   previous: teams/index
   next: teams/invitations/add-invitation
   guides:
+    - teams/invitations/add-invitation
+    - teams/invitations/list-invitations
   related:
   featured:
 ---
+
+A team member is a user invited to join a team.
+After accepting, the member gets the same access as other people in that team: based on the role assigned to the team at the organization, project, or environment level.
+
+## About
+
+- Members are invited to a specific team, and that team can be attached to one or more projects or environments
+- A member can join multiple teams in the same organization
+
+## Who should use this
+
+- Team admins keeping team access current
+- Organization owners checking who can access shared resources
+
+## Why this exists
+
+- It is easier to add and remove people from one team than from every project or environment
+
+## Relationship to other concepts
+
+- Teams are organized by organization
+- Roles control what a member can do through team membership in an environment
+
+## Start here
+
+- Add team members by inviting users in [Invite Team Member](/docs/teams/invitations/add-invitation)
+- Track invites and statuses in [List Team Invitations](/docs/teams/invitations/list-invitations)

--- a/docs/docs/teams/view-team.md
+++ b/docs/docs/teams/view-team.md
@@ -1,23 +1,48 @@
 ---
 title: View a Team
-intro: In this section, you will learn how to manage your team.
 links:
-  overview:
+  overview: teams/index
   quickstart:
   previous: teams/list-teams
   next: teams/invitations/add-invitation
-  guides:
-  related:
-    - teams/add-team
-    - teams/list-teams
+guides:
+  - teams/invitations/list-invitations
+  - teams/add-team
+featured:
 ---
 
-1. On the selected project's page, locate the Teams card.
-2. Click View all on the Teams card to see the list of existing teams.
-   > If there are no teams yet, create one by clicking the Add team button.
-3. Select the team you want to manage.
-4. For each team, you can:
-   - Invite new members
-   - View existing members
-   - Edit team information
-   - Delete the team, if needed
+Review one team and understand who is attached before changing membership or access.
+
+## Goal
+
+Check team state before you invite members or reuse the team in environments.
+
+## Who should use this
+
+- Organization owners validating team health
+- Project admins connecting teams to project workflows
+
+## You need
+
+- Permission to view team details in the organization
+
+## Steps
+
+1. Open the organization that owns the team
+2. Open `Teams`
+3. Select the team you want to review
+4. Open related sections for members or invitations
+
+## Expected result
+
+- You can confirm current members and invite activity
+- You can open invites or team access actions from there
+
+## Common issues
+
+- Team details are hidden: check your organization role
+- Member list looks stale: refresh the team view
+
+## Next
+
+- Invite people with [Invite Team Member](/docs/teams/invitations/add-invitation)

--- a/docs/docs/teams/view-team.md
+++ b/docs/docs/teams/view-team.md
@@ -5,10 +5,10 @@ links:
   quickstart:
   previous: teams/list-teams
   next: teams/invitations/add-invitation
-guides:
-  - teams/invitations/list-invitations
-  - teams/add-team
-featured:
+  guides:
+    - teams/invitations/list-invitations
+    - teams/add-team
+  featured:
 ---
 
 Review one team and understand who is attached before changing membership or access.


### PR DESCRIPTION
## Description of changes

**Problem to be fixed**
* Docs were still showing project as the container for teams and roles.

- [x] Improved docs guidelines and saved them in `authoring-guidelines.md`
- [x] Applied new guildelines to: organizations, projects, environments, tokens, cronjobs, teams, roles and team invitations

## GitHub issues resolved by this PR
- N/A

## Quality Assurance
- New visitors should be able to get started and create their first Organization, project, environment, tokens and cronjobs, as now operation docs should follow the same outcome-first structure

## More info
