### PR TITLE
feat: cardlist add button tooltip

### DIFF
--- a/.changeset/add-tooltip.md
+++ b/.changeset/add-tooltip.md
@@ -1,0 +1,5 @@
+---
+"@devopness/ui-react": patch
+---
+
+Add `tooltip` prop to `addUrl` in `Card` for enabled-state tooltip and accessible name on the + button

--- a/packages/ui/react/src/components/CardList/CardList.stories.tsx
+++ b/packages/ui/react/src/components/CardList/CardList.stories.tsx
@@ -502,12 +502,13 @@ function renderAllZero({ cardsCount, isLoading, isError }: CardListStoryArgs) {
  */
 const allCardsWithAddUrl: CardListProps['data'] = allEnvironmentCards.map(
   (card) => {
-    const singular = labelToSingular[card.label] ?? card.label.toLowerCase()
+    const lower = card.label.toLowerCase()
+    const singular = labelToSingular[card.label] ?? lower
     return {
       ...card,
       addUrl: {
         target: '_self' as const,
-        to: `/projects/1/environments/1/${card.label.toLowerCase().replace(/ /g, '-')}/new`,
+        to: `/projects/1/environments/1/${lower.replace(/ /g, '-')}/new`,
         tooltip: `Add ${singular}`,
       },
     }

--- a/packages/ui/react/src/components/CardList/CardList.stories.tsx
+++ b/packages/ui/react/src/components/CardList/CardList.stories.tsx
@@ -501,10 +501,17 @@ function renderAllZero({ cardsCount, isLoading, isError }: CardListStoryArgs) {
  * Pre-computed cards with addUrl set, showing the + button in each card header.
  */
 const allCardsWithAddUrl: CardListProps['data'] = allEnvironmentCards.map(
-  (card) => ({
-    ...card,
-    addUrl: `/projects/1/environments/1/${card.label.toLowerCase().replace(/ /g, '-')}/new`,
-  })
+  (card) => {
+    const singular = labelToSingular[card.label] ?? card.label.toLowerCase()
+    return {
+      ...card,
+      addUrl: {
+        target: '_self' as const,
+        to: `/projects/1/environments/1/${card.label.toLowerCase().replace(/ /g, '-')}/new`,
+        tooltip: `Add ${singular}`,
+      },
+    }
+  }
 )
 
 /**

--- a/packages/ui/react/src/components/Templates/Card/Card.tsx
+++ b/packages/ui/react/src/components/Templates/Card/Card.tsx
@@ -242,6 +242,7 @@ const Card = ({ children, ...props }: CardProps) => (
                   </StyledAddCtaButton>
                 ) : (
                   <StyledAddCtaLink
+                    aria-label={tooltip ?? 'add'}
                     hideExternalUrlIcon
                     hideUnderline
                     target="_self"

--- a/packages/ui/react/src/components/Templates/Card/Card.tsx
+++ b/packages/ui/react/src/components/Templates/Card/Card.tsx
@@ -78,12 +78,14 @@ type CardProps = React.PropsWithChildren<{
    * When an object is provided, supports the same props as `url` plus:
    * - `disabled`: renders the button as disabled instead of navigating
    * - `disabledTooltip`: tooltip message shown when disabled
+   * - `tooltip`: tooltip message shown when enabled
    */
   addUrl?:
     | string
     | (Omit<LinkProps, 'style'> & {
         disabled?: boolean
         disabledTooltip?: string
+        tooltip?: string
       })
   /**
    * Subtitle to display in the card
@@ -222,11 +224,11 @@ const Card = ({ children, ...props }: CardProps) => (
             )
           }
 
-          const { disabled, disabledTooltip, ...linkProps } = addUrl
+          const { disabled, disabledTooltip, tooltip, ...linkProps } = addUrl
 
           return (
             <StyledAddCta>
-              <Tooltip title={disabled ? (disabledTooltip ?? '') : ''}>
+              <Tooltip title={disabled ? (disabledTooltip ?? '') : (tooltip ?? '')}>
                 {disabled ? (
                   <StyledAddCtaButton
                     aria-label="add"

--- a/packages/ui/react/src/components/Templates/Card/Card.tsx
+++ b/packages/ui/react/src/components/Templates/Card/Card.tsx
@@ -231,7 +231,7 @@ const Card = ({ children, ...props }: CardProps) => (
               <Tooltip title={disabled ? disabledTooltip : tooltip}>
                 {disabled ? (
                   <StyledAddCtaButton
-                    aria-label="add"
+                    aria-label={disabledTooltip ?? 'add'}
                     disabled
                     type="button"
                   >

--- a/packages/ui/react/src/components/Templates/Card/Card.tsx
+++ b/packages/ui/react/src/components/Templates/Card/Card.tsx
@@ -228,7 +228,7 @@ const Card = ({ children, ...props }: CardProps) => (
 
           return (
             <StyledAddCta>
-              <Tooltip title={disabled ? (disabledTooltip ?? '') : (tooltip ?? '')}>
+              <Tooltip title={disabled ? disabledTooltip : tooltip}>
                 {disabled ? (
                   <StyledAddCtaButton
                     aria-label="add"


### PR DESCRIPTION
## Description of changes
- Add `tooltip?: string` to the `addUrl` object type in `CardProps` so consumers can pass a tooltip message for the enabled state of the `+` button, alongside the existing `disabledTooltip` for the disabled state.
- Pass `tooltip` to the `<Tooltip title={...}>` already wrapping the add CTA, so hovering the enabled `+` button shows the configured message (e.g. "Add server").
- Add `aria-label={tooltip ?? 'add'}` to the enabled `StyledAddCtaLink` so screen readers announce the button's purpose even when the hover tooltip is not visible.
- Update the `WithAddUrl` Storybook story in `CardList.stories.tsx` to use the object form of `addUrl` with `tooltip: 'Add <resource>'`, demonstrating the new prop on each card.

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: passing `addUrl={{ to: '/new', tooltip: 'Add server' }}` to a `Card` renders a `+` button that shows "Add server" on hover, announces "Add server" to screen readers via `aria-label`, and the existing disabled-state tooltip (`disabledTooltip`) continues to work unchanged.

## Problem(s) to be Solved

`Card` already rendered a tooltip on the `+` button when disabled (`disabledTooltip`), but had no equivalent for the enabled state. Additionally, the enabled link had no accessible name — screen readers announced it only as "link" — because the icon carries no text.

## More info

### Before
<img width="1917" height="962" alt="image" src="https://github.com/user-attachments/assets/605e4e57-3744-478e-92c5-24749a9f8f5f" />


### After
<img width="1918" height="962" alt="image" src="https://github.com/user-attachments/assets/2887e369-d09b-489f-9ec2-a54d5b338c77" />
