### PR TITLE
ci: use a PAT to sync packages on changeset PRs

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - packages/**/src/**
       - packages/**/package.json
+      - .changeset/**
     branches:
       - main
       - "*.x" # maintenance releases

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -54,7 +54,10 @@ jobs:
           title: "chore: version packages"
           publish: npx changeset publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT is required here instead of GITHUB_TOKEN: pushes made with GITHUB_TOKEN do not
+          # trigger downstream workflows (GitHub suppresses them to prevent loops), so
+          # sync-package-versions.yml would never fire when changesets updates the release branch
+          GITHUB_TOKEN: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
 
   release-pypi-packages:
     name: Release PyPI Packages

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -19,8 +19,10 @@ on:
     paths:
       - '**/package*.json'
       - 'packages/**/CHANGELOG.md'
+      - '.changeset/**'
     branches:
-      # Trigger when commits are pushed to the changesets branch, to sync the root lock file
+      # Triggered by pushes from the changesets bot (GITHUB_TOKEN suppresses pull_request events,
+      # so the push trigger on this branch is the only way to catch changeset-driven updates)
       - 'changeset-release/*'
 
 permissions:


### PR DESCRIPTION
Add support for changeset files in workflow triggers.

## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.

- Keep PRs single-purpose and minimal; avoid unrelated cleanup.
-->

Problem: sync packages workflows were not triggered in changeset PRs, such as #3163
This happens because GitHub don't trigger related workflows when a PR is created using GITHUB_TOKEN, to prevent infinite loops.

Solution:

- [x] Use Personal Access Token, instead of GITHUB_TOKEN, to ensure sync packages workflow is triggered

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: changeset PRs automatically update root level package.json, without manual intervention

<!-- Use a concrete, verifiable, success criteria. Keep it short -->

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
