### PR TITLE
ci: fix release workflow to lint CHANGELOG and push using PAT

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -53,20 +53,22 @@ jobs:
       - name: Install SDK dependencies
         run: npm ci --ignore-scripts
 
-      - name: Configure git remote to use PAT
-        # Pushes made with GITHUB_TOKEN do not trigger downstream workflows (GitHub suppresses them
-        # to prevent loops), so sync-package-versions.yml would never fire when changesets updates
-        # the release branch. Embedding the PAT in the remote URL takes precedence over the action's
-        # credential helper, so git pushes use the PAT while changesets/action's API calls use the
-        # workflow token passed via the github-token input below.
-        run: git remote set-url origin https://x-access-token:${{ secrets.DEVOPNESS_AUTOMATION_PAT }}@github.com/${{ github.repository }}
-
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v1
         with:
           title: 'chore: version packages'
-          publish: npx changeset publish
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # changesets/action runs these via exec("sh",["-c",cmd]), so shell variable assignment
+          # syntax works here. Shadowing GITHUB_TOKEN back to the short-lived workflow token
+          # prevents the long-lived PAT from being inherited by changeset scripts or npm lifecycle
+          # hooks (changesets/action explicitly sets GITHUB_TOKEN in every subprocess it spawns).
+          version: GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset version
+          publish: GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset publish
+        env:
+          # changesets/action writes ~/.netrc with GITHUB_TOKEN for git authentication. The PAT
+          # must be used here so the push triggers downstream workflows — GITHUB_TOKEN pushes are
+          # suppressed by GitHub to prevent loops and would never fire sync-package-versions.yml.
+          GITHUB_TOKEN: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
+          WORKFLOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-pypi-packages:
     name: Release PyPI Packages

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -63,8 +63,8 @@ jobs:
           # (prepare, prepack, postpublish, etc.) — a leak surface for the automation PAT.
           # Shadowing GITHUB_TOKEN back to the short-lived workflow token in both commands limits
           # the PAT's exposure to the action's own git credential setup (.netrc) only.
-          version: sh -c 'GITHUB_TOKEN="$WORKFLOW_GITHUB_TOKEN" npx changeset version'
-          publish: sh -c 'GITHUB_TOKEN="$WORKFLOW_GITHUB_TOKEN" npx changeset publish'
+          version: "sh -c 'GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset version'"
+          publish: "sh -c 'GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset publish'"
         env:
           # changesets/action writes ~/.netrc with GITHUB_TOKEN for git push authentication, so
           # the PAT must be here — GITHUB_TOKEN pushes are suppressed by GitHub to prevent loops

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -61,6 +61,18 @@ jobs:
         # workflow token passed via the github-token input below.
         run: git remote set-url origin https://x-access-token:${{ secrets.DEVOPNESS_AUTOMATION_PAT }}@github.com/${{ github.repository }}
 
+      - name: Debug release credentials
+        env:
+          PAT: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
+          WORKFLOW_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "PAT present: ${PAT:+yes}"
+          echo "PAT prefix: ${PAT:0:5}"
+          echo "Workflow token present: ${WORKFLOW_TOKEN:+yes}"
+          echo "Workflow token prefix: ${WORKFLOW_TOKEN:0:5}"
+          echo "Redacted origin: $(git remote get-url origin | sed -E 's#(https://x-access-token:)[^@]+@#\1***@#')"
+          git ls-remote origin HEAD | sed -E 's#(https://x-access-token:)[^@]+@#\1***@#'
+
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v1
         with:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -73,6 +73,10 @@ jobs:
           echo "Redacted origin: $(git remote get-url origin | sed -E 's#(https://x-access-token:)[^@]+@#\1***@#')"
           git ls-remote origin HEAD | sed -E 's#(https://x-access-token:)[^@]+@#\1***@#'
 
+      - name: Debug PAT push access
+        run: git push --dry-run origin HEAD:refs/heads/pat-debug --force
+        continue-on-error: true
+
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v1
         with:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -61,22 +61,6 @@ jobs:
         # workflow token passed via the github-token input below.
         run: git remote set-url origin https://x-access-token:${{ secrets.DEVOPNESS_AUTOMATION_PAT }}@github.com/${{ github.repository }}
 
-      - name: Debug release credentials
-        env:
-          PAT: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
-          WORKFLOW_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "PAT present: ${PAT:+yes}"
-          echo "PAT prefix: ${PAT:0:5}"
-          echo "Workflow token present: ${WORKFLOW_TOKEN:+yes}"
-          echo "Workflow token prefix: ${WORKFLOW_TOKEN:0:5}"
-          echo "Redacted origin: $(git remote get-url origin | sed -E 's#(https://x-access-token:)[^@]+@#\1***@#')"
-          git ls-remote origin HEAD | sed -E 's#(https://x-access-token:)[^@]+@#\1***@#'
-
-      - name: Debug PAT push access
-        run: git push --dry-run origin HEAD:refs/heads/pat-debug --force
-        continue-on-error: true
-
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v1
         with:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -53,18 +53,33 @@ jobs:
       - name: Install SDK dependencies
         run: npm ci --ignore-scripts
 
