### PR TITLE
docs: add guide for managing received team invitations

### DIFF
--- a/docs/docs/teams/invitations/index.md
+++ b/docs/docs/teams/invitations/index.md
@@ -8,6 +8,7 @@ links:
   guides:
     - teams/invitations/add-invitation
     - teams/invitations/list-invitations
+    - teams/invitations/received-invitations
   related:
     - teams/view-team
   featured:
@@ -47,3 +48,4 @@ If you want the tighter security default, use private invitations. Use public li
 
 - Send one invitation in [Invite Team Member](/docs/teams/invitations/add-invitation)
 - Review invite status in [List Team Invitations](/docs/teams/invitations/list-invitations)
+- Manage invites sent to you in [Received Invitations](/docs/teams/invitations/received-invitations)

--- a/docs/docs/teams/invitations/index.md
+++ b/docs/docs/teams/invitations/index.md
@@ -8,9 +8,9 @@ links:
   guides:
     - teams/invitations/add-invitation
     - teams/invitations/list-invitations
-    - teams/invitations/received-invitations
   related:
     - teams/view-team
+    - users/teams/invitations/list-invitations
   featured:
 ---
 
@@ -48,4 +48,4 @@ If you want the tighter security default, use private invitations. Use public li
 
 - Send one invitation in [Invite Team Member](/docs/teams/invitations/add-invitation)
 - Review invite status in [List Team Invitations](/docs/teams/invitations/list-invitations)
-- Manage invites sent to you in [Received Invitations](/docs/teams/invitations/received-invitations)
+- Manage invites sent to you in [Received Invitations](/docs/users/teams/invitations/list-invitations)

--- a/docs/docs/teams/invitations/list-invitations.md
+++ b/docs/docs/teams/invitations/list-invitations.md
@@ -4,10 +4,9 @@ links:
   overview: teams/invitations/index
   quickstart:
   previous: teams/invitations/add-invitation
-  next: teams/invitations/received-invitations
   guides:
     - teams/invitations/add-invitation
-    - teams/invitations/received-invitations
+    - users/teams/invitations/list-invitations
     - teams/invitations/index
   featured:
 ---

--- a/docs/docs/teams/invitations/list-invitations.md
+++ b/docs/docs/teams/invitations/list-invitations.md
@@ -4,9 +4,10 @@ links:
   overview: teams/invitations/index
   quickstart:
   previous: teams/invitations/add-invitation
-  # next: teams/members/add-team-member
+  next: teams/invitations/received-invitations
   guides:
     - teams/invitations/add-invitation
+    - teams/invitations/received-invitations
     - teams/invitations/index
   featured:
 ---

