### PR TITLE
fix(ui-react): prevent Card add CTA hover circle from being clipped

### DIFF
--- a/.changeset/card-add-cta-hover-clipped.md
+++ b/.changeset/card-add-cta-hover-clipped.md
@@ -1,0 +1,10 @@
+---
+"@devopness/ui-react": patch
+---
+
+Fix Card add CTA button hover circle being clipped on the right
+
+Increased the `addCta` grid column from `32px` to `40px` to give enough
+room for the button's hover background circle (24px icon + 6px padding
+on each side), preventing it from being cut off by the container's
+`overflow: hidden`.

--- a/packages/ui/react/src/components/Templates/Card/Card.styled.ts
+++ b/packages/ui/react/src/components/Templates/Card/Card.styled.ts
@@ -146,7 +146,7 @@ const StyledHeader = styled.div<StyledHeaderProps>`
   grid-template-areas: ${({ $hasAddCta }) =>
     $hasAddCta ? "'icon title indicator addCta'" : "'icon title indicator'"};
   grid-template-columns: ${({ $hasAddCta }) =>
-    $hasAddCta ? '36px 1fr 24px 32px' : '36px 1fr 20px'};
+    $hasAddCta ? '36px 1fr 24px 40px' : '36px 1fr 20px'};
   grid-template-rows: 36px;
   height: 63px;
   padding: 14px 15px 0 15px;


### PR DESCRIPTION
## Description of changes

- [x] Increased the `addCta` grid column on `StyledHeader` from `32px` to `40px` so the hover background circle of the add "+" button is no longer cut off on the right side.

## GitHub issues resolved by this PR

- [ ] N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: hovering over the add "+" button on any Card header shows a complete circle background with no clipping on the right side

## More info

The button is 36px wide (24px icon + 6px padding on each side) but the grid column was only 32px, causing the `overflow: hidden` on the container to clip the right 4px of the hover circle.

### Before

<img width="296" height="118" alt="image" src="https://github.com/user-attachments/assets/6519a636-9c2f-423b-818e-80b80c6e14af" />

### After

<img width="324" height="106" alt="image" src="https://github.com/user-attachments/assets/c50ec09a-6275-49a8-9f65-4681ec8da877" />
