### PR TITLE
ci: fix release-packages to use PAT for changesets

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -57,16 +57,18 @@ jobs:
         uses: changesets/action@v1
         with:
           title: 'chore: version packages'
-          # changesets/action forwards GITHUB_TOKEN to the publish subprocess, which means the
-          # long-lived PAT would be inherited by `npx changeset publish` and every npm lifecycle
-          # script it spawns (prepare, prepack, postpublish, etc.) — creating a leak surface for
-          # the automation PAT. Shadowing it back to the short-lived workflow token here limits
-          # the PAT's exposure to git operations only (the insteadOf rewrite set up by the action).
-          publish: env GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset publish
+          # changesets/action explicitly sets GITHUB_TOKEN in the env of every subprocess it
+          # spawns (version and publish), so the long-lived PAT would be inherited by
+          # `npx changeset version/publish` and every npm lifecycle script they spawn
+          # (prepare, prepack, postpublish, etc.) — a leak surface for the automation PAT.
+          # Shadowing GITHUB_TOKEN back to the short-lived workflow token in both commands limits
+          # the PAT's exposure to the action's own git credential setup (.netrc) only.
+          version: sh -c 'GITHUB_TOKEN="$WORKFLOW_GITHUB_TOKEN" npx changeset version'
+          publish: sh -c 'GITHUB_TOKEN="$WORKFLOW_GITHUB_TOKEN" npx changeset publish'
         env:
-          # changesets/action sets up a git `insteadOf` rewrite using GITHUB_TOKEN, so the PAT
-          # must be here for git pushes to use it (GITHUB_TOKEN pushes are suppressed by GitHub
-          # to prevent loops and would never trigger sync-package-versions.yml).
+          # changesets/action writes ~/.netrc with GITHUB_TOKEN for git push authentication, so
+          # the PAT must be here — GITHUB_TOKEN pushes are suppressed by GitHub to prevent loops
+          # and would never trigger sync-package-versions.yml on the changeset-release/* branch.
           GITHUB_TOKEN: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
           WORKFLOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -41,9 +41,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          # Prevent the default credential helper from shadowing the PAT set in the next step.
-          # changesets/action pushes commits and tags via git — those must use the PAT so that
-          # the push triggers downstream workflows (GITHUB_TOKEN pushes are suppressed by GitHub).
+          # Disable the default credential helper so changesets/action's own insteadOf rewrite
+          # (based on the PAT in GITHUB_TOKEN below) is the sole credential in effect.
           persist-credentials: false
 
       - name: Set up Node
@@ -54,21 +53,16 @@ jobs:
       - name: Install SDK dependencies
         run: npm ci --ignore-scripts
 
-      - name: Configure git remote to use PAT
-        # Pushes made with GITHUB_TOKEN do not trigger downstream workflows (GitHub suppresses them
-        # to prevent loops), so sync-package-versions.yml would never fire when changesets updates
-        # the release branch. Embedding the PAT in the remote URL takes precedence over the
-        # credential helper that changesets/action sets up, so git pushes use the PAT while the
-        # changesets/action Octokit calls use the always-valid GITHUB_TOKEN below.
-        run: git remote set-url origin https://x-access-token:${{ secrets.DEVOPNESS_AUTOMATION_PAT }}@github.com/${{ github.repository }}
-
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v1
         with:
           title: "chore: version packages"
           publish: npx changeset publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use the PAT so that changesets' internal `git insteadOf` rewrite uses the PAT for the
+          # push. GITHUB_TOKEN pushes are suppressed by GitHub (to prevent loops) and would never
+          # trigger sync-package-versions.yml on the changeset-release/* branch.
+          GITHUB_TOKEN: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
 
   release-pypi-packages:
     name: Release PyPI Packages

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -9,7 +9,7 @@ on:
       - .changeset/**
     branches:
       - main
-      - "*.x" # maintenance releases
+      - '*.x' # maintenance releases
 
 permissions:
   contents: write
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "24.x"
+          node-version: '24.x'
 
       - name: Install SDK dependencies
         run: npm ci --ignore-scripts
@@ -56,13 +56,19 @@ jobs:
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v1
         with:
-          title: "chore: version packages"
-          publish: npx changeset publish
+          title: 'chore: version packages'
+          # changesets/action forwards GITHUB_TOKEN to the publish subprocess, which means the
+          # long-lived PAT would be inherited by `npx changeset publish` and every npm lifecycle
+          # script it spawns (prepare, prepack, postpublish, etc.) — creating a leak surface for
+          # the automation PAT. Shadowing it back to the short-lived workflow token here limits
+          # the PAT's exposure to git operations only (the insteadOf rewrite set up by the action).
+          publish: env GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset publish
         env:
-          # Use the PAT so that changesets' internal `git insteadOf` rewrite uses the PAT for the
-          # push. GITHUB_TOKEN pushes are suppressed by GitHub (to prevent loops) and would never
-          # trigger sync-package-versions.yml on the changeset-release/* branch.
+          # changesets/action sets up a git `insteadOf` rewrite using GITHUB_TOKEN, so the PAT
+          # must be here for git pushes to use it (GITHUB_TOKEN pushes are suppressed by GitHub
+          # to prevent loops and would never trigger sync-package-versions.yml).
           GITHUB_TOKEN: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
+          WORKFLOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-pypi-packages:
     name: Release PyPI Packages


### PR DESCRIPTION
Updated GitHub Actions workflow to use personal access token (PAT) for git operations instead of GITHUB_TOKEN to trigger downstream workflows.

## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.

- Keep PRs single-purpose and minimal; avoid unrelated cleanup.
-->

It seems I was wrong in https://github.com/devopness/devopness/pull/3167 

- [x] Trigger changeset PRs with PAT instead of GITHUB_TOKEN, so it can trigger related workflows to sync pkg files

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: changeset PRs created without the issues noticed in https://github.com/devopness/devopness/actions/runs/27346166563/job/80795290451 

<!-- Use a concrete, verifiable, success criteria. Keep it short -->

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
