### PR TITLE
ci: improve sync-package-versions triggers and filters

### DIFF
--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -47,7 +47,8 @@ jobs:
         with:
           filters: |
             has_package_changes:
-              - '**/package*.json'
+              - 'package.json'
+              - 'packages/**/package.json'
             should_sync_lockfile:
               - '**/package*.json'
               - 'packages/**/CHANGELOG.md'

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -15,10 +15,6 @@ on:
     types:
       - opened
       - synchronize
-    paths:
-      - '**/package*.json'
-      - 'packages/**/CHANGELOG.md'
-      - '.changeset/**'
   push:
     paths:
       - '**/package*.json'
@@ -31,7 +27,7 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency: ${{ github.workflow }}-${{ github.head_ref }}
+concurrency: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
 
 jobs:
   detect-changes:
@@ -51,13 +47,9 @@ jobs:
         with:
           filters: |
             has_package_changes:
-              - 'package.json'
-              - 'package-lock.json'
-              - 'packages/**/package.json'
+              - '**/package*.json'
             should_sync_lockfile:
-              - 'package.json'
-              - 'package-lock.json'
-              - 'packages/**/package.json'
+              - '**/package*.json'
               - 'packages/**/CHANGELOG.md'
               - '.changeset/**'
 
@@ -175,7 +167,7 @@ jobs:
     name: Verify sync of package versions
     needs: [detect-changes, sync-pypi-package-versions, sync-main-lockfile]
     if: >
-      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' ||
+      ((github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
        github.event_name == 'push')
       && (needs.detect-changes.outputs.has_package_changes == 'true' || needs.detect-changes.outputs.should_sync_lockfile == 'true')
       && always()


### PR DESCRIPTION
## Description of changes

- [x] Partially revert the work done on https://github.com/devopness/devopness/pull/3089, as it didn't trigger sync lock file workflow on #3091

- [x] Improve the sync-package-versions workflow to reliably trigger on changesets release PRs:

- Remove path filter from PR trigger (unreliable at PR creation time)
- Keep path filter on push to changeset-release/* branches (reduces noise on main)
- Simplify internal path filters with wildcard patterns (**/package*.json)
- Fix concurrency context to work with both PR and push events
- Fix operator precedence in verify-sync condition

This ensures package-lock.json is automatically synced when new package versions are released, without manual intervention needed.

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: CI should be triggered and lock files synced

<!-- Use a concrete, verifiable, success criteria. Keep it short -->

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->