+      - name: Write changeset wrapper scripts
+        # changesets/action passes GITHUB_TOKEN (set to the PAT below) into every subprocess it
+        # spawns, leaking the long-lived PAT to `npx changeset version/publish` and all npm
+        # lifecycle scripts they invoke. Wrapper scripts shadow GITHUB_TOKEN back to the
+        # short-lived workflow token so the PAT is only used by the action's git credential setup.
+        # Scripts are used instead of inline shell expressions because changesets/action invokes
+        # the version/publish commands via exec("sh", ["-c", cmd]), which double-wraps any sh -c
+        # construct and causes "Unterminated quoted string" parse errors.
+        env:
+          WORKFLOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat > /tmp/cs-version.sh << 'EOF'
+          #!/bin/sh
+          exec env GITHUB_TOKEN="$WORKFLOW_GITHUB_TOKEN" npx changeset version
+          EOF
+          cat > /tmp/cs-publish.sh << 'EOF'
+          #!/bin/sh
+          exec env GITHUB_TOKEN="$WORKFLOW_GITHUB_TOKEN" npx changeset publish
+          EOF
+          chmod +x /tmp/cs-version.sh /tmp/cs-publish.sh
+
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v1
         with:
           title: 'chore: version packages'
-          # changesets/action explicitly sets GITHUB_TOKEN in the env of every subprocess it
-          # spawns (version and publish), so the long-lived PAT would be inherited by
-          # `npx changeset version/publish` and every npm lifecycle script they spawn
-          # (prepare, prepack, postpublish, etc.) — a leak surface for the automation PAT.
-          # Shadowing GITHUB_TOKEN back to the short-lived workflow token in both commands limits
-          # the PAT's exposure to the action's own git credential setup (.netrc) only.
-          version: GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset version
-          publish: GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset publish
+          version: /tmp/cs-version.sh
+          publish: /tmp/cs-publish.sh
         env:
           # changesets/action writes ~/.netrc with GITHUB_TOKEN for git push authentication, so
           # the PAT must be here — GITHUB_TOKEN pushes are suppressed by GitHub to prevent loops

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          # Disable the default credential helper so changesets/action's own insteadOf rewrite
-          # (based on the PAT in GITHUB_TOKEN below) is the sole credential in effect.
+          # Disable the default credential helper so the PAT remote rewrite below is the sole
+          # credential in effect for git pushes.
           persist-credentials: false
 
       - name: Set up Node
@@ -52,6 +52,14 @@ jobs:
 
       - name: Install SDK dependencies
         run: npm ci --ignore-scripts
+
+      - name: Configure git remote to use PAT
+        # Pushes made with GITHUB_TOKEN do not trigger downstream workflows (GitHub suppresses them
+        # to prevent loops), so sync-package-versions.yml would never fire when changesets updates
+        # the release branch. Embedding the PAT in the remote URL takes precedence over the action's
+        # credential helper, so git pushes use the PAT while changesets/action's API calls use the
+        # workflow token passed via the github-token input below.
+        run: git remote set-url origin https://x-access-token:${{ secrets.DEVOPNESS_AUTOMATION_PAT }}@github.com/${{ github.repository }}
 
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v1

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -53,39 +53,20 @@ jobs:
       - name: Install SDK dependencies
         run: npm ci --ignore-scripts
 
-      - name: Write changeset wrapper scripts
-        # changesets/action passes GITHUB_TOKEN (set to the PAT below) into every subprocess it
-        # spawns, leaking the long-lived PAT to `npx changeset version/publish` and all npm
-        # lifecycle scripts they invoke. Wrapper scripts shadow GITHUB_TOKEN back to the
-        # short-lived workflow token so the PAT is only used by the action's git credential setup.
-        # Scripts are used instead of inline shell expressions because changesets/action invokes
-        # the version/publish commands via exec("sh", ["-c", cmd]), which double-wraps any sh -c
-        # construct and causes "Unterminated quoted string" parse errors.
-        env:
-          WORKFLOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cat > /tmp/cs-version.sh << 'EOF'
-          #!/bin/sh
-          exec env GITHUB_TOKEN="$WORKFLOW_GITHUB_TOKEN" npx changeset version
-          EOF
-          cat > /tmp/cs-publish.sh << 'EOF'
-          #!/bin/sh
-          exec env GITHUB_TOKEN="$WORKFLOW_GITHUB_TOKEN" npx changeset publish
-          EOF
-          chmod +x /tmp/cs-version.sh /tmp/cs-publish.sh
+      - name: Configure git remote to use PAT
+        # Pushes made with GITHUB_TOKEN do not trigger downstream workflows (GitHub suppresses them
+        # to prevent loops), so sync-package-versions.yml would never fire when changesets updates
+        # the release branch. Embedding the PAT in the remote URL takes precedence over the action's
+        # credential helper, so git pushes use the PAT while changesets/action's API calls use the
+        # workflow token passed via the github-token input below.
+        run: git remote set-url origin https://x-access-token:${{ secrets.DEVOPNESS_AUTOMATION_PAT }}@github.com/${{ github.repository }}
 
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v1
         with:
           title: 'chore: version packages'