--- a/docs/docs/teams/invitations/received-invitations.md
+++ b/docs/docs/teams/invitations/received-invitations.md
@@ -1,0 +1,54 @@
+---
+title: Received Invitations
+links:
+  overview: teams/invitations/index
+  quickstart:
+  previous: teams/invitations/list-invitations
+  guides:
+    - teams/invitations/add-invitation
+    - teams/invitations/index
+  featured:
+---
+
+Manage received team invitations and accept or decline them.
+
+## Goal
+
+Know where to find and manage your received invitations.
+
+## Who should use this
+
+- Team collaborators who are joining a organization/environment
+
+## You need
+
+- A valid Devopness account with a existing e-mail
+
+## Steps
+
+1. In any page whitin the Devopness app, click your profile button at the top right
+2. Select [`Teams Invitations`](https://app.devopness.com/profile/teams/invitations)
+
+*OR*
+
+1. Check your e-mail for a new mail from Devopness
+2. There should be a brief summary of who invited you, to which organization and which team
+3. Click the `VIEW INVITATION` button, you will be redirected to the `Teams Invitations` page
+
+## Expected result
+
+- You can see the invitations you have received
+- You can accept or decline an invite
+
+## Common issues
+
+- No invitations found: confirm with a organization admin that you have been invited
+- Missing invite: refresh the page after an admin invites you
+
+## Next
+
+- After accepting an invite, check wether you now have access to that organization
+
+1. On the upper-left corner, click the Devopness logo to [see all available organizations to you](https://app.devopness.com/organizations)
+2. Select the organization of the recent accepted invite
+3. From that point on get in contact with your organization admin for any needed permissions (see [roles](/docs/roles))

--- a/docs/docs/teams/invitations/received-invitations.md
+++ b/docs/docs/teams/invitations/received-invitations.md
@@ -6,6 +6,7 @@ links:
   previous: teams/invitations/list-invitations
   guides:
     - teams/invitations/add-invitation
+    - teams/invitations/list-invitations
     - teams/invitations/index
   featured:
 ---
@@ -28,12 +29,14 @@ Know where to find and manage your received invitations.
 
 1. In any page whitin the Devopness app, click your profile button at the top right
 2. Select [`Teams Invitations`](https://app.devopness.com/profile/teams/invitations)
+3. Now in the invitations view either accept or decline an invite
 
 _OR_
 
 1. Check your e-mail for a new mail from Devopness
 2. There should be a brief summary of who invited you, to which organization and which team
 3. Click the `VIEW INVITATION` button, you will be redirected to the `Teams Invitations` page
+4. Now in the invitations view either accept or decline an invite
 
 ## Expected result
 

--- a/docs/docs/teams/invitations/received-invitations.md
+++ b/docs/docs/teams/invitations/received-invitations.md
@@ -29,7 +29,7 @@ Know where to find and manage your received invitations.
 1. In any page whitin the Devopness app, click your profile button at the top right
 2. Select [`Teams Invitations`](https://app.devopness.com/profile/teams/invitations)
 
-*OR*
+_OR_
 
 1. Check your e-mail for a new mail from Devopness
 2. There should be a brief summary of who invited you, to which organization and which team

--- a/docs/docs/users/index.md
+++ b/docs/docs/users/index.md
@@ -1,6 +1,5 @@
 ---
 title: Users
-intro: In this section you will learn how to find your activity summary.
 links:
   overview:
   quickstart:
@@ -9,5 +8,15 @@ links:
   guides:
   related:
     - users/find-your-activity-summary
+    - users/teams/invitations/list-invitations
+    - users/subscriptions/index
   featured:
 ---
+
+In this section you will learn how to manage your user profile settings, subscriptions, and activity.
+
+## Start here
+
+- Find your activity summary in [Find your Devopness Activity Summary](/docs/users/find-your-activity-summary)
+- Manage invites sent to you in [Received Invitations](/docs/users/teams/invitations/list-invitations)
+- Manage billing and plans in [Billing and Plans](/docs/users/subscriptions/index)

--- a/docs/docs/users/teams/invitations/list-invitations.md
+++ b/docs/docs/users/teams/invitations/list-invitations.md
@@ -1,12 +1,14 @@
 ---
 title: Received Invitations
 links:
-  overview: teams/invitations/index
+  overview: users/index
   quickstart:
-  previous: teams/invitations/list-invitations
+  previous: users/index
   guides:
     - teams/invitations/add-invitation
     - teams/invitations/list-invitations
+    - teams/invitations/index
+  related:
     - teams/invitations/index
   featured:
 ---
@@ -19,15 +21,15 @@ Know where to find and manage your received invitations.
 
 ## Who should use this
 
-- Team collaborators who are joining a organization/environment
+- Team collaborators who are joining an organization/environment
 
 ## You need
 
-- A valid Devopness account with a existing e-mail
+- A valid Devopness account with an existing email
 
 ## Steps
 
-1. In any page whitin the Devopness app, click your profile button at the top right
+1. In any page within the Devopness app, click your profile button at the top right
 2. Select [`Teams Invitations`](https://app.devopness.com/profile/teams/invitations)
 3. Now in the invitations view either accept or decline an invite
 
@@ -50,7 +52,7 @@ _OR_
 
 ## Next
 
-- After accepting an invite, check wether you now have access to that organization
+- After accepting an invite, check whether you now have access to that organization
 
 1. On the upper-left corner, click the Devopness logo to [see all available organizations to you](https://app.devopness.com/organizations)
 2. Select the organization of the recent accepted invite


### PR DESCRIPTION
## Description of changes
- [x] Add a new operation page at `docs/docs/teams/invitations/received-invitations.md` explaining how collaborators find, accept, and decline team invitations they receive
- [x] Follow the docs authoring structure with Goal, Steps, Expected result, Common issues, and Next sections

## GitHub issues resolved by this PR

- [ ] N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: contributors can open the Received Invitations guide from the team invitations docs flow and follow the steps to manage invites sent to their account.
- Open the Received Invitations page in the local docs site and confirm the page renders with correct navigation links from the team invitations section.

## More info
- This page complements the existing [List Team Invitations](../blob/main/docs/docs/teams/invitations/list-invitations.md) guide, which covers the admin view of sent invites.
- Docs-only change; no changeset required.
- Contribution follows the [Contributor Code of Conduct](https://github.com/devopness/devopness/blob/main/CODE_OF_CONDUCT.md).

<img width="1872" height="2223" alt="image" src="https://github.com/user-attachments/assets/3dd98b62-f61e-4a19-8ebc-6c2fb30e87bb" />

