### PR TITLE
fix(ui-react): refine Button hover with color-mix per variant

### DIFF
--- a/.changeset/button-hover-color-mix.md
+++ b/.changeset/button-hover-color-mix.md
@@ -1,0 +1,5 @@
+---
+"@devopness/ui-react": patch
+---
+
+Refine Button hover state: replace the global `filter: brightness(75%)` with `color-mix`-based background and border colors so each `buttonType` darkens (or lightens for outlined/borderless variants) in a way that respects its base color, and transition `background-color` and `border-color` instead of `filter` for a smoother hover

--- a/packages/ui/react/src/components/Buttons/Button/Button.stories.ts
+++ b/packages/ui/react/src/components/Buttons/Button/Button.stories.ts
@@ -27,5 +27,71 @@ const Primary: Story = {
   },
 }
 
+const Borderless: Story = {
+  args: {
+    children: 'Borderless',
+    buttonType: 'borderless',
+  },
+}
+
+const OutlinedSecondary: Story = {
+  args: {
+    children: 'Outlined Secondary',
+    buttonType: 'outlinedSecondary',
+  },
+}
+
+const OutlinedAuxiliary: Story = {
+  args: {
+    children: 'Outlined Auxiliary',
+    buttonType: 'outlinedAuxiliary',
+  },
+}
+
+const Medium: Story = {
+  args: {
+    children: 'Medium Size',
+    typeSize: 'medium',
+  },
+}
+
+const AutoSize: Story = {
+  args: {
+    children: 'Auto Size',
+    typeSize: 'auto',
+  },
+}
+
+const WithIcon: Story = {
+  args: {
+    children: 'With Icon',
+    icon: 'add',
+  },
+}
+
+const Loading: Story = {
+  args: {
+    children: 'Loading',
+    loading: true,
+  },
+}
+
+const Disabled: Story = {
+  args: {
+    children: 'Disabled',
+    disabled: true,
+  },
+}
+
 export default meta
-export { Primary }
+export {
+  Primary,
+  Borderless,
+  OutlinedSecondary,
+  OutlinedAuxiliary,
+  Medium,
+  AutoSize,
+  WithIcon,
+  Loading,
+  Disabled,
+}

--- a/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
+++ b/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
@@ -215,7 +215,8 @@ const BaseButton = styled.button<
       text-transform: uppercase;
       transition:
         background-color 0.15s ease,
-        border-color 0.15s ease;
+        border-color 0.15s ease,
+        filter 0.3s ease;
 
       /** Border */
       border-color: ${resolvedBorderColor};
@@ -224,8 +225,15 @@ const BaseButton = styled.button<
       border-width: ${resolvedBorderWidth}px;
 
       &:hover:enabled {
-        background-color: ${resolvedHoverBackgroundColor};
-        border-color: ${resolvedHoverBorderColor};
+        filter: brightness(75%);
+      }
+
+      @supports (background-color: color-mix(in srgb, red 50%, blue)) {
+        &:hover:enabled {
+          filter: none;
+          background-color: ${resolvedHoverBackgroundColor};
+          border-color: ${resolvedHoverBorderColor};
+        }
       }
 
       &:disabled {

--- a/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
+++ b/packages/ui/react/src/components/Buttons/Button/Button.styled.ts
@@ -103,6 +103,33 @@ const getHeight = (typeSize: StyledProps['$typeSize']) => {
   }
 }
 
+const getHoverBackgroundColor = (
+  buttonType: StyledProps['$buttonType'],
+  resolvedBackgroundColor: string,
+  resolvedTextColor: string
+) => {
+  switch (buttonType) {
+    case 'borderless':
+    case 'outlinedSecondary':
+    case 'outlinedAuxiliary':
+      return `color-mix(in srgb, ${resolvedTextColor} 12%, white)`
+    default:
+      return `color-mix(in srgb, ${resolvedBackgroundColor} 90%, #000)`
+  }
+}
+
+const getHoverBorderColor = (
+  buttonType: StyledProps['$buttonType'],
+  resolvedBorderColor: string
+) => {
+  switch (buttonType) {
+    case 'borderless':
+      return 'transparent'
+    default:
+      return `color-mix(in srgb, ${resolvedBorderColor} 88%, #000)`
+  }
+}
+
 const ContentIcon = styled.div<Pick<StyledProps, '$iconSize'>>`
   ${({ $iconSize }) => css`
     /** Base */
@@ -143,46 +170,77 @@ const BaseButton = styled.button<
     $noPointerEvents,
     $revertOrientation,
     $typeSize,
