### PR TITLE
ci: sync lock files when CHANGELOG.md is updated

### DIFF
--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -41,6 +41,7 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - 'packages/**/package.json'
+              - 'packages/**/CHANGELOG.md'
 
   load-pypi-projects:
     name: Load Python packages matrix

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -31,13 +31,18 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      changes: ${{ steps.filter.outputs.changes }}
+      has_package_changes: ${{ steps.filter.outputs.has_package_changes }}
+      should_sync_lockfile: ${{ steps.filter.outputs.should_sync_lockfile }}
     steps:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
-            changes:
+            has_package_changes:
+              - 'package.json'
+              - 'package-lock.json'
+              - 'packages/**/package.json'
+            should_sync_lockfile:
               - 'package.json'
               - 'package-lock.json'
               - 'packages/**/package.json'
@@ -48,7 +53,7 @@ jobs:
     needs: detect-changes
     if: >
       github.event.pull_request.user.login != 'dependabot[bot]' &&
-      needs.detect-changes.outputs.changes == 'true'
+      needs.detect-changes.outputs.has_package_changes == 'true'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -68,7 +73,7 @@ jobs:
     needs: [detect-changes, load-pypi-projects]
     if: >
       github.event.pull_request.user.login != 'dependabot[bot]' &&
-      needs.detect-changes.outputs.changes == 'true'
+      needs.detect-changes.outputs.has_package_changes == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -118,7 +123,7 @@ jobs:
     needs: detect-changes
     if: >
       github.event.pull_request.user.login != 'dependabot[bot]' &&
-      needs.detect-changes.outputs.changes == 'true'
+      needs.detect-changes.outputs.should_sync_lockfile == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -155,6 +160,7 @@ jobs:
     needs: [detect-changes, sync-pypi-package-versions, sync-main-lockfile]
     if: >
       github.event.pull_request.user.login != 'dependabot[bot]'
+      && (needs.detect-changes.outputs.has_package_changes == 'true' || needs.detect-changes.outputs.should_sync_lockfile == 'true')
       && always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description of changes

- [x] **Problem**: Automatically generated package version upgrades PRs (such as https://github.com/devopness/devopness/pull/3077) the CI is not updating the root lock file and PR requires manual intervention to force CI execution.
- [x] **Solution**: Watch for changes in package `CHANGELOG.md` files to trigger the `sync-main-lockfile` job, and unblock CI.

## GitHub issues resolved by this PR
- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: new PRs generated by changeset action, will automatically update repo root package-lock.json

<!-- Use a concrete, verifiable, success criteria. Keep it short -->

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