-          version: /tmp/cs-version.sh
-          publish: /tmp/cs-publish.sh
-        env:
-          # changesets/action writes ~/.netrc with GITHUB_TOKEN for git push authentication, so
-          # the PAT must be here — GITHUB_TOKEN pushes are suppressed by GitHub to prevent loops
-          # and would never trigger sync-package-versions.yml on the changeset-release/* branch.
-          GITHUB_TOKEN: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
-          WORKFLOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          publish: npx changeset publish
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   release-pypi-packages:
     name: Release PyPI Packages

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -53,6 +53,19 @@ jobs:
       - name: Install SDK dependencies
         run: npm ci --ignore-scripts
 
+      - name: Prepare changeset version hook
+        # `changesets/action` executes the version command before it stages the release PR.
+        # We wrap it so generated CHANGELOG files are normalized before commit creation.
+        run: |
+          cat > /tmp/cs-version.sh << 'EOF'
+          #!/bin/sh
+          # Keep the version step strict so the formatter failure surfaces immediately.
+          set -e
+          npx changeset version
+          npm run format:changelogs
+          EOF
+          chmod +x /tmp/cs-version.sh
+
       - name: Configure git remote to use PAT
         # Pushes made with GITHUB_TOKEN do not trigger downstream workflows (GitHub suppresses them
         # to prevent loops), so sync-package-versions.yml would never fire when changesets updates
@@ -65,6 +78,7 @@ jobs:
         uses: changesets/action@v1
         with:
           title: 'chore: version packages'
+          version: /tmp/cs-version.sh
           publish: npx changeset publish
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -63,8 +63,8 @@ jobs:
           # (prepare, prepack, postpublish, etc.) — a leak surface for the automation PAT.
           # Shadowing GITHUB_TOKEN back to the short-lived workflow token in both commands limits
           # the PAT's exposure to the action's own git credential setup (.netrc) only.
-          version: "sh -c 'GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset version'"
-          publish: "sh -c 'GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset publish'"
+          version: GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset version
+          publish: GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset publish
         env:
           # changesets/action writes ~/.netrc with GITHUB_TOKEN for git push authentication, so
           # the PAT must be here — GITHUB_TOKEN pushes are suppressed by GitHub to prevent loops

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -57,18 +57,8 @@ jobs:
         uses: changesets/action@v1
         with:
           title: 'chore: version packages'
-          # changesets/action runs these via exec("sh",["-c",cmd]), so shell variable assignment
-          # syntax works here. Shadowing GITHUB_TOKEN back to the short-lived workflow token
-          # prevents the long-lived PAT from being inherited by changeset scripts or npm lifecycle
-          # hooks (changesets/action explicitly sets GITHUB_TOKEN in every subprocess it spawns).
-          version: GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset version
-          publish: GITHUB_TOKEN=$WORKFLOW_GITHUB_TOKEN npx changeset publish
-        env:
-          # changesets/action writes ~/.netrc with GITHUB_TOKEN for git authentication. The PAT
-          # must be used here so the push triggers downstream workflows — GITHUB_TOKEN pushes are
-          # suppressed by GitHub to prevent loops and would never fire sync-package-versions.yml.
-          GITHUB_TOKEN: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
-          WORKFLOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          publish: npx changeset publish
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   release-pypi-packages:
     name: Release PyPI Packages

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0"
   },
+  "scripts": {
+    "format:changelogs": "npx prettier --write \"packages/*/*/CHANGELOG.md\""
+  },
   "devDependencies": {
     "jsdom": "^29.1.1"
   },


### PR DESCRIPTION
## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.

- Keep PRs single-purpose and minimal; avoid unrelated cleanup.
-->

Continue the work started in #3176 and previous PRs:

- [x] Fix release workflow to use a GitHub PAT when committing to changeset branch, so downstream workflows are triggered
- [x] Ensure CHANGELOG.md passes linter before being pushed,  to prevent PR checks to fail when CHANGELOG is not formatted

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: release workflows runs without errors

<!-- Use a concrete, verifiable, success criteria. Keep it short -->

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
