### PR TITLE
fix(ui-react): restore TimerCounter behavior for completed/failed states

### DIFF
--- a/.changeset/fix-timer-counter-zero-on-completed.md
+++ b/.changeset/fix-timer-counter-zero-on-completed.md
@@ -1,0 +1,23 @@
+---
+"@devopness/ui-react": patch
+---
+
+Fix `TimerCounter` showing `00:00` for completed/failed actions
+
+The `TimerCounter` component was early-returning to `00:00` whenever
+`shouldStartTimer` was `false`, even when `shouldStopTimer` was `true` —
+which froze the timer at `00:00` for any action that had finished
+(completed, failed, skipped) when callers used `shouldStartTimer` to
+indicate "the action is not currently running".
+
+The effect logic now matches the previous (pre-migration) local
+implementation: `shouldStartTimer` only nudges the displayed value to
+`00:00` before the actual decision, while `shouldResetTimer`,
+`shouldStopTimer`, and `timerStartDate` determine the final state.
+
+This restores the expected behavior across status combinations:
+
+- `Pending` / `Waiting` / `Queued` (no start date) → `00:00`
+- `InProgress` → live ticking
+- `Completed` / `Failed` → final duration
+- `Skipped` (no start date) → `00:00`

--- a/.changeset/fix-timer-counter-zero-on-completed.md
+++ b/.changeset/fix-timer-counter-zero-on-completed.md
@@ -2,22 +2,32 @@
 "@devopness/ui-react": patch
 ---
 
-Fix `TimerCounter` showing `00:00` for completed/failed actions
+Fix `TimerCounter` showing stale values and leaking intervals on prop transitions
 
-The `TimerCounter` component was early-returning to `00:00` whenever
-`shouldStartTimer` was `false`, even when `shouldStopTimer` was `true` —
-which froze the timer at `00:00` for any action that had finished
-(completed, failed, skipped) when callers used `shouldStartTimer` to
-indicate "the action is not currently running".
+Two problems were fixed:
 
-The effect logic now matches the previous (pre-migration) local
-implementation: `shouldStartTimer` only nudges the displayed value to
-`00:00` before the actual decision, while `shouldResetTimer`,
-`shouldStopTimer`, and `timerStartDate` determine the final state.
+1. The component was early-returning to `00:00` whenever `shouldStartTimer`
+   was `false`, even when `shouldStopTimer` was `true` — which froze the
+   timer at `00:00` for any finished action (`Completed`, `Failed`,
+   `Skipped`) when callers used `shouldStartTimer` to mean "the action is
+   currently running".
 
-This restores the expected behavior across status combinations:
+2. The effect that controlled the interval lifecycle only depended on
+   `shouldStartTimer`, but it also read `shouldResetTimer`,
+   `shouldStopTimer`, and `timerStartDate`. When any of those changed
+   without `shouldStartTimer` changing, the interval could keep running
+   (stop/reset transitions) or never start (`timerStartDate` going from
+   `null` to a real date). The displayed value could also flicker as the
+   stale interval kept overwriting the value derived from the new props.
+
+The effect now lives in a single `useEffect` that depends on every prop
+it reads, and `formatDurationTime` is accessed via a ref so the effect
+does not restart on every parent re-render when the caller doesn't
+memoize it.
+
+Behavior matrix across status combinations:
 
 - `Pending` / `Waiting` / `Queued` (no start date) → `00:00`
 - `InProgress` → live ticking
-- `Completed` / `Failed` → final duration
+- `Completed` / `Failed` → final duration (no flicker on transition)
 - `Skipped` (no start date) → `00:00`

--- a/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.test.tsx
+++ b/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.test.tsx
@@ -1,20 +1,20 @@
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+
+import { describe, it, expect, vi } from 'vitest'
 
 import { TimerCounter } from './TimerCounter'
 
 const mockFormatDurationTime = (start?: string | null, end?: string | null) =>
