### PR TITLE
fix(ui-react): bump @mui packages to 9.1.1 and fix vitest ESM compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ This file is for fast, action-oriented instructions for AI agents.
 - Avoid `--amend` unless the user asks for it
 
 ## PR instructions
+
+- Before creating PR, make sure branch has no merge conflicts with base branch
 - PR titles should be written in active imperative form, not end with a period, and read naturally, using Conventional Commits (`feat:`, `fix:`, `refactor:`, `chore:`, etc.)
 - **CRITICAL: All PRs MUST pass CI validation before submission**
   - Read `.github/PULL_REQUEST_TEMPLATE.md` to understand required sections

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md) for instructions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2934,34 +2934,58 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.5.0.tgz",
-      "integrity": "sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.1.1.tgz",
+      "integrity": "sha512-AupmMICbdJHqAh6FfOMaaiiIr7dfEgZJn5DFfiPuGNrbs+ZZy9cD1APwO0TSVBz5j08MJEEY6n7iC76/2wjMEA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
-    "node_modules/@mui/material": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
-      "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
+    "node_modules/@mui/icons-material": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.1.1.tgz",
+      "integrity": "sha512-OXhm9DajemStb58AumM06DuPhHTa3XD36TFD4yf6WtJyNRO5DfEZbbnHlBg/US2Y2oOXwM/XurMTBOD6L/YYZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/core-downloads-tracker": "^6.5.0",
-        "@mui/system": "^6.5.0",
-        "@mui/types": "~7.2.24",
-        "@mui/utils": "^6.4.9",
+        "@babel/runtime": "^7.29.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^9.1.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.1.1.tgz",
+      "integrity": "sha512-Wv+gInjrpf99l1Q0oHe0eOWGTnlbkzs5nowClX65KCT/2fyPMwcbFEEkUsOHdpcHhB5UAbz/d7jlwt5ajWVvlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/core-downloads-tracker": "^9.1.1",
+        "@mui/system": "^9.1.1",
+        "@mui/types": "^9.1.1",
+        "@mui/utils": "^9.1.1",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
-        "csstype": "^3.1.3",
+        "csstype": "^3.2.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.0.0",
+        "react-is": "^19.2.6",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -2974,7 +2998,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^6.5.0",
+        "@mui/material-pigment-css": "^9.1.1",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2995,14 +3019,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.9.tgz",
-      "integrity": "sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.1.1.tgz",
+      "integrity": "sha512-oH6c+d6sJ1CZT0Vg2/fHdUQ5zvo9Pn+f+WWk0tlQliHqqIRdN32DZ7UxjalW3LUj4OkHbdWR31biWuLxK9i7Cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/utils": "^6.4.9",
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "^9.1.1",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3023,17 +3046,16 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.5.0.tgz",
-      "integrity": "sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.1.1.tgz",
+      "integrity": "sha512-neaYKdJfvEG54q8efHLJR7swpHG/gfSv9xGqW5iTSMsubD7yPCPFrhVBt284j1DOF3uZaaDJSHQL7gz6jGF21Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@emotion/cache": "^11.13.5",
+        "@babel/runtime": "^7.29.2",
+        "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
-        "csstype": "^3.1.3",
+        "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3081,19 +3103,18 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.5.0.tgz",
-      "integrity": "sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.1.1.tgz",
+      "integrity": "sha512-q+aqNa58QZUwmmyUvJKKrStrej+4BcWFw4M0Ug+zRylPIQgR64cqvBnE3QTfLZm4OXulydp8Hl3zwKxMayrdsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/private-theming": "^6.4.9",
-        "@mui/styled-engine": "^6.5.0",
-        "@mui/types": "~7.2.24",
-        "@mui/utils": "^6.4.9",
+        "@babel/runtime": "^7.29.2",
+        "@mui/private-theming": "^9.1.1",
+        "@mui/styled-engine": "^9.1.1",
+        "@mui/types": "^9.1.1",
+        "@mui/utils": "^9.1.1",
         "clsx": "^2.1.1",
