### PR TITLE
ci: improve path filters to sync lock file

### DIFF
--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -188,6 +188,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fail if sync-pypi-package-versions did not succeed
+        if: needs.detect-changes.outputs.has_package_changes == 'true'
         run: |
           if [ "${{ needs.sync-pypi-package-versions.result }}" = "failure" ] || [ "${{ needs.sync-pypi-package-versions.result }}" = "cancelled" ]; then
             echo "❌ Job `sync-pypi-package-versions` failed or was cancelled"

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -15,11 +15,13 @@ on:
     types:
       - opened
       - synchronize
+    paths:
+      - '**/package*.json'
+      - 'packages/**/CHANGELOG.md'
+      - '.changeset/**'
   push:
     paths:
-      - 'package.json'
-      - 'package-lock.json'
-      - 'packages/**/package.json'
+      - '**/package*.json'
       - 'packages/**/CHANGELOG.md'
     branches:
       # Trigger when commits are pushed to the changesets branch, to sync the root lock file

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -59,6 +59,7 @@ jobs:
               - 'package-lock.json'
               - 'packages/**/package.json'
               - 'packages/**/CHANGELOG.md'
+              - '.changeset/**'
 
   load-pypi-projects:
     name: Load Python packages matrix


### PR DESCRIPTION
## Description of changes

- [x] Continue the work started on https://github.com/devopness/devopness/pull/3081 and improve sync lock file logic to be triggered also when changeset files are touched in a PR.

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: CI should be triggered and lock files synced

<!-- Use a concrete, verifiable, success criteria. Keep it short -->

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