-  }) => css`
-    /** Base */
-    cursor: pointer;
-    display: flex;
-    background-color: ${getBackgroundColor($buttonType, $backgroundColor)};
-    height: ${getHeight($typeSize)};
-    margin: ${$noMargin ? '0' : '0 15px'};
-    padding: ${$noPadding ? '0' : '5px 15px'};
-    user-select: none;
+  }) => {
+    const resolvedBackgroundColor = getBackgroundColor(
+      $buttonType,
+      $backgroundColor
+    )
+    const resolvedBorderColor = getBorderColor($buttonType, $borderColor)
+    const resolvedTextColor = getTextColor($buttonType, $color)
+    const resolvedHeight = getHeight($typeSize)
+    const resolvedFontFamily = getFont('roboto')
+    const resolvedBorderStyle = getBorderStyle($buttonType)
+    const resolvedBorderWidth = getBorderWidth($typeSize)
+    const resolvedHoverBackgroundColor = getHoverBackgroundColor(
+      $buttonType,
+      resolvedBackgroundColor,
+      resolvedTextColor
+    )
+    const resolvedHoverBorderColor = getHoverBorderColor(
+      $buttonType,
+      resolvedBorderColor
+    )
 
-    /** Flex Layout */
-    gap: ${$noIconMargin ? '0' : '10px'};
-    align-items: center;
-    flex-direction: ${$revertOrientation ? 'row-reverse' : 'row'};
-    justify-content: center;
+    return css`
+      /** Base */
+      cursor: pointer;
+      display: flex;
+      background-color: ${resolvedBackgroundColor};
+      height: ${resolvedHeight};
+      margin: ${$noMargin ? '0' : '0 15px'};
+      padding: ${$noPadding ? '0' : '5px 15px'};
+      user-select: none;
 
-    /** Text */
-    color: ${getTextColor($buttonType, $color)};
-    font-family: ${getFont('roboto')};
-    font-size: 13px;
-    line-height: 1;
-    text-transform: uppercase;
-    transition: filter 0.3s;
+      /** Flex Layout */
+      gap: ${$noIconMargin ? '0' : '10px'};
+      align-items: center;
+      flex-direction: ${$revertOrientation ? 'row-reverse' : 'row'};
+      justify-content: center;
 
-    /** Border */
-    border-color: ${getBorderColor($buttonType, $borderColor)};
-    border-radius: 25px;
-    border-style: ${getBorderStyle($buttonType)};
-    border-width: ${getBorderWidth($typeSize)}px;
+      /** Text */
+      color: ${resolvedTextColor};
+      font-family: ${resolvedFontFamily};
+      font-size: 13px;
+      line-height: 1;
+      text-transform: uppercase;
+      transition:
+        background-color 0.15s ease,
+        border-color 0.15s ease;
 
-    &:hover:enabled {
-      filter: brightness(75%);
-    }
+      /** Border */
+      border-color: ${resolvedBorderColor};
+      border-radius: 25px;
+      border-style: ${resolvedBorderStyle};
+      border-width: ${resolvedBorderWidth}px;
 
