### PR TITLE
ci: skip sync pkg jobs on fork PRs

### DIFF
--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -175,9 +175,7 @@ jobs:
   verify-sync:
     name: Verify sync of package versions
     needs: [detect-changes, sync-pypi-package-versions, sync-main-lockfile]
-    # Skip fork PRs: sync jobs are skipped for forks (can't push back), so there's nothing to verify
     if: >
-      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
       ((github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
        github.event_name == 'push')
       && (needs.detect-changes.outputs.has_package_changes == 'true' || needs.detect-changes.outputs.should_sync_lockfile == 'true')
@@ -190,17 +188,61 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # For non-fork PRs and pushes: the sync jobs ran — fail if they did not succeed
       - name: Fail if sync-pypi-package-versions did not succeed
-        if: needs.detect-changes.outputs.has_package_changes == 'true'
+        if: >
+          needs.detect-changes.outputs.has_package_changes == 'true' &&
+          (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           if [ "${{ needs.sync-pypi-package-versions.result }}" = "failure" ] || [ "${{ needs.sync-pypi-package-versions.result }}" = "cancelled" ]; then
-            echo "❌ Job `sync-pypi-package-versions` failed or was cancelled"
+            echo "❌ Job 'sync-pypi-package-versions' failed or was cancelled"
             exit 1
           fi
 
       - name: Fail if sync-main-lockfile did not succeed
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           if [ "${{ needs.sync-main-lockfile.result }}" = "failure" ] || [ "${{ needs.sync-main-lockfile.result }}" = "cancelled" ]; then
-            echo "❌ Job `sync-main-lockfile` failed or was cancelled"
+            echo "❌ Job 'sync-main-lockfile' failed or was cancelled"
             exit 1
           fi
+
+      # For fork PRs: the sync jobs were skipped (can't push to a fork), so validate read-only instead
+      - name: Set up Node (fork PR lockfile check)
+        if: >
+          needs.detect-changes.outputs.should_sync_lockfile == 'true' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Fail if package-lock.json is out of sync (fork PR)
+        if: >
+          needs.detect-changes.outputs.should_sync_lockfile == 'true' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          npm install --workspaces
+          if ! git diff --exit-code package-lock.json; then
+            echo "❌ package-lock.json is out of sync — run 'npm install --workspaces' locally and commit the result"
+            exit 1
+          fi
+
+      - name: Fail if pyproject.toml versions are out of sync (fork PR)
+        if: >
+          needs.detect-changes.outputs.has_package_changes == 'true' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          PACKAGES=$(cat .github/configs/python-packages.json | jq -r '.[].path')
+          FAILED=false
+          for PKG_PATH in $PACKAGES; do
+            EXPECTED=$(jq -r .version "$PKG_PATH/package.json")
+            ACTUAL=$(grep -m1 '^version = ' "$PKG_PATH/pyproject.toml" | sed 's/version = "\(.*\)"/\1/')
+            if [ "$ACTUAL" != "$EXPECTED" ]; then
+              echo "❌ $PKG_PATH/pyproject.toml version ('$ACTUAL') does not match package.json ('$EXPECTED')"
+              FAILED=true
+            fi
+          done
+          if [ "$FAILED" = "true" ]; then exit 1; fi

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -59,8 +59,10 @@ jobs:
   load-pypi-projects:
     name: Load Python packages matrix
     needs: detect-changes
+    # Skip fork PRs: GITHUB_TOKEN cannot push to a fork's branch, so these sync jobs would always fail
     if: >
       needs.detect-changes.outputs.has_package_changes == 'true' &&
+      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
       ((github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
        github.event_name == 'push')
     runs-on: ubuntu-latest
@@ -80,8 +82,10 @@ jobs:
   sync-pypi-package-versions:
     name: Sync pyproject.toml
     needs: [detect-changes, load-pypi-projects]
+    # Skip fork PRs: GITHUB_TOKEN cannot push to a fork's branch, so these sync jobs would always fail
     if: >
       needs.detect-changes.outputs.has_package_changes == 'true' &&
+      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
       ((github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
        github.event_name == 'push')
     runs-on: ubuntu-latest
@@ -131,8 +135,10 @@ jobs:
   sync-main-lockfile:
     name: Sync the package-lock.json
     needs: detect-changes
+    # Skip fork PRs: GITHUB_TOKEN cannot push to a fork's branch, so these sync jobs would always fail
     if: >
       needs.detect-changes.outputs.should_sync_lockfile == 'true' &&
+      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
       ((github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
        github.event_name == 'push')
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -175,7 +175,9 @@ jobs:
   verify-sync:
     name: Verify sync of package versions
     needs: [detect-changes, sync-pypi-package-versions, sync-main-lockfile]
+    # Skip fork PRs: sync jobs are skipped for forks (can't push back), so there's nothing to verify
     if: >
+      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
       ((github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
        github.event_name == 'push')
       && (needs.detect-changes.outputs.has_package_changes == 'true' || needs.detect-changes.outputs.should_sync_lockfile == 'true')


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.

- Keep PRs single-purpose and minimal; avoid unrelated cleanup.
-->

When PRs coming from fork needs to update package.json files, the sync package versions workflow failed for not having access to COMMIT author/email variables defined in base repo.
- Example: https://github.com/devopness/devopness/actions/runs/27265312481/job/80520869483?pr=3144

The solution here is to skip those jobs when the PR comes from a forked repo, but keep running them on automated PRs created directly on base repo

- [x] Update sync package jobs to skip PRs from forked repos

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: sync package jobs should not fail on PRs coming from forked repositories

<!-- Use a concrete, verifiable, success criteria. Keep it short -->

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
