### PR TITLE
feat: add addUrl prop to CardList and implement WithAddUrl story

### DIFF
--- a/.changeset/feat-add-url.md
+++ b/.changeset/feat-add-url.md
@@ -1,0 +1,5 @@
+---
+'@devopness/ui-react': patch
+---
+
+Add 'addUrl' to the Pick<CardProps, ...> union in CardListProps.data so consumers can pass addUrl per card item and have it reach the underlying Card component via the existing {...props} spread.

--- a/packages/ui/react/src/components/CardList/CardList.stories.tsx
+++ b/packages/ui/react/src/components/CardList/CardList.stories.tsx
@@ -510,7 +510,11 @@ const allCardsWithAddUrl: CardListProps['data'] = allEnvironmentCards.map(
 /**
  * WithAddUrl render: uses pre-computed cards with addUrl set.
  */
-function renderWithAddUrl({ cardsCount, isLoading, isError }: CardListStoryArgs) {
+function renderWithAddUrl({
+  cardsCount,
+  isLoading,
+  isError,
+}: CardListStoryArgs) {
   return (
     <CardList
       data={isLoading ? [] : allCardsWithAddUrl.slice(0, cardsCount)}

--- a/packages/ui/react/src/components/CardList/CardList.stories.tsx
+++ b/packages/ui/react/src/components/CardList/CardList.stories.tsx
@@ -497,6 +497,30 @@ function renderAllZero({ cardsCount, isLoading, isError }: CardListStoryArgs) {
   )
 }
 
+/**
+ * Pre-computed cards with addUrl set, showing the + button in each card header.
+ */
+const allCardsWithAddUrl: CardListProps['data'] = allEnvironmentCards.map(
+  (card) => ({
+    ...card,
+    addUrl: `/projects/1/environments/1/${card.label.toLowerCase().replace(/ /g, '-')}/new`,
+  })
+)
+
+/**
+ * WithAddUrl render: uses pre-computed cards with addUrl set.
+ */
+function renderWithAddUrl({ cardsCount, isLoading, isError }: CardListStoryArgs) {
+  return (
+    <CardList
+      data={isLoading ? [] : allCardsWithAddUrl.slice(0, cardsCount)}
+      isLoading={isLoading}
+      isError={isError}
+      loadingCardsCount={cardsCount}
+    />
+  )
+}
+
 /** Default: 4 cards rendered. Adjust `cardsCount` to show 1–12 cards. */
 const Default: StoryObj<CardListStoryArgs> = {
   args: {
@@ -547,7 +571,17 @@ const Error: StoryObj<CardListStoryArgs> = {
   render: renderCardList,
 }
 
-export { AllResources, AllZero, Default, Error, Loading }
+/** WithAddUrl: 4 cards each showing a + button in the header via the addUrl prop. */
+const WithAddUrl: StoryObj<CardListStoryArgs> = {
+  args: {
+    cardsCount: 4,
+    isLoading: false,
+    isError: false,
+  },
+  render: renderWithAddUrl,
+}
+
+export { AllResources, AllZero, Default, Error, Loading, WithAddUrl }
 
 const meta = {
   title: 'Components/CardList',

--- a/packages/ui/react/src/components/CardList/CardList.test.tsx
+++ b/packages/ui/react/src/components/CardList/CardList.test.tsx
@@ -1,6 +1,6 @@
-import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import '@testing-library/jest-dom'
+import { describe, expect, it } from 'vitest'
 
 import type { CardListProps } from './CardList'
 import { CardList } from './CardList'
@@ -45,5 +45,25 @@ describe('CardList', () => {
 
     expect(screen.getByTestId('card-list-empty-state')).toBeInTheDocument()
     expect(screen.queryByRole('article')).not.toBeInTheDocument()
+  })
+
+  it('renders add button when addUrl is provided', () => {
+    const dataWithAddUrl = [
+      {
+        ...mockData[0],
+        addUrl: { to: '/test/add', disabled: true },
+      },
+    ] satisfies CardListProps['data']
+
+    render(
+      <CardList
+        data={dataWithAddUrl}
+        isError={false}
+        isLoading={false}
+        loadingCardsCount={1}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /add/i })).toBeInTheDocument()
   })
 })

--- a/packages/ui/react/src/components/CardList/CardList.tsx
+++ b/packages/ui/react/src/components/CardList/CardList.tsx
@@ -15,7 +15,7 @@ type CardListProps = {
   /**
    * Array of card data to be rendered
    */
-  data: (Pick<CardProps, 'children' | 'icon' | 'footer' | 'url'> & {
+  data: (Pick<CardProps, 'addUrl' | 'children' | 'icon' | 'footer' | 'url'> & {
     backgroundColor: Color
     color: Color
     indicator: number


### PR DESCRIPTION
## Description of changes
- Add 'addUrl' to the Pick<CardProps, ...> union in CardListProps.data so consumers can pass addUrl per card item and have it reach the underlying Card component via the existing {...props} spread.
- Add a WithAddUrl Storybook story demonstrating the + button rendered on each card header.
- Add a test case renders add button when addUrl is provided covering the addUrl path through CardList.

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: passing addUrl to an item in CardList.data renders a + button on the corresponding card header, and all existing CardList tests continue to pass.

## Problem(s) to be Solved
The Card component has supported addUrl since @devopness/ui-react v2.187.1, but CardListProps.data did not include it in its Pick<CardProps>. This meant the prop was silently discarded at the type boundary, so TypeScript would reject it even though Card supports it, making the feature effectively inaccessible to CardList consumers. This change closes that gap.

## More info

### Before
<img width="1917" height="972" alt="image" src="https://github.com/user-attachments/assets/c7899113-19ab-4015-b523-2ab5c6443fcb" />


### After
<img width="1917" height="967" alt="after-cardList-add" src="https://github.com/user-attachments/assets/41016d68-5b13-42fb-b693-be9773d884df" />


