### PR TITLE
fix(ci): remove unnecessary buildx setup

### DIFF
--- a/.github/workflows/ci-sdk-python.yml
+++ b/.github/workflows/ci-sdk-python.yml
@@ -54,9 +54,6 @@ jobs:
           persist-credentials: true
           fetch-depth: 0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build Docker Image
         run: make build-image
 

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -118,10 +118,6 @@ jobs:
             echo "should_publish=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Set up Docker Buildx
-        if: steps.version_check.outputs.should_publish == 'true'
-        uses: docker/setup-buildx-action@v3
-
       - name: Build Docker Image
         if: steps.version_check.outputs.should_publish == 'true'
         working-directory: ${{ matrix.path }}


### PR DESCRIPTION
## Description of changes

Fix failing Python SDK CI jobs as in https://github.com/devopness/devopness/actions/runs/28550126286/job/84645116929?pr=3261 

- [x] Remove the unnecessary `docker/setup-buildx-action@v3` step from the Python CI workflow.
- [x] Remove the same Buildx setup from the package release workflow, since the Python Makefile already uses plain `docker build`.

## GitHub issues resolved by this PR
- [x] N/A

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: the Python CI and release jobs no longer fail while booting Buildx, and the workflow logs no longer show the Buildx Node 20 deprecation warning.

## More info
The failing job log showed `docker/setup-buildx-action@v3` timing out while pulling `moby/buildkit` from Docker Hub. This change removes that unnecessary dependency path.