### PR TITLE
chore: bump @mui/material to 9.0.1 in ui-react package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2916,6 +2916,7 @@
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.5.0.tgz",
       "integrity": "sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
@@ -2926,6 +2927,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
       "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/core-downloads-tracker": "^6.5.0",
@@ -2975,6 +2977,7 @@
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.9.tgz",
       "integrity": "sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/utils": "^6.4.9",
@@ -3002,6 +3005,7 @@
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.5.0.tgz",
       "integrity": "sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@emotion/cache": "^11.13.5",
@@ -3059,6 +3063,7 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.5.0.tgz",
       "integrity": "sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/private-theming": "^6.4.9",
@@ -3099,6 +3104,7 @@
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
       "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -3113,6 +3119,7 @@
       "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
       "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/types": "~7.2.24",
@@ -18049,7 +18056,7 @@
       "version": "2.184.6",
       "license": "MIT",
       "dependencies": {
-        "@mui/material": "^6.5.0",
+        "@mui/material": "^9.0.1",
         "@mui/styled-engine-sc": "^9.0.1",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/themes": "^3.3.0",
@@ -18167,6 +18174,213 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "packages/ui/react/node_modules/@mui/core-downloads-tracker": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.1.tgz",
+      "integrity": "sha512-GzamIIhZ1bH77dq7eKaeyRgJdkypsxin4jBFq2EMs4lBWRR0LFO1CSVMsoebn/VvjcNrnrOrjy48MkrkQUK2iw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "packages/ui/react/node_modules/@mui/material": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.1.tgz",
+      "integrity": "sha512-voyCpeUxcSWLN7KPZuq0pGCIt726T9K6kiVM3XUcywZDAlZSarLHaUxJVQpospbjjOzN53hwyjo8s6KoWl6utw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/core-downloads-tracker": "^9.0.1",
+        "@mui/system": "^9.0.1",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.1",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.4",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^9.0.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ui/react/node_modules/@mui/material/node_modules/@mui/system": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.1.tgz",
+      "integrity": "sha512-WvlioaLxk6ewUIOfh0StxUvOPDS1mCfzaulcudsL1brZNXuh0N9FMk7RpH7ImJKjEz412SEy/V/yvqmtxbqxCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/private-theming": "^9.0.1",
+        "@mui/styled-engine": "^9.0.0",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.1",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ui/react/node_modules/@mui/material/node_modules/@mui/system/node_modules/@mui/private-theming": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.1.tgz",
+      "integrity": "sha512-pSIGq4Yw749KHEwlkYZWVERgHgwJELP6ODtBNUfV8V4oIb5H+h7IQDFXuk/b2oQccODK1enJAtiEzlgLZmq+8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "^9.0.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ui/react/node_modules/@mui/material/node_modules/@mui/system/node_modules/@mui/styled-engine": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.0.0.tgz",
+      "integrity": "sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ui/react/node_modules/@mui/material/node_modules/@mui/types": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ui/react/node_modules/@mui/material/node_modules/@mui/utils": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.1.tgz",
+      "integrity": "sha512-f3UO3jNN1pYg5zxqXC81Bvv8hx5ACcYc0387382ZI7M5ono1heIwHYLrKsz85myguWdeVKPRZGmDdynWUBjK2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.0.0",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "packages/ui/react/node_modules/@types/node": {

--- a/packages/ui/react/package.json
+++ b/packages/ui/react/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://github.com/devopness/devopness#readme",
   "dependencies": {
-    "@mui/material": "^6.5.0",
+    "@mui/material": "^9.0.1",
     "@mui/styled-engine-sc": "^9.0.1",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/themes": "^3.3.0",

--- a/packages/ui/react/src/components/Forms/Autocomplete/Autocomplete.tsx
+++ b/packages/ui/react/src/components/Forms/Autocomplete/Autocomplete.tsx
@@ -41,16 +41,19 @@ const Autocomplete = ({ inputProps, autocompleteProps }: AutocompleteProps) => (
     freeSolo
     slots={{ popper: AutocompletePopper }}
     renderInput={(params) => {
-      const { slotProps } = params
-      const { input: muiInputProps, htmlInput: muiHtmlInputProps } = slotProps
+      const {
+        slotProps: {
+          input: { ref: inputRef },
+          htmlInput: muiInputProps,
+        },
+      } = params
 
       return (
-        <div ref={muiInputProps.ref}>
+        <div ref={inputRef}>
           <Input
             {...inputProps}
-            {...muiInputProps}
             type="text"
-            inputProps={muiHtmlInputProps}
+            inputProps={muiInputProps}
           />
         </div>
       )

--- a/packages/ui/react/src/components/Forms/Autocomplete/Autocomplete.tsx
+++ b/packages/ui/react/src/components/Forms/Autocomplete/Autocomplete.tsx
@@ -41,10 +41,11 @@ const Autocomplete = ({ inputProps, autocompleteProps }: AutocompleteProps) => (
     freeSolo
     slots={{ popper: AutocompletePopper }}
     renderInput={(params) => {
-      const { InputProps, inputProps: muiInputProps } = params
+      const { slotProps } = params
+      const { input: muiInputProps } = slotProps
 
       return (
-        <div ref={InputProps.ref}>
+        <div ref={muiInputProps.ref}>
           <Input
             {...inputProps}
             {...muiInputProps}

--- a/packages/ui/react/src/components/Forms/Autocomplete/Autocomplete.tsx
+++ b/packages/ui/react/src/components/Forms/Autocomplete/Autocomplete.tsx
@@ -42,7 +42,7 @@ const Autocomplete = ({ inputProps, autocompleteProps }: AutocompleteProps) => (
     slots={{ popper: AutocompletePopper }}
     renderInput={(params) => {
       const { slotProps } = params
-      const { input: muiInputProps } = slotProps
+      const { input: muiInputProps, htmlInput: muiHtmlInputProps } = slotProps
 
       return (
         <div ref={muiInputProps.ref}>
@@ -50,6 +50,7 @@ const Autocomplete = ({ inputProps, autocompleteProps }: AutocompleteProps) => (
             {...inputProps}
             {...muiInputProps}
             type="text"
+            inputProps={muiHtmlInputProps}
           />
         </div>
       )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description of changes

Address CI errors found in #3001

- [x] Upgraded `@mui/material` in `packages/ui/react` from `^6.5.0` to `^9.0.1`.
- [x] Updated `packages/ui/react/package.json` lockfile state from the previous dependency bump.
- [x] Updated `packages/ui/react/src/components/Forms/Autocomplete/Autocomplete.tsx` to use MUI 9 `slotProps` safely:
  - Keep `slotProps.input.ref` only for wrapper ref.
  - Use `slotProps.htmlInput` as `inputProps`.
  - Remove spreading `slotProps.input` into our `Input` component to avoid leaking MUI-internal props into the DOM.

## GitHub issues resolved by this PR
- [x] N/A

## Quality Assurance
- [x] `npm test --workspace @devopness/ui-react` (253 tests passed)
- [x] `npm run lint --workspace @devopness/ui-react`
- [x] `npm run build --workspace @devopness/ui-react`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7528527-24bd-444a-952f-b469dec813fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7528527-24bd-444a-952f-b469dec813fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