-        "csstype": "^3.1.3",
+        "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3122,11 +3143,13 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.24",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
-      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.1.1.tgz",
+      "integrity": "sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==",
       "license": "MIT",
-      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -3137,18 +3160,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
-      "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.1.1.tgz",
+      "integrity": "sha512-qSNfnkzZMptaaWFFklpDf4NPJztgwsMDVfM/sSDt+wq4ssYSBhLYwwjuB6eS/+p2IUYbeRzHluzXbw0Zn7aI4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/types": "~7.2.24",
-        "@types/prop-types": "^15.7.14",
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.1.1",
+        "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.0.0"
+        "react-is": "^19.2.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -15507,9 +15529,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
     "node_modules/react-is-18": {
@@ -18785,9 +18807,9 @@
       "version": "2.190.1",
       "license": "MIT",
       "dependencies": {
-        "@mui/icons-material": "^9.0.1",
-        "@mui/material": "^9.0.1",
-        "@mui/styled-engine-sc": "^9.1.1",
+        "@mui/icons-material": "9.1.1",
+        "@mui/material": "9.1.1",
+        "@mui/styled-engine-sc": "9.1.1",
         "@radix-ui/react-slot": "^1.2.5",
         "@radix-ui/themes": "^3.3.0",
         "classnames": "^2.5.1",
@@ -18904,239 +18926,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "packages/ui/react/node_modules/@mui/core-downloads-tracker": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.1.tgz",
-      "integrity": "sha512-GzamIIhZ1bH77dq7eKaeyRgJdkypsxin4jBFq2EMs4lBWRR0LFO1CSVMsoebn/VvjcNrnrOrjy48MkrkQUK2iw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      }
-    },
-    "packages/ui/react/node_modules/@mui/icons-material": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.0.1.tgz",
-      "integrity": "sha512-5PRpQjVLTNLyV/2J9J53Yz4R0tVbodG0BQDN2zQI1QBG1OPYM25ar+4N20eyFOfJT6zKglLzsnU70+zdVLaTkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@mui/material": "^9.0.1",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/ui/react/node_modules/@mui/material": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.1.tgz",
-      "integrity": "sha512-voyCpeUxcSWLN7KPZuq0pGCIt726T9K6kiVM3XUcywZDAlZSarLHaUxJVQpospbjjOzN53hwyjo8s6KoWl6utw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@mui/core-downloads-tracker": "^9.0.1",
-        "@mui/system": "^9.0.1",
-        "@mui/types": "^9.0.0",
-        "@mui/utils": "^9.0.1",
-        "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.12",
-        "clsx": "^2.1.1",
-        "csstype": "^3.2.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.2.4",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^9.0.1",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@mui/material-pigment-css": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/ui/react/node_modules/@mui/material/node_modules/@mui/system": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.1.tgz",
-      "integrity": "sha512-WvlioaLxk6ewUIOfh0StxUvOPDS1mCfzaulcudsL1brZNXuh0N9FMk7RpH7ImJKjEz412SEy/V/yvqmtxbqxCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@mui/private-theming": "^9.0.1",
-        "@mui/styled-engine": "^9.0.0",
-        "@mui/types": "^9.0.0",
-        "@mui/utils": "^9.0.1",
-        "clsx": "^2.1.1",
-        "csstype": "^3.2.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/ui/react/node_modules/@mui/material/node_modules/@mui/system/node_modules/@mui/private-theming": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.1.tgz",
-      "integrity": "sha512-pSIGq4Yw749KHEwlkYZWVERgHgwJELP6ODtBNUfV8V4oIb5H+h7IQDFXuk/b2oQccODK1enJAtiEzlgLZmq+8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@mui/utils": "^9.0.1",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/ui/react/node_modules/@mui/material/node_modules/@mui/system/node_modules/@mui/styled-engine": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.0.0.tgz",
-      "integrity": "sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/sheet": "^1.4.0",
-        "csstype": "^3.2.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "packages/ui/react/node_modules/@mui/material/node_modules/@mui/types": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
-      "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/ui/react/node_modules/@mui/material/node_modules/@mui/utils": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.1.tgz",
-      "integrity": "sha512-f3UO3jNN1pYg5zxqXC81Bvv8hx5ACcYc0387382ZI7M5ono1heIwHYLrKsz85myguWdeVKPRZGmDdynWUBjK2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@mui/types": "^9.0.0",
-        "@types/prop-types": "^15.7.15",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.2.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "packages/ui/react/node_modules/@types/node": {

--- a/packages/ui/react/package.json
+++ b/packages/ui/react/package.json
@@ -65,9 +65,9 @@
   },
   "homepage": "https://github.com/devopness/devopness#readme",
   "dependencies": {
-    "@mui/icons-material": "^9.0.1",
-    "@mui/material": "^9.0.1",
-    "@mui/styled-engine-sc": "^9.1.1",
+    "@mui/icons-material": "9.1.1",
+    "@mui/material": "9.1.1",
+    "@mui/styled-engine-sc": "9.1.1",
     "@radix-ui/react-slot": "^1.2.5",
     "@radix-ui/themes": "^3.3.0",
     "classnames": "^2.5.1",

--- a/packages/ui/react/vitest.config.ts
+++ b/packages/ui/react/vitest.config.ts
@@ -17,7 +17,9 @@ export default mergeConfig(
           // imports and react-transition-group has no exports map for this entry. Inlining forces
           // Vite to process MUI through its own resolver (which handles directory imports), instead
           // of handing the .mjs file directly to Node's native ESM loader.
-          inline: ['@mui/material'],
+          inline: [
+            '@mui/material',
+          ],
         },
       },
     },