-    &:disabled {
-      cursor: not-allowed;
-      opacity: 0.5;
-      pointer-events: ${$noPointerEvents ? 'none' : 'auto'};
-    }
-  `}
+      &:hover:enabled {
+        background-color: ${resolvedHoverBackgroundColor};
+        border-color: ${resolvedHoverBorderColor};
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+        pointer-events: ${$noPointerEvents ? 'none' : 'auto'};
+      }
+    `
+  }}
 `
 
-export { BaseButton, ContentIcon, Label }
+export {
+  BaseButton,
+  ContentIcon,
+  Label,
+  getHoverBackgroundColor,
+  getHoverBorderColor,
+}

--- a/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
+++ b/packages/ui/react/src/components/Buttons/Button/Button.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { Button } from '.'
+import { getHoverBackgroundColor, getHoverBorderColor } from './Button.styled'
 import { getColor } from 'src/colors'
 
 describe('Button', () => {
@@ -260,6 +261,74 @@ describe('Button', () => {
       const button = screen.getByTestId('button')
       expect(button).toHaveStyle({
         height: 'auto',
+      })
+    })
+  })
+
+  describe('hover color helpers', () => {
+    const bg = '#123456'
+    const text = '#abcdef'
+    const border = '#fedcba'
+
+    describe('getHoverBackgroundColor', () => {
+      it('mixes text color with white for borderless', () => {
+        expect(getHoverBackgroundColor('borderless', bg, text)).toBe(
+          `color-mix(in srgb, ${text} 12%, white)`
+        )
+      })
+
+      it('mixes text color with white for outlinedSecondary', () => {
+        expect(getHoverBackgroundColor('outlinedSecondary', bg, text)).toBe(
+          `color-mix(in srgb, ${text} 12%, white)`
+        )
+      })
+
+      it('mixes text color with white for outlinedAuxiliary', () => {
+        expect(getHoverBackgroundColor('outlinedAuxiliary', bg, text)).toBe(
+          `color-mix(in srgb, ${text} 12%, white)`
+        )
+      })
+
+      it('darkens background for default buttonType', () => {
+        expect(getHoverBackgroundColor('Default', bg, text)).toBe(
+          `color-mix(in srgb, ${bg} 90%, #000)`
+        )
+      })
+
+      it('darkens background when buttonType is undefined', () => {
+        expect(getHoverBackgroundColor(undefined, bg, text)).toBe(
+          `color-mix(in srgb, ${bg} 90%, #000)`
+        )
+      })
+    })
+
+    describe('getHoverBorderColor', () => {
+      it('returns transparent for borderless', () => {
+        expect(getHoverBorderColor('borderless', border)).toBe('transparent')
+      })
+
+      it('darkens border for outlinedSecondary', () => {
+        expect(getHoverBorderColor('outlinedSecondary', border)).toBe(
+          `color-mix(in srgb, ${border} 88%, #000)`
+        )
+      })
+
+      it('darkens border for outlinedAuxiliary', () => {
+        expect(getHoverBorderColor('outlinedAuxiliary', border)).toBe(
+          `color-mix(in srgb, ${border} 88%, #000)`
+        )
+      })
+
+      it('darkens border for default buttonType', () => {
+        expect(getHoverBorderColor('Default', border)).toBe(
+          `color-mix(in srgb, ${border} 88%, #000)`
+        )
+      })
+
+      it('darkens border when buttonType is undefined', () => {
+        expect(getHoverBorderColor(undefined, border)).toBe(
+          `color-mix(in srgb, ${border} 88%, #000)`
+        )
       })
     })
   })


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.

- Keep PRs single-purpose and minimal; avoid unrelated cleanup.
-->

Replace the global `filter: brightness(75%)` hover on `Button` with `color-mix`-based background and border colors computed per `buttonType`, so every variant produces intentional visual feedback on hover instead of being uniformly dimmed.

- [x] `Default`: background darkens — `color-mix(in srgb, <bg> 90%, #000)` — same direction as before but no longer dims the white text via filter
- [x] `outlinedSecondary` / `outlinedAuxiliary`: background lightens with a text-tinted overlay — `color-mix(in srgb, <text> 12%, white)` — instead of producing the muddy grey that `filter: brightness(75%)` caused on a white background
- [x] `borderless`: same light purple tint on hover. Previously the hover was nearly invisible because brightness has nothing to darken on a transparent background
- [x] Transition `background-color` / `border-color` (`0.15s ease`) instead of `filter` (`0.3s`) for snappier feedback
- [x] Return `transparent` as the hover border color for `borderless` (was emitting an empty CSS value)
- [x] Add Storybook stories for `Borderless`, `OutlinedSecondary`, `OutlinedAuxiliary`, `Medium`, `AutoSize`, `WithIcon`, `Loading`, `Disabled` so every variant is visually verifiable
- [x] Add unit tests for `getHoverBackgroundColor` / `getHoverBorderColor` covering all `buttonType` branches (10 new tests, 31 passing total)
- [x] Add `@devopness/ui-react` patch changeset

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [ ] N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged, released, and consumed by `web-app` in production, success criteria is: hovering any `Button` variant produces a smooth color transition that matches the base color of that variant — `Default` darkens; `borderless`, `outlinedSecondary`, and `outlinedAuxiliary` lighten with a subtle purple tint instead of looking dimmed/muddy
- [x] `npm test -- --run Button` (inside `packages/ui/react`) — 31/31 passing
- [x] `npm run lint` (inside `packages/ui/react`) — clean
- [x] Manual visual verification on local Storybook (`http://localhost:6006/?path=/story/buttons-button--<variant>`) — captured BEFORE/AFTER for `Primary`, `Borderless`, `OutlinedSecondary`, `OutlinedAuxiliary` in both resting and hover states (see "More info" below)

### How to reproduce locally
1. `cd packages/ui/react && npm install`
2. `npm run storybook` — opens at `http://localhost:6006`
3. In the sidebar, open **Buttons > Button** and click any of the 9 stories
4. Hover the button in the preview area to see the new per-variant hover behavior

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->

