### PR TITLE
ci: release PR must use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -40,6 +40,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Prevent the default credential helper from shadowing the PAT set in the next step.
+          # changesets/action pushes commits and tags via git — those must use the PAT so that
+          # the push triggers downstream workflows (GITHUB_TOKEN pushes are suppressed by GitHub).
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -49,16 +54,21 @@ jobs:
       - name: Install SDK dependencies
         run: npm ci --ignore-scripts
 
+      - name: Configure git remote to use PAT
+        # Pushes made with GITHUB_TOKEN do not trigger downstream workflows (GitHub suppresses them
+        # to prevent loops), so sync-package-versions.yml would never fire when changesets updates
+        # the release branch. Embedding the PAT in the remote URL takes precedence over the
+        # credential helper that changesets/action sets up, so git pushes use the PAT while the
+        # changesets/action Octokit calls use the always-valid GITHUB_TOKEN below.
+        run: git remote set-url origin https://x-access-token:${{ secrets.DEVOPNESS_AUTOMATION_PAT }}@github.com/${{ github.repository }}
+
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v1
         with:
           title: "chore: version packages"
           publish: npx changeset publish
         env:
-          # A PAT is required here instead of GITHUB_TOKEN: pushes made with GITHUB_TOKEN do not
-          # trigger downstream workflows (GitHub suppresses them to prevent loops), so
-          # sync-package-versions.yml would never fire when changesets updates the release branch
-          GITHUB_TOKEN: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-pypi-packages:
     name: Release PyPI Packages


### PR DESCRIPTION
Updated GitHub Actions workflow to configure git remote with PAT and use GITHUB_TOKEN for publishing packages.

## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.

- Keep PRs single-purpose and minimal; avoid unrelated cleanup.
-->

Revert part of my changes on #3164 and #3166:

- [x] Revert to use GITHUB_TOKEN when creating the release PR
- [x] Keep PAT for remote url

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: release PRs/commits will use GITHUB_TOKEN instead of a PAT

<!-- Use a concrete, verifiable, success criteria. Keep it short -->

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