--- a/packages/ui/react/vitest.config.ts
+++ b/packages/ui/react/vitest.config.ts
@@ -10,6 +10,16 @@ export default mergeConfig(
       globals: true,
       environment: 'jsdom',
       setupFiles: resolve(__dirname, 'src/setupTest.ts'),
+      server: {
+        deps: {
+          // @mui/material >=9.1.0 ships internal/Transition.mjs which does a bare directory import
+          // of 'react-transition-group/TransitionGroupContext'. Node ESM doesn't support directory
+          // imports and react-transition-group has no exports map for this entry. Inlining forces
+          // Vite to process MUI through its own resolver (which handles directory imports), instead
+          // of handing the .mjs file directly to Node's native ESM loader.
+          inline: ['@mui/material'],
+        },
+      },
     },
   })
 )


### PR DESCRIPTION
## Description of changes

- [x] Bump \`@mui/material\`, \`@mui/icons-material\`, and \`@mui/styled-engine-sc\` to \`9.1.1\`
- [x] Add \`server.deps.inline: ['@mui/material']\` to \`vitest.config.ts\` to fix test failures introduced by \`@mui/material >=9.1.0\`

\`@mui/material >=9.1.0\` ships \`internal/Transition.mjs\` (native ESM) which does a bare directory import of \`react-transition-group/TransitionGroupContext\`. Node's ESM loader rejects directory imports and \`react-transition-group@4.4.5\` has no \`exports\` map entry for this path, causing 21 test files to fail with \`ERR_UNSUPPORTED_DIR_IMPORT\`. Setting \`server.deps.inline\` tells Vitest to route \`@mui/material\` through Vite's own resolver, which handles directory imports correctly. The production build is unaffected.

## GitHub issues resolved by this PR

- [ ] closes #N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: CI passes on PRs that bump \`@mui/material\` to \`>=9.1.0\` (e.g. Dependabot PR #3146)

## More info

Verified locally:
- Reproduced the 21-file failure with \`@mui/material@9.1.0\` before the fix
- Ran \`npm test\` with \`@mui/material@9.1.1\` after the fix — all 43 test files pass