All screenshots were captured on local Storybook (`http://localhost:6006/?path=/story/buttons-button--<variant>`) with the browser URL bar visible for reproducibility. Each pair uses the exact same story URL — only the `Button.styled.ts` content differs between BEFORE (current `main`) and AFTER (this PR).

### Primary — http://localhost:6006/?path=/story/buttons-button--primary

**BEFORE — normal / hover**

<img width="1554" height="992" alt="before-primary-normal" src="https://github.com/user-attachments/assets/c8179fba-7f45-4998-aed2-dd47edef1286" />
<img width="1554" height="992" alt="before-primary-hover" src="https://github.com/user-attachments/assets/72a73869-15a8-4f4f-a005-449928446d2e" />

**AFTER — normal / hover**

<img width="1554" height="992" alt="after-primary-normal" src="https://github.com/user-attachments/assets/c1948995-b329-4e9c-bcd5-14357071a9dd" />
<img width="1554" height="992" alt="after-primary-hover" src="https://github.com/user-attachments/assets/415850dd-b6ea-4a59-83d7-562289db1fca" />

### Borderless — http://localhost:6006/?path=/story/buttons-button--borderless

**BEFORE — normal / hover** (hover is nearly invisible because `filter: brightness` has nothing to darken on a transparent background)

<img width="1554" height="992" alt="before-borderless-normal" src="https://github.com/user-attachments/assets/64873606-1f48-4073-bc95-1563883616aa" />
<img width="1554" height="992" alt="before-borderless-hover" src="https://github.com/user-attachments/assets/f224377c-6f42-491c-9666-4432f4383dde" />

**AFTER — normal / hover** (clear light-purple tint on hover)

<img width="1554" height="992" alt="after-borderless-normal" src="https://github.com/user-attachments/assets/ece23190-d9a8-472d-ba79-f4028dec680c" />
<img width="1554" height="992" alt="after-borderless-hover" src="https://github.com/user-attachments/assets/b2b91966-d682-420b-b1c9-bcb2085162d9" />

### OutlinedSecondary — http://localhost:6006/?path=/story/buttons-button--outlined-secondary

**BEFORE — normal / hover** (muddy grey from brightness applied on white)

<img width="1554" height="992" alt="before-outlined-secondary-normal" src="https://github.com/user-attachments/assets/46fd6a61-b57c-462d-9342-a01c802eb980" />
<img width="1554" height="992" alt="before-outlined-secondary-hover" src="https://github.com/user-attachments/assets/0e6e002e-93dc-4c15-beec-0d0af546e084" />

**AFTER — normal / hover** (purple tint matching the button's identity)

<img width="1554" height="992" alt="after-outlined-secondary-normal" src="https://github.com/user-attachments/assets/ff4a2ac6-4fcf-4d36-b365-745e26701f45" />
<img width="1554" height="992" alt="after-outlined-secondary-hover" src="https://github.com/user-attachments/assets/0e6f4761-83b6-453a-8449-c8a976655d98" />

### OutlinedAuxiliary — http://localhost:6006/?path=/story/buttons-button--outlined-auxiliary

**BEFORE — normal / hover**

<img width="1554" height="992" alt="before-outlined-auxiliary-normal" src="https://github.com/user-attachments/assets/ea562381-f858-4a00-8fa8-f7f63d4b8106" />
<img width="1554" height="992" alt="before-outlined-auxiliary-hover" src="https://github.com/user-attachments/assets/6bf36c66-f347-4ded-83f3-611caded5df6" />

**AFTER — normal / hover**

<img width="1554" height="992" alt="after-outlined-auxiliary-normal" src="https://github.com/user-attachments/assets/d15d0385-82b0-4345-90e1-2b50c6ac1318" />
<img width="1554" height="992" alt="after-outlined-auxiliary-hover" src="https://github.com/user-attachments/assets/9721ae10-7b1c-4c94-befe-91abf7cae6c6" />

### Why this approach

`filter: brightness(75%)` darkens every pixel by the same amount. For the `Default` (primary purple) button that means purple gets a bit darker — works fine. For `outlinedSecondary` / `outlinedAuxiliary` the background is white, so `brightness(75%)` produces a dirty grey instead of a tinted highlight. For `borderless` the background is transparent — the filter has nothing to darken, so the hover state is barely visible (only the text dims slightly).

With `color-mix(in srgb, <base> X%, <target>)` each variant lightens or darkens relative to its own base color, producing a tint that feels intentional for every variant while keeping the same component API.