-  start && !end ? '00:05' : '—'
+  start && end ? 'final-duration' : start ? 'live-duration' : '—'
 
 const mockFormatDateTime = (date?: string | null) =>
   date ? `formatted-${date}` : '—'
 
 describe('TimerCounter', () => {
-  it('renders 00:00 when shouldStartTimer is false', () => {
+  it('renders 00:00 when timerStartDate is null', () => {
     render(
       <TimerCounter
-        shouldStartTimer={false}
         formatDurationTime={mockFormatDurationTime}
         formatDateTime={mockFormatDateTime}
       />
@@ -22,16 +22,59 @@ describe('TimerCounter', () => {
     expect(screen.getByText('00:00')).toBeInTheDocument()
   })
 
-  it('renders formatted duration when shouldStartTimer is true', () => {
+  it('renders 00:00 when shouldResetTimer is true even with valid dates', () => {
     render(
       <TimerCounter
-        shouldStartTimer
         timerStartDate="2025-09-16T12:00:00Z"
+        timerFinalDate="2025-09-16T14:00:00Z"
+        shouldResetTimer
         formatDurationTime={mockFormatDurationTime}
         formatDateTime={mockFormatDateTime}
       />
     )
-    expect(screen.getByText('00:05')).toBeInTheDocument()
+    expect(screen.getByText('00:00')).toBeInTheDocument()
+  })
+
+  it('renders the final formatted duration when shouldStopTimer is true and dates are set', () => {
+    render(
+      <TimerCounter
+        timerStartDate="2025-09-16T12:00:00Z"
+        timerFinalDate="2025-09-16T14:00:00Z"
+        shouldStopTimer
+        formatDurationTime={mockFormatDurationTime}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('final-duration')).toBeInTheDocument()
+  })
+
+  it('shows the final duration when shouldStartTimer is false and shouldStopTimer is true', () => {
+    render(
+      <TimerCounter
+        timerStartDate="2025-09-16T12:00:00Z"
+        timerFinalDate="2025-09-16T14:00:00Z"
+        shouldStartTimer={false}
+        shouldStopTimer
+        formatDurationTime={mockFormatDurationTime}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('final-duration')).toBeInTheDocument()
+    expect(screen.queryByText('00:00')).not.toBeInTheDocument()
+  })
+
+  it('starts ticking when only shouldStartTimer is true and dates are set', () => {
+    vi.useFakeTimers()
+    render(
+      <TimerCounter
+        timerStartDate="2025-09-16T12:00:00Z"
+        shouldStartTimer
+        formatDurationTime={mockFormatDurationTime}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('live-duration')).toBeInTheDocument()
+    vi.useRealTimers()
   })
 
   it('shows tooltip with formatted dates', async () => {

--- a/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.test.tsx
+++ b/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.test.tsx
@@ -48,6 +48,19 @@ describe('TimerCounter', () => {
     expect(screen.getByText('final-duration')).toBeInTheDocument()
   })
 
+  it('renders 00:00 when shouldStartTimer is false and shouldStopTimer is not set, even with a valid start date', () => {
+    render(
+      <TimerCounter
+        timerStartDate="2025-09-16T12:00:00Z"
+        shouldStartTimer={false}
+        formatDurationTime={mockFormatDurationTime}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('00:00')).toBeInTheDocument()
+    expect(screen.queryByText('live-duration')).not.toBeInTheDocument()
+  })
+
   it('shows the final duration when shouldStartTimer is false and shouldStopTimer is true', () => {
     render(
       <TimerCounter

--- a/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.test.tsx
+++ b/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 
 import { describe, it, expect, vi } from 'vitest'
 
@@ -99,5 +99,134 @@ describe('TimerCounter', () => {
     expect(
       await screen.findByText(/formatted-2025-09-16T14:00:00Z/)
     ).toBeInTheDocument()
+  })
+
+  it('stops the running interval when shouldStopTimer transitions to true', () => {
+    vi.useFakeTimers()
+    const formatSpy = vi.fn((_start?: string | null, end?: string | null) =>
+      end ? 'final-duration' : 'live-duration'
+    )
+
+    const { rerender } = render(
+      <TimerCounter
+        timerStartDate="2025-09-16T12:00:00Z"
+        shouldStartTimer
+        formatDurationTime={formatSpy}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('live-duration')).toBeInTheDocument()
+
+    rerender(
+      <TimerCounter
+        timerStartDate="2025-09-16T12:00:00Z"
+        timerFinalDate="2025-09-16T14:00:00Z"
+        shouldStartTimer={false}
+        shouldStopTimer
+        formatDurationTime={formatSpy}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('final-duration')).toBeInTheDocument()
+
+    formatSpy.mockClear()
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+    expect(formatSpy).not.toHaveBeenCalled()
+    expect(screen.getByText('final-duration')).toBeInTheDocument()
+
+    vi.useRealTimers()
+  })
+
+  it('starts ticking when timerStartDate transitions from null to a real date', () => {
+    vi.useFakeTimers()
+    const { rerender } = render(
+      <TimerCounter
+        shouldStartTimer
+        formatDurationTime={mockFormatDurationTime}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('00:00')).toBeInTheDocument()
+
+    rerender(
+      <TimerCounter
+        timerStartDate="2025-09-16T12:00:00Z"
+        shouldStartTimer
+        formatDurationTime={mockFormatDurationTime}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('live-duration')).toBeInTheDocument()
+
+    vi.useRealTimers()
+  })
+
+  it('resets to 00:00 and stops the interval when shouldResetTimer transitions to true', () => {
+    vi.useFakeTimers()
+    const formatSpy = vi.fn(mockFormatDurationTime)
+
+    const { rerender } = render(
+      <TimerCounter
+        timerStartDate="2025-09-16T12:00:00Z"
+        shouldStartTimer
+        formatDurationTime={formatSpy}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('live-duration')).toBeInTheDocument()
+
+    rerender(
+      <TimerCounter
+        timerStartDate="2025-09-16T12:00:00Z"
+        shouldStartTimer
+        shouldResetTimer
+        formatDurationTime={formatSpy}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('00:00')).toBeInTheDocument()
+
+    formatSpy.mockClear()
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+    expect(formatSpy).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
+  })
+
+  it('resets to 00:00 and stops the interval when timerStartDate transitions back to null', () => {
+    vi.useFakeTimers()
+    const formatSpy = vi.fn(mockFormatDurationTime)
+
+    const { rerender } = render(
+      <TimerCounter
+        timerStartDate="2025-09-16T12:00:00Z"
+        shouldStartTimer
+        formatDurationTime={formatSpy}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('live-duration')).toBeInTheDocument()
+
+    rerender(
+      <TimerCounter
+        timerStartDate={null}
+        shouldStartTimer
+        formatDurationTime={formatSpy}
+        formatDateTime={mockFormatDateTime}
+      />
+    )
+    expect(screen.getByText('00:00')).toBeInTheDocument()
+
+    formatSpy.mockClear()
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+    expect(formatSpy).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
   })
 })

--- a/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.tsx
+++ b/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.tsx
@@ -80,8 +80,14 @@ const TimerCounter = ({
       return
     }
 
-    if (shouldStopTimer || !shouldStartTimer) {
+    if (shouldStopTimer) {
       tick()
+      return
+    }
+
+    if (!shouldStartTimer) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setTimerState('00:00')
       return
     }
 

--- a/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.tsx
+++ b/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.tsx
@@ -52,32 +52,48 @@ const TimerCounter = ({
   timerFinalDate,
   shouldResetTimer,
   shouldStopTimer,
-  shouldStartTimer,
+  shouldStartTimer = true,
   formatDurationTime,
   formatDateTime,
 }: TimerCounterProps) => {
-  const [
-    intervalEventCounter,
-    setIntervalEventCounter,
-  ] = useState<number>(0)
   const [
     timerState,
     setTimerState,
   ] = useState<string>('—')
 
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const formatDurationRef = useRef(formatDurationTime)
 
-  const handleStopTimer = useCallback((): void => {
-    if (intervalRef.current !== null) {
-      clearInterval(intervalRef.current)
-      intervalRef.current = null
+  useEffect(() => {
+    formatDurationRef.current = formatDurationTime
+  })
+
+  useEffect(() => {
+    const tick = () => {
+      setTimerState((prev) => {
+        const next = formatDurationRef.current(timerStartDate, timerFinalDate)
+        return next === prev ? prev : next
+      })
     }
-  }, [])
 
-  const handleTimerState = useCallback((): void => {
-    setTimerState(formatDurationTime(timerStartDate, timerFinalDate))
+    if (shouldResetTimer || timerStartDate == null) {
+      setTimerState('00:00')
+      return
+    }
+
+    if (shouldStopTimer || !shouldStartTimer) {
+      tick()
+      return
+    }
+
+    tick()
+    const intervalId = setInterval(tick, 1000)
+    return () => {
+      clearInterval(intervalId)
+    }
   }, [
-    formatDurationTime,
+    shouldStartTimer,
+    shouldStopTimer,
+    shouldResetTimer,
     timerStartDate,
     timerFinalDate,
   ])
@@ -95,43 +111,6 @@ const TimerCounter = ({
       formatDateTime,
     ]
   )
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    handleTimerState()
-  }, [
-    intervalEventCounter,
-    timerFinalDate,
-    shouldResetTimer,
-    shouldStopTimer,
-    handleTimerState,
-  ])
-
-  useEffect(() => {
-    /* eslint-disable react-hooks/set-state-in-effect */
-    if (!shouldStartTimer) setTimerState('00:00')
-    if (shouldResetTimer || timerStartDate == null) {
-      setTimerState('00:00')
-      handleStopTimer()
-    } else if (shouldStopTimer) {
-      handleStopTimer()
-      handleTimerState()
-    } else {
-      const intervalIndex = setInterval(() => {
-        handleTimerState()
-      }, 1000)
-      intervalRef.current = intervalIndex
-      setIntervalEventCounter((prev) => prev + 1)
-    }
-    /* eslint-enable react-hooks/set-state-in-effect */
-
-    return () => {
-      handleStopTimer()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    shouldStartTimer,
-  ])
 
   return (
     <Container>

--- a/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.tsx
+++ b/packages/ui/react/src/components/Primitives/TimerCounter/TimerCounter.tsx
@@ -50,34 +50,25 @@ type TimerCounterProps = {
 const TimerCounter = ({
   timerStartDate,
   timerFinalDate,
-  shouldResetTimer = false,
-  shouldStopTimer = false,
-  shouldStartTimer = true,
+  shouldResetTimer,
+  shouldStopTimer,
+  shouldStartTimer,
   formatDurationTime,
   formatDateTime,
 }: TimerCounterProps) => {
-  const getInitialTimerState = useCallback(() => {
-    if (!shouldStartTimer || shouldResetTimer || timerStartDate == null) {
-      return '00:00'
-    }
-    return formatDurationTime(timerStartDate, timerFinalDate)
-  }, [
-    shouldStartTimer,
-    shouldResetTimer,
-    timerStartDate,
-    timerFinalDate,
-    formatDurationTime,
-  ])
-
+  const [
+    intervalEventCounter,
+    setIntervalEventCounter,
+  ] = useState<number>(0)
   const [
     timerState,
     setTimerState,
-  ] = useState<string>(getInitialTimerState)
+  ] = useState<string>('—')
 
-  const intervalRef = useRef<NodeJS.Timeout | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  const handleStopTimer = useCallback(() => {
-    if (intervalRef.current) {
+  const handleStopTimer = useCallback((): void => {
+    if (intervalRef.current !== null) {
       clearInterval(intervalRef.current)
       intervalRef.current = null
     }
@@ -106,41 +97,40 @@ const TimerCounter = ({
   )
 
   useEffect(() => {
-    if (!shouldStartTimer || shouldResetTimer || timerStartDate == null) {
-      handleStopTimer()
-      const timeoutId = setTimeout(() => {
-        setTimerState('00:00')
-      }, 0)
-      return () => {
-        handleStopTimer()
-        clearTimeout(timeoutId)
-      }
-    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    handleTimerState()
+  }, [
+    intervalEventCounter,
+    timerFinalDate,
+    shouldResetTimer,
+    shouldStopTimer,
+    handleTimerState,
+  ])
 
-    if (shouldStopTimer) {
+  useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect */
+    if (!shouldStartTimer) setTimerState('00:00')
+    if (shouldResetTimer || timerStartDate == null) {
+      setTimerState('00:00')
       handleStopTimer()
-      const timeoutId = setTimeout(handleTimerState, 0)
-      return () => {
-        handleStopTimer()
-        clearTimeout(timeoutId)
-      }
+    } else if (shouldStopTimer) {
+      handleStopTimer()
+      handleTimerState()
+    } else {
+      const intervalIndex = setInterval(() => {
+        handleTimerState()
+      }, 1000)
+      intervalRef.current = intervalIndex
+      setIntervalEventCounter((prev) => prev + 1)
     }
-
-    const initialTimeoutId = setTimeout(handleTimerState, 0)
-    intervalRef.current = setInterval(handleTimerState, 1000)
+    /* eslint-enable react-hooks/set-state-in-effect */
 
     return () => {
       handleStopTimer()
-      clearTimeout(initialTimeoutId)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     shouldStartTimer,
-    shouldResetTimer,
-    shouldStopTimer,
-    timerStartDate,
-    timerFinalDate,
-    handleTimerState,
-    handleStopTimer,
   ])
 
   return (


### PR DESCRIPTION
## Description of changes

- [x] Fix `TimerCounter` showing `00:00` for finished actions (Completed / Failed / Skipped) — restore the pre-migration effect logic where `shouldStartTimer=false` no longer overrides `shouldStopTimer`
- [x] Add regression test for the `shouldStartTimer=false + shouldStopTimer=true` combination
- [x] Add changeset (patch)

### Problem

After the `TimerCounter` migration to `@devopness/ui-react`, the component shows `00:00` for any finished action (Completed / Failed / Skipped) instead of the final duration.

Root cause: the new effect logic early-returns to `00:00` whenever `shouldStartTimer` is `false`, even when `shouldStopTimer` is `true` and valid `timerStartDate` / `timerFinalDate` are provided.

The web app's `ProgressViewerTable.Timer` wires the props like:

```tsx
shouldStartTimer={status === InProgress}
shouldStopTimer={[Completed, Failed, Skipped].includes(status)}
```

So for every finished action, `shouldStartTimer` is `false` → the component freezes at `00:00`, regardless of `shouldStopTimer`.

### Behavior matrix after the fix

- Pending / Waiting / Queued (no start date) → `00:00`
- InProgress → live ticking
- Completed / Failed → final duration
- Skipped (no start date) → `00:00`

## GitHub issues resolved by this PR

- N/A — production bug surfaced after the web-app TimerCounter migration (devopness/devopness-web-app PR 2051).

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: in `devopness-web-app`, action lists (applications / cronjobs / daemons / etc.) and the action viewer display the correct final duration for Completed / Failed actions instead of `00:00`.

## More info

<img width="1470" height="836" alt="TimerCounter storybook after fix" src="https://github.com/user-attachments/assets/b69ed64e-6a39-4c57-bccb-7ad644d5dabf" />