### PR TITLE
fix(ui-react): use IconButton for Popover close button

### DIFF
--- a/packages/ui/react/src/components/Primitives/Popover/Popover.tsx
+++ b/packages/ui/react/src/components/Primitives/Popover/Popover.tsx
@@ -3,9 +3,8 @@ import { ReactNode } from 'react'
 import type { PopoverProps as MaterialPopoverProps } from '@mui/material'
 
 import { Container, Footer, Header, Title } from './Popover.styled'
-import { Button } from 'src/components/Buttons'
+import { IconButton } from 'src/components/Buttons'
 import { ConditionalWrapper } from 'src/components/helpers'
-import { iconLoader } from 'src/icons'
 
 type PopoverProps = {
   /** Optional header title */
@@ -47,14 +46,13 @@ const Popover = ({ title, footer, children, ...props }: PopoverProps) => (
       $justifyContent={title ? 'space-between' : 'end'}
     >
       {title && <Title data-testid="popover-title">{title}</Title>}
-      <Button
-        noPadding
-        noMargin
-        buttonType="borderless"
+      <IconButton
+        variant="ghost"
+        name="close"
+        size={14}
+        aria-label="Close"
         onClick={() => props.onClose?.({}, 'backdropClick')}
-      >
-        {iconLoader('close', 14)}
-      </Button>
+      />
     </Header>
 
     {children}


### PR DESCRIPTION
## Description of changes

- [x] Swap the `Button buttonType="borderless"` used as the Popover close target for the new `IconButton variant="ghost"`, so the hover state matches the rest of the design system (circular, hugging the icon) instead of the horizontal pill produced by the legacy Button
- [x] Accessibility: the close button now has an explicit `aria-label="Close"` (enforced by `IconButton`'s required prop)

## GitHub issues resolved by this PR

- [ ] N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: opening any `Popover` with a header renders a circular hover affordance around the close icon (no horizontal pill), and the close icon button is announced as "Close" by assistive tech

## More info

### Before

<img width="1470" height="922" alt="Popover close button before — horizontal pill hover" src="https://github.com/user-attachments/assets/8a2f0aff-35f5-4227-9e62-4e89b648a6a5" />

### After

<img width="1469" height="921" alt="Popover close button after — circular IconButton ghost hover" src="https://github.com/user-attachments/assets/83d2e2cd-968a-4b66-ac2a-9a00cc88305f" />