### PR TITLE
docs(daemons): move deprecated intro field from frontmatter to body

### DIFF
--- a/docs/docs/daemons/add-daemon.md
+++ b/docs/docs/daemons/add-daemon.md
@@ -1,6 +1,5 @@
 ---
 title: Add a Daemon
-intro: Add a Daemon to keep a program alive, always running with the number of configured processes. A daemon run as a background process and can restart the program when it fails or its code/command line is modified.
 links:
   overview:
   quickstart:
@@ -12,6 +11,8 @@ links:
 required_permissions:
   - daemon:create
 ---
+
+Add a Daemon to keep a program alive, always running with the number of configured processes. A daemon run as a background process and can restart the program when it fails or its code/command line is modified.
 
 1. On Devopness, navigate to a project, then select an environment
 1. Find the `Daemons` card

--- a/docs/docs/daemons/edit-daemon.md
+++ b/docs/docs/daemons/edit-daemon.md
@@ -1,6 +1,5 @@
 ---
 title: Edit a Daemon
-intro: Edit a Daemon to update the application, settings, command, or other configurations of an existing Daemon.
 links:
   overview:
   quickstart:
@@ -12,6 +11,8 @@ links:
 required_permissions:
   - daemon:update
 ---
+
+Edit a Daemon to update the application, settings, command, or other configurations of an existing Daemon.
 
 1. On Devopness, navigate to a project, then select an environment
 1. Find the `Daemons` card

--- a/docs/docs/daemons/index.md
+++ b/docs/docs/daemons/index.md
@@ -1,6 +1,5 @@
 ---
 title: Daemons
-intro: Many applications rely on background processes, or daemons, to keep critical programs alive and running continuously. Devopness simplifies the management of these daemons by providing a centralized platform, allowing you to configure, monitor, and maintain these persistent processes with ease. Daemons run as background processes and can automatically restart a program if it fails or when its code/command line is modified.
 links:
   overview:
   quickstart:
@@ -8,3 +7,5 @@ links:
   related:
   featured:
 ---
+
+Many applications rely on background processes, or daemons, to keep critical programs alive and running continuously. Devopness simplifies the management of these daemons by providing a centralized platform, allowing you to configure, monitor, and maintain these persistent processes with ease. Daemons run as background processes and can automatically restart a program if it fails or when its code/command line is modified.

--- a/docs/docs/daemons/remove-daemon.md
+++ b/docs/docs/daemons/remove-daemon.md
@@ -1,6 +1,5 @@
 ---
 title: Remove a Daemon
-intro: Remove a Daemon when it is no longer needed.
 links:
   overview:
   quickstart:
@@ -12,6 +11,8 @@ links:
 required_permissions:
   - daemon:delete
 ---
+
+Remove a Daemon when it is no longer needed.
 
 1. On Devopness, navigate to a project, then select an environment
 1. Find the `Daemons` card


### PR DESCRIPTION
## Description of changes

- [x] Migrates the deprecated `intro` frontmatter to body content across the `daemons/` documentation cluster (4 files), following the migration documented in [`docs/docs/README.md`](https://github.com/devopness/devopness/blob/main/docs/docs/README.md#intro)
- [x] Aligns with the authoring guideline rule: *"Do not add `intro` in frontmatter. Write page context in the markdown body"* ([`authoring-guidelines.md`](https://github.com/devopness/devopness/blob/main/docs/docs/authoring-guidelines.md#2-intro-and-frontmatter-behavior))
- [x] Scoped intentionally to `daemons/` for easy review — other clusters still using `intro:` (`ssh-keys/`, `virtual-hosts/`, `security/`) can follow in separate PRs if maintainers want the same treatment

For each file in `docs/docs/daemons/`:

- removed `intro: <text>` from the YAML frontmatter
- moved the same text to the first paragraph of the markdown body

No content was added, removed, or rewritten — only relocated.

Files touched:

- `docs/docs/daemons/index.md`
- `docs/docs/daemons/add-daemon.md`
- `docs/docs/daemons/edit-daemon.md`
- `docs/docs/daemons/remove-daemon.md`

## GitHub issues resolved by this PR

- [ ] N/A — this PR aligns existing pages with the deprecation already documented in `docs/docs/README.md`; no specific issue is open for the daemons cluster.

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: the four `daemons/` pages (`/docs/daemons`, `/docs/daemons/add-daemon`, `/docs/daemons/edit-daemon`, `/docs/daemons/remove-daemon`) render with the intro text as the first body paragraph below the page title, and `intro:` no longer appears in their frontmatter.

Verified locally with `cd docs && npm install && npm run dev`. Visual comparison below confirms the intro paragraph renders directly under the page title — visually equivalent to the previous behavior, where `docs/source.config.ts` aliased `intro` to `description`.

## More info

### Visual evidence

#### `/docs/daemons` (index)

| Before | After |
|---|---|
| ![before-daemons-index](https://github.com/user-attachments/assets/eac85328-a934-4cff-99c3-dd468aed99ca) | ![after-daemons-index](https://github.com/user-attachments/assets/f457bc09-adc6-4372-8dcb-77d45ebc8055) |

#### `/docs/daemons/add-daemon`

| Before | After |
|---|---|
| ![before-daemons-add](https://github.com/user-attachments/assets/10aba8b8-9050-41e4-bb0f-65eb562f5071) | ![after-daemons-add](https://github.com/user-attachments/assets/3db294c5-5707-44d1-b791-43e57a5dd0e4) |

#### `/docs/daemons/edit-daemon`

| Before | After |
|---|---|
| ![before-daemons-edit](https://github.com/user-attachments/assets/1b9a2945-c317-47ed-9686-b26f1798f1bf) | ![after-daemons-edit](https://github.com/user-attachments/assets/406cb6ef-ce18-4e74-9674-99aa6f9fb9e7) |

#### `/docs/daemons/remove-daemon`

| Before | After |
|---|---|
| ![before-daemons-remove](https://github.com/user-attachments/assets/1af45991-9407-4464-9c88-4fe1a89515f2) | ![after-daemons-remove](https://github.com/user-attachments/assets/0b4a4370-e3f4-47ef-878f-fff173b9b1c5) |

### Note on pagination card subtitles

Removing `intro:` also removes the implicit `intro → description` mapping in `docs/source.config.ts`. As a consequence, **pagination cards pointing to the affected pages no longer show a description subtitle** — matching the precedent already set by the migrated [`cronjobs/`](https://github.com/devopness/devopness/tree/main/docs/docs/cronjobs) cluster:

![reference-cronjobs-already-migrated](https://github.com/user-attachments/assets/a6cf1cca-8a6b-4a0c-ba65-ed94fd01c84c)

The `/docs/cronjobs` index above renders the `Add a Cron Job` pagination card without a subtitle (already migrated, no `description:` field).

If maintainers prefer to preserve pagination subtitles for these pages, an explicit `description:` field can be added per file in a follow-up; this PR keeps parity with the existing migration pattern.