### PR TITLE
ci: enhance package syncing on changeset PRs

### DIFF
--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -15,6 +15,15 @@ on:
     types:
       - opened
       - synchronize
+  push:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'packages/**/package.json'
+      - 'packages/**/CHANGELOG.md'
+    branches:
+      # Trigger when commits are pushed to the changesets branch, to sync the root lock file
+      - 'changeset-release/*'
 
 permissions:
   contents: write
@@ -26,7 +35,8 @@ jobs:
   detect-changes:
     name: Detect changes in package.json files
     if: >
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
+      github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -52,8 +62,9 @@ jobs:
     name: Load Python packages matrix
     needs: detect-changes
     if: >
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      needs.detect-changes.outputs.has_package_changes == 'true'
+      needs.detect-changes.outputs.has_package_changes == 'true' &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
+       github.event_name == 'push')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -72,8 +83,9 @@ jobs:
     name: Sync pyproject.toml
     needs: [detect-changes, load-pypi-projects]
     if: >
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      needs.detect-changes.outputs.has_package_changes == 'true'
+      needs.detect-changes.outputs.has_package_changes == 'true' &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
+       github.event_name == 'push')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -83,15 +95,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: '3.13'
 
       - name: Sync '${{ matrix.name }}' version
         run: |
@@ -107,14 +119,14 @@ jobs:
         run: |
           git config --global user.email "${{ vars.DEVOPNESS_AUTOMATIONS_EMAIL }}"
           git config --global user.name "${{ vars.DEVOPNESS_AUTOMATIONS_USERNAME }}"
-          git fetch origin ${{ github.head_ref }} || true
+          git fetch origin ${{ github.head_ref || github.ref_name }} || true
           # Try to rebase local changes onto the latest remote to avoid non-fast-forward push errors
-          git pull --rebase origin ${{ github.head_ref }} || true
+          git pull --rebase origin ${{ github.head_ref || github.ref_name }} || true
 
       - uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore: sync '${{ matrix.name }}' version"
-          file_pattern: "${{ matrix.path }}/pyproject.toml ${{ matrix.path }}/*.lock"
+          file_pattern: '${{ matrix.path }}/pyproject.toml ${{ matrix.path }}/*.lock'
           commit_user_name: ${{ vars.DEVOPNESS_AUTOMATIONS_USERNAME }}
           commit_user_email: ${{ vars.DEVOPNESS_AUTOMATIONS_EMAIL }}
 
@@ -122,21 +134,22 @@ jobs:
     name: Sync the package-lock.json
     needs: detect-changes
     if: >
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      needs.detect-changes.outputs.should_sync_lockfile == 'true'
+      needs.detect-changes.outputs.should_sync_lockfile == 'true' &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
+       github.event_name == 'push')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "24.x"
+          node-version: '24.x'
 
       - name: Sync workspace versions in lockfile
         run: npm install --workspaces
@@ -145,13 +158,13 @@ jobs:
         run: |
           git config --global user.email "${{ vars.DEVOPNESS_AUTOMATIONS_EMAIL }}"
           git config --global user.name "${{ vars.DEVOPNESS_AUTOMATIONS_USERNAME }}"
-          git fetch origin ${{ github.head_ref }} || true
-          git pull --rebase origin ${{ github.head_ref }} || true
+          git fetch origin ${{ github.head_ref || github.ref_name }} || true
+          git pull --rebase origin ${{ github.head_ref || github.ref_name }} || true
 
       - uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: "chore: update package-lock.json"
-          file_pattern: "package-lock.json"
+          commit_message: 'chore: update package-lock.json'
+          file_pattern: 'package-lock.json'
           commit_user_name: ${{ vars.DEVOPNESS_AUTOMATIONS_USERNAME }}
           commit_user_email: ${{ vars.DEVOPNESS_AUTOMATIONS_EMAIL }}
 
@@ -159,15 +172,16 @@ jobs:
     name: Verify sync of package versions
     needs: [detect-changes, sync-pypi-package-versions, sync-main-lockfile]
     if: >
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' ||
+       github.event_name == 'push')
       && (needs.detect-changes.outputs.has_package_changes == 'true' || needs.detect-changes.outputs.should_sync_lockfile == 'true')
       && always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fail if sync-pypi-package-versions did not succeed


### PR DESCRIPTION
## Description of changes

- [x] Revert https://github.com/devopness/devopness/pull/3079 and improve sync lock file logic to be triggered when new commits are pushed to changeset PR branches 

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: CI should be triggered and lock files synced

<!-- Use a concrete, verifiable, success criteria. Keep it short -->

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
