### PR TITLE
feat(sdk-python): add list_environment_variables convenience method to VariableService

### DIFF
--- a/packages/sdks/python/src/devopness/services/variable_service.py
+++ b/packages/sdks/python/src/devopness/services/variable_service.py
@@ -2,10 +2,12 @@
 Devopness API Python SDK - Painless essential DevOps to everyone
 """
 
+from ..core import DevopnessResponse
 from ..generated.api.variables_api import (
     VariablesApiService,
     VariablesApiServiceAsync,
 )
+from ..generated.models import VariableRelation
 
 __all__ = ["VariableService", "VariableServiceAsync"]
 
@@ -15,8 +17,36 @@ class VariableService(
 ):
     """Service for variables in the Devopness API."""
 
+    def list_environment_variables(
+        self,
+        environment_id: int,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> DevopnessResponse[list[VariableRelation]]:
+        """Return a list of all variables belonging to an environment."""
+        return self.list_variables_by_resource_type(
+            environment_id,
+            "environment",
+            page=page,
+            per_page=per_page,
+        )
+
 
 class VariableServiceAsync(
     VariablesApiServiceAsync,
 ):
     """Async service for variables in the Devopness API."""
+
+    async def list_environment_variables(
+        self,
+        environment_id: int,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> DevopnessResponse[list[VariableRelation]]:
+        """Return a list of all variables belonging to an environment."""
+        return await self.list_variables_by_resource_type(
+            environment_id,
+            "environment",
+            page=page,
+            per_page=per_page,
+        )

--- a/packages/sdks/python/src/devopness/services/variable_service.py
+++ b/packages/sdks/python/src/devopness/services/variable_service.py
@@ -22,6 +22,8 @@ class VariableService(
         environment_id: int,
         page: int | None = None,
         per_page: int | None = None,
+        include_virtual_variables: bool | None = None,
+        variable_target: str | None = None,
     ) -> DevopnessResponse[list[VariableRelation]]:
         """Return a list of all variables belonging to an environment."""
         return self.list_variables_by_resource_type(
@@ -29,6 +31,8 @@ class VariableService(
             "environment",
             page=page,
             per_page=per_page,
+            include_virtual_variables=include_virtual_variables,
+            variable_target=variable_target,
         )
 
 
@@ -42,6 +46,8 @@ class VariableServiceAsync(
         environment_id: int,
         page: int | None = None,
         per_page: int | None = None,
+        include_virtual_variables: bool | None = None,
+        variable_target: str | None = None,
     ) -> DevopnessResponse[list[VariableRelation]]:
         """Return a list of all variables belonging to an environment."""
         return await self.list_variables_by_resource_type(
@@ -49,4 +55,6 @@ class VariableServiceAsync(
             "environment",
             page=page,
             per_page=per_page,
+            include_virtual_variables=include_virtual_variables,
+            variable_target=variable_target,
         )

--- a/packages/sdks/python/tests/unit/services/test_variable_service.py
+++ b/packages/sdks/python/tests/unit/services/test_variable_service.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from devopness import DevopnessClient, DevopnessClientAsync, DevopnessClientConfig
+
+
+class TestVariableServiceListEnvironmentVariables(unittest.TestCase):
+    def setUp(self) -> None:
+        config = DevopnessClientConfig(base_url="https://test.local")
+        self.client = DevopnessClient(config)
+
+    def test_list_environment_variables_calls_correct_resource_type(self) -> None:
+        with patch.object(
+            self.client.variables,
+            "list_variables_by_resource_type",
+            return_value=MagicMock(),
+        ) as mock:
+            self.client.variables.list_environment_variables(1097)
+            mock.assert_called_once_with(1097, "environment", page=None, per_page=None)
+
+    def test_list_environment_variables_passes_pagination(self) -> None:
+        with patch.object(
+            self.client.variables,
+            "list_variables_by_resource_type",
+            return_value=MagicMock(),
+        ) as mock:
+            self.client.variables.list_environment_variables(1097, page=2, per_page=10)
+            mock.assert_called_once_with(1097, "environment", page=2, per_page=10)
+
+
+class TestVariableServiceAsyncListEnvironmentVariables(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        config = DevopnessClientConfig(base_url="https://test.local")
+        self.client = DevopnessClientAsync(config)
+
+    async def test_list_environment_variables_calls_correct_resource_type(self) -> None:
+        with patch.object(
+            self.client.variables,
+            "list_variables_by_resource_type",
+            new_callable=AsyncMock,
+        ) as mock:
+            await self.client.variables.list_environment_variables(1097)
+            mock.assert_called_once_with(1097, "environment", page=None, per_page=None)
+
+    async def test_list_environment_variables_passes_pagination(self) -> None:
+        with patch.object(
+            self.client.variables,
+            "list_variables_by_resource_type",
+            new_callable=AsyncMock,
+        ) as mock:
+            await self.client.variables.list_environment_variables(1097, page=2, per_page=10)
+            mock.assert_called_once_with(1097, "environment", page=2, per_page=10)

--- a/packages/sdks/python/tests/unit/services/test_variable_service.py
+++ b/packages/sdks/python/tests/unit/services/test_variable_service.py
@@ -62,7 +62,9 @@ class TestVariableServiceListEnvironmentVariables(unittest.TestCase):
             )
 
 
-class TestVariableServiceAsyncListEnvironmentVariables(unittest.IsolatedAsyncioTestCase):
+class TestVariableServiceAsyncListEnvironmentVariables(
+    unittest.IsolatedAsyncioTestCase
+):
     def setUp(self) -> None:
         config = DevopnessClientConfig(base_url="https://test.local")
         self.client = DevopnessClientAsync(config)
@@ -89,7 +91,9 @@ class TestVariableServiceAsyncListEnvironmentVariables(unittest.IsolatedAsyncioT
             "list_variables_by_resource_type",
             new_callable=AsyncMock,
         ) as mock:
-            await self.client.variables.list_environment_variables(1097, page=2, per_page=10)
+            await self.client.variables.list_environment_variables(
+                1097, page=2, per_page=10
+            )
             mock.assert_called_once_with(
                 1097,
                 "environment",

--- a/packages/sdks/python/tests/unit/services/test_variable_service.py
+++ b/packages/sdks/python/tests/unit/services/test_variable_service.py
@@ -16,7 +16,14 @@ class TestVariableServiceListEnvironmentVariables(unittest.TestCase):
             return_value=MagicMock(),
         ) as mock:
             self.client.variables.list_environment_variables(1097)
-            mock.assert_called_once_with(1097, "environment", page=None, per_page=None)
+            mock.assert_called_once_with(
+                1097,
+                "environment",
+                page=None,
+                per_page=None,
+                include_virtual_variables=None,
+                variable_target=None,
+            )
 
     def test_list_environment_variables_passes_pagination(self) -> None:
         with patch.object(
@@ -25,7 +32,34 @@ class TestVariableServiceListEnvironmentVariables(unittest.TestCase):
             return_value=MagicMock(),
         ) as mock:
             self.client.variables.list_environment_variables(1097, page=2, per_page=10)
-            mock.assert_called_once_with(1097, "environment", page=2, per_page=10)
+            mock.assert_called_once_with(
+                1097,
+                "environment",
+                page=2,
+                per_page=10,
+                include_virtual_variables=None,
+                variable_target=None,
+            )
+
+    def test_list_environment_variables_passes_filters(self) -> None:
+        with patch.object(
+            self.client.variables,
+            "list_variables_by_resource_type",
+            return_value=MagicMock(),
+        ) as mock:
+            self.client.variables.list_environment_variables(
+                1097,
+                include_virtual_variables=True,
+                variable_target="server",
+            )
+            mock.assert_called_once_with(
+                1097,
+                "environment",
+                page=None,
+                per_page=None,
+                include_virtual_variables=True,
+                variable_target="server",
+            )
 
 
 class TestVariableServiceAsyncListEnvironmentVariables(unittest.IsolatedAsyncioTestCase):
@@ -40,7 +74,14 @@ class TestVariableServiceAsyncListEnvironmentVariables(unittest.IsolatedAsyncioT
             new_callable=AsyncMock,
         ) as mock:
             await self.client.variables.list_environment_variables(1097)
-            mock.assert_called_once_with(1097, "environment", page=None, per_page=None)
+            mock.assert_called_once_with(
+                1097,
+                "environment",
+                page=None,
+                per_page=None,
+                include_virtual_variables=None,
+                variable_target=None,
+            )
 
     async def test_list_environment_variables_passes_pagination(self) -> None:
         with patch.object(
@@ -49,4 +90,31 @@ class TestVariableServiceAsyncListEnvironmentVariables(unittest.IsolatedAsyncioT
             new_callable=AsyncMock,
         ) as mock:
             await self.client.variables.list_environment_variables(1097, page=2, per_page=10)
-            mock.assert_called_once_with(1097, "environment", page=2, per_page=10)
+            mock.assert_called_once_with(
+                1097,
+                "environment",
+                page=2,
+                per_page=10,
+                include_virtual_variables=None,
+                variable_target=None,
+            )
+
+    async def test_list_environment_variables_passes_filters(self) -> None:
+        with patch.object(
+            self.client.variables,
+            "list_variables_by_resource_type",
+            new_callable=AsyncMock,
+        ) as mock:
+            await self.client.variables.list_environment_variables(
+                1097,
+                include_virtual_variables=True,
+                variable_target="server",
+            )
+            mock.assert_called_once_with(
+                1097,
+                "environment",
+                page=None,
+                per_page=None,
+                include_virtual_variables=True,
+                variable_target="server",
+            )


### PR DESCRIPTION
## Description of changes

Adds list_environment_variables convenience method to VariableService and VariableServiceAsync.

Without this method, callers must write client.variables.list_variables_by_resource_type(env_id, "environment") — requiring knowledge of a magic string and a non-obvious argument order that silently produces a 404 when swapped. This PR adds a named wrapper that matches the pattern already established by ApplicationService.list_environment_applications.

- [x] Added list_environment_variables to VariableService (sync)
- [x] Added list_environment_variables to VariableServiceAsync (async)
- [x] Forwards all parameters: page, per_page, include_virtual_variables, variable_target
- [x] Added unit tests for both variants covering forwarding, pagination, and filter parameters

## GitHub issues resolved by this PR

- [ ] closes #3120

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: callers can use client.variables.list_environment_variables(env_id) instead of client.variables.list_variables_by_resource_type(env_id, environment)

## More info

Discovered while using the SDK against the live Devopness API. ApplicationService already has list_environment_applications as a named method. VariableService did not have an equivalent.