### PR TITLE
fix: pass GitHub token to changeset version hook

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -76,6 +76,10 @@ jobs:
 
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v1
+        env:
+          # @changesets/changelog-github reads GITHUB_TOKEN from the environment while
+          # `npx changeset version` runs inside the custom version hook.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           title: 'chore: version packages'
           version: /tmp/cs-version.sh


### PR DESCRIPTION
## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- N/A


## Description of changes
- The Release - Packages workflow failed during the Changesets `version` step because `@changesets/changelog-github` expects `GITHUB_TOKEN` to be present in the environment while the custom `/tmp/cs-version.sh` hook runs `npx changeset version`.

- Export `GITHUB_TOKEN` into the `changesets/action@v1` step in `.github/workflows/release-packages.yml` so the changelog generation can authenticate while the version hook runs (added an `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` block).

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: CI passing

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4581cfa5d0832c96a4c0216a79bb34)