### PR TITLE
fix: make SDK-JS token expiry check browser safe

### DIFF
--- a/.changeset/browser-safe-sdk-token-expiry.md
+++ b/.changeset/browser-safe-sdk-token-expiry.md
@@ -1,0 +1,5 @@
+---
+"@devopness/sdk-js": patch
+---
+
+Fix `accessToken` expiry checks so the SDK can decode JWT payloads in browser runtimes and safely ignore malformed tokens instead of throwing from the axios error path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This file is for fast, action-oriented instructions for AI agents.
 
 - Do not hand-edit `packages/sdks/common/spec.json`
 - Prefer source inputs over editing generated output
+- Avoid workaround flags or bypasses such as `--legacy-peer-deps`, `--force`, or similar installer shortcuts unless the user explicitly asks for a temporary unblock and you explain the tradeoff.
 
 ## Monorepo structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18686,6 +18686,9 @@
         "typedoc": "^0.28.19",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.61.1"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "packages/sdks/javascript/node_modules/@eslint/config-array": {

--- a/packages/sdks/javascript/AGENTS.md
+++ b/packages/sdks/javascript/AGENTS.md
@@ -11,6 +11,7 @@ From `packages/sdks/javascript`, use these package scripts:
 - `make build-sdk-js`
 - `make test`
 - `make lint`
+- `make npm ARGS=run lint:fix`
 
 ## Generated files
 

--- a/packages/sdks/javascript/AGENTS.md
+++ b/packages/sdks/javascript/AGENTS.md
@@ -22,3 +22,4 @@ From `packages/sdks/javascript`, use these package scripts:
 
 - For non-docker local workflows, prefer package-level scripts and CI examples in CI workflows.
 - Follow the root [AGENTS.md](../../../AGENTS.md) for repository-wide git workflow and PR guidance.
+- Do not use installer or build workarounds such as `--legacy-peer-deps` or `--force` or similar shortcuts for dependency conflicts. Fix the package constraints, lockfiles, or build inputs instead.

--- a/packages/sdks/javascript/eslint.config.mjs
+++ b/packages/sdks/javascript/eslint.config.mjs
@@ -15,6 +15,7 @@ export default tseslint.config(
       "node_modules",
       "dist",
       "coverage",
+      "src/api/generated/**/*",
       "src/services/AuthService.ts",
     ]
   },

--- a/packages/sdks/javascript/eslint.config.mjs
+++ b/packages/sdks/javascript/eslint.config.mjs
@@ -15,7 +15,6 @@ export default tseslint.config(
       "node_modules",
       "dist",
       "coverage",
-      "src/api/generated/**/*",
       "src/services/AuthService.ts",
     ]
   },

--- a/packages/sdks/javascript/package.json
+++ b/packages/sdks/javascript/package.json
@@ -18,7 +18,8 @@
     "docs-export-service-index": "find src/services/ ! -name 'index.ts' -name '*.ts' -type f | sort -k3 -t'/' | xargs -I'{}' bash -c 'echo \"export * from $(echo -e \"\\x27\")./$(basename $0 .ts)$(echo -e \"\\x27\")\" >> src/services/index.ts' {} \\;",
     "docs-update-service-index": "npm run docs-remove-service-index && npm run docs-export-service-index",
     "docs": "npm run docs-update-service-index && typedoc",
-    "lint": "eslint src/common src/services src/DevopnessApiClient.ts src/index.ts",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "prepublishOnly": "npm run lint && npm test && npm run build",
     "test": "jest"
   },

--- a/packages/sdks/javascript/package.json
+++ b/packages/sdks/javascript/package.json
@@ -18,7 +18,7 @@
     "docs-export-service-index": "find src/services/ ! -name 'index.ts' -name '*.ts' -type f | sort -k3 -t'/' | xargs -I'{}' bash -c 'echo \"export * from $(echo -e \"\\x27\")./$(basename $0 .ts)$(echo -e \"\\x27\")\" >> src/services/index.ts' {} \\;",
     "docs-update-service-index": "npm run docs-remove-service-index && npm run docs-export-service-index",
     "docs": "npm run docs-update-service-index && typedoc",
-    "lint": "eslint .",
+    "lint": "eslint src/common src/services src/DevopnessApiClient.ts src/index.ts",
     "prepublishOnly": "npm run lint && npm test && npm run build",
     "test": "jest"
   },
@@ -50,6 +50,9 @@
     "url": "https://github.com/devopness/devopness/issues"
   },
   "homepage": "https://github.com/devopness/devopness#readme",
+  "engines": {
+    "node": ">=16"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@openapitools/openapi-generator-cli": "^2.39.1",

--- a/packages/sdks/javascript/src/services/ApiBaseService.ts
+++ b/packages/sdks/javascript/src/services/ApiBaseService.ts
@@ -150,10 +150,34 @@ export class ApiBaseService {
         }
 
         const decodedToken = JSON.parse(
-            Buffer.from(ApiBaseService.accessToken?.split(".")?.[1], "base64").toString()
+            ApiBaseService.decodeJwtPayload(ApiBaseService.accessToken)
         );
 
         return response?.status === 401 && decodedToken.exp < (new Date().getTime() / 1000);
+    }
+
+    /**
+     * Decode the JWT payload so we can inspect the `exp` claim without depending on Node-only APIs.
+     * The SDK runs in browser and Node environments, so this keeps the token parsing portable.
+     */
+    private static decodeJwtPayload(token: string): string {
+        const payload = token.split(".")?.[1];
+
+        if (!payload) {
+            return "{}";
+        }
+
+        const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+        const paddingLength = (4 - (base64.length % 4)) % 4;
+        const paddedBase64 = base64 + "=".repeat(paddingLength);
+        const binary = atob(paddedBase64);
+
+        return decodeURIComponent(
+            Array.from(binary, (character) => {
+                const hex = character.charCodeAt(0).toString(16);
+                return `%${hex.length === 1 ? `0${hex}` : hex}`;
+            }).join("")
+        );
     }
 
     public baseURL(): string {

--- a/packages/sdks/javascript/src/services/ApiBaseService.ts
+++ b/packages/sdks/javascript/src/services/ApiBaseService.ts
@@ -2,6 +2,11 @@ import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosRequestHeade
 import { ApiError, ArgumentNullException, NetworkError } from "../common/Exceptions";
 
 declare const window: unknown;
+declare const Buffer: {
+    from(value: string, encoding: string): {
+        toString(encoding: string): string;
+    };
+};
 
 export interface ConfigurationOptions {
     apiToken?: string;
@@ -157,27 +162,36 @@ export class ApiBaseService {
     }
 
     /**
-     * Decode the JWT payload so we can inspect the `exp` claim without depending on Node-only APIs.
-     * The SDK runs in browser and Node environments, so this keeps the token parsing portable.
+     * Decode the JWT payload so we can inspect the `exp` claim in both browser and Node runtimes.
+     * This avoids relying on a Node-only JWT helper while still tolerating malformed tokens safely.
      */
     private static decodeJwtPayload(token: string): string {
-        const payload = token.split(".")?.[1];
+        try {
+            const payload = token.split(".")?.[1];
 
-        if (!payload) {
+            if (!payload) {
+                return "{}";
+            }
+
+            const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+            const paddingLength = (4 - (base64.length % 4)) % 4;
+            const paddedBase64 = base64 + "=".repeat(paddingLength);
+
+            if (typeof globalThis.atob === "function") {
+                const binary = globalThis.atob(paddedBase64);
+
+                return decodeURIComponent(
+                    Array.from(binary, (character) => {
+                        const hex = character.charCodeAt(0).toString(16);
+                        return `%${hex.length === 1 ? `0${hex}` : hex}`;
+                    }).join("")
+                );
+            }
+
+            return Buffer.from(paddedBase64, "base64").toString("utf8");
+        } catch {
             return "{}";
         }
-
-        const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
-        const paddingLength = (4 - (base64.length % 4)) % 4;
-        const paddedBase64 = base64 + "=".repeat(paddingLength);
-        const binary = atob(paddedBase64);
-
-        return decodeURIComponent(
-            Array.from(binary, (character) => {
-                const hex = character.charCodeAt(0).toString(16);
-                return `%${hex.length === 1 ? `0${hex}` : hex}`;
-            }).join("")
-        );
     }
 
     public baseURL(): string {

--- a/packages/sdks/javascript/src/services/ApiBaseService.ts
+++ b/packages/sdks/javascript/src/services/ApiBaseService.ts
@@ -149,11 +149,17 @@ export class ApiBaseService {
             return false;
         }
 
-        const decodedToken = JSON.parse(
-            ApiBaseService.decodeJwtPayload(ApiBaseService.accessToken)
-        );
+        let decodedToken: Record<string, unknown> = {};
 
-        return response?.status === 401 && decodedToken.exp < (new Date().getTime() / 1000);
+        try {
+            decodedToken = JSON.parse(
+                ApiBaseService.decodeJwtPayload(ApiBaseService.accessToken)
+            );
+        } catch {
+            return false;
+        }
+
+        return response?.status === 401 && (decodedToken.exp as number) < (new Date().getTime() / 1000);
     }
 
     /**

--- a/packages/sdks/javascript/src/services/ApiBaseService.ts
+++ b/packages/sdks/javascript/src/services/ApiBaseService.ts
@@ -180,6 +180,8 @@ export class ApiBaseService {
                 }).join("")
             );
         } catch {
+            // Malformed or legacy token payloads should not break the axios error path.
+            // Treat undecodable tokens as empty payloads and let the 401 handling continue.
             return "{}";
         }
     }

--- a/packages/sdks/javascript/src/services/ApiBaseService.ts
+++ b/packages/sdks/javascript/src/services/ApiBaseService.ts
@@ -2,11 +2,6 @@ import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosRequestHeade
 import { ApiError, ArgumentNullException, NetworkError } from "../common/Exceptions";
 
 declare const window: unknown;
-declare const Buffer: {
-    from(value: string, encoding: string): {
-        toString(encoding: string): string;
-    };
-};
 
 export interface ConfigurationOptions {
     apiToken?: string;
@@ -176,19 +171,14 @@ export class ApiBaseService {
             const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
             const paddingLength = (4 - (base64.length % 4)) % 4;
             const paddedBase64 = base64 + "=".repeat(paddingLength);
+            const binary = atob(paddedBase64);
 
-            if (typeof globalThis.atob === "function") {
-                const binary = globalThis.atob(paddedBase64);
-
-                return decodeURIComponent(
-                    Array.from(binary, (character) => {
-                        const hex = character.charCodeAt(0).toString(16);
-                        return `%${hex.length === 1 ? `0${hex}` : hex}`;
-                    }).join("")
-                );
-            }
-
-            return Buffer.from(paddedBase64, "base64").toString("utf8");
+            return decodeURIComponent(
+                Array.from(binary, (character) => {
+                    const hex = character.charCodeAt(0).toString(16);
+                    return `%${hex.length === 1 ? `0${hex}` : hex}`;
+                }).join("")
+            );
         } catch {
             return "{}";
         }

--- a/packages/sdks/javascript/src/services/ApiBaseService.ts
+++ b/packages/sdks/javascript/src/services/ApiBaseService.ts
@@ -149,7 +149,7 @@ export class ApiBaseService {
             return false;
         }
 
-        let decodedToken: Record<string, unknown> = {};
+        let decodedToken: Record<string, unknown>;
 
         try {
             decodedToken = JSON.parse(

--- a/packages/sdks/javascript/tests/ApiBaseService.spec.ts
+++ b/packages/sdks/javascript/tests/ApiBaseService.spec.ts
@@ -1,0 +1,72 @@
+import { beforeEach, expect, test } from '@jest/globals';
+import { AxiosResponse } from 'axios';
+
+import { ApiBaseService, Configuration } from '../src/services/ApiBaseService';
+
+class TestApiBaseService extends ApiBaseService {
+    public hasExpired(response: AxiosResponse | undefined): boolean {
+        return this.isTokenExpired(response);
+    }
+}
+
+const base64UrlEncode = (value: string): string => {
+    return btoa(value)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/g, '');
+};
+
+const buildJwt = (payload: Record<string, unknown>): string => {
+    const header = base64UrlEncode(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+    const body = base64UrlEncode(JSON.stringify(payload));
+
+    return `${header}.${body}.signature`;
+};
+
+const buildResponse = (status: number): AxiosResponse => {
+    return {
+        data: null,
+        status,
+        statusText: 'OK',
+        config: {},
+        headers: {},
+    } as AxiosResponse;
+};
+
+beforeEach(() => {
+    ApiBaseService.configuration = new Configuration({});
+    ApiBaseService.accessToken = '';
+});
+
+test('isTokenExpired returns false when there is no access token', () => {
+    const service = new TestApiBaseService();
+
+    expect(service.hasExpired(buildResponse(401))).toBe(false);
+});
+
+test('isTokenExpired returns false when the response is not a 401', () => {
+    ApiBaseService.accessToken = buildJwt({ exp: Math.floor(Date.now() / 1000) - 60 });
+    const service = new TestApiBaseService();
+
+    expect(service.hasExpired(buildResponse(200))).toBe(false);
+});
+
+test('isTokenExpired returns true for an expired token', () => {
+    ApiBaseService.accessToken = buildJwt({
+        exp: Math.floor(Date.now() / 1000) - 60,
+        sub: 'jeferson-oliveira@example.com',
+    });
+    const service = new TestApiBaseService();
+
+    expect(service.hasExpired(buildResponse(401))).toBe(true);
+});
+
+test('isTokenExpired returns false for a token that is still valid', () => {
+    ApiBaseService.accessToken = buildJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        sub: 'jeferson-oliveira@example.com',
+    });
+    const service = new TestApiBaseService();
+
+    expect(service.hasExpired(buildResponse(401))).toBe(false);
+});

--- a/packages/sdks/javascript/tests/ApiBaseService.spec.ts
+++ b/packages/sdks/javascript/tests/ApiBaseService.spec.ts
@@ -70,3 +70,10 @@ test('isTokenExpired returns false for a token that is still valid', () => {
 
     expect(service.hasExpired(buildResponse(401))).toBe(false);
 });
+
+test('isTokenExpired returns false when the token payload cannot be decoded', () => {
+    ApiBaseService.accessToken = 'header.not-base64.signature';
+    const service = new TestApiBaseService();
+
+    expect(service.hasExpired(buildResponse(401))).toBe(false);
+});

--- a/packages/sdks/javascript/tests/DevopnessApiClient.spec.ts
+++ b/packages/sdks/javascript/tests/DevopnessApiClient.spec.ts
@@ -1,3 +1,4 @@
+import { expect, jest, test } from '@jest/globals';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
@@ -54,7 +55,7 @@ test("base URL is configurable on initialization", () => {
 })
 
 test("expired access_token should trigger callback function", async () => {
-  const mockRefreshTokenCallback = jest.fn(token => token);
+  const mockRefreshTokenCallback = jest.fn((token: string) => token);
 
   const apiClient = new DevopnessApiClient();
   apiClient.accessToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJhcGkuZGV2b3BuZXNzLmNvbSIsImlhdCI6MTcxMjYyMTYwMywiZXhwIjoxNzEyNTg5MjAzLCJhdWQiOiJ3d3cubXktcHJvZHVjdC5jb20iLCJzdWIiOiJzb21lb25lQGV4YW1wbGUuY29tIiwic2NvcGUiOlsic2VydmVyOnJlYWQiLCJzZXJ2ZXI6Z2V0X3N0YXR1cyIsImFwcGxpY2F0aW9uOmRlcGxveSIsImFwcGxpY2F0aW9uOmVkaXQiLCJjcm9uam9iOnJlYWQiLCJjcm9uam9iOmRlcGxveSIsInNzbC1jZXJ0aWZpY2F0ZTpkZXBsb3kiXX0.GirkUv0UI1kUORKpcWSrSKsfbM-s5Hwd1LSlDpExgbg';

--- a/packages/sdks/javascript/tsconfig.json
+++ b/packages/sdks/javascript/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "es2015",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "lib": [
       "ES2015",
       "DOM"
@@ -16,7 +16,6 @@
     "removeComments": false,
     /* Strict Type-Checking Options */
     "strict": true,
-    "isolatedModules": true,
     "noImplicitAny": true,
     "noUnusedLocals": false,
     "strictNullChecks": true,

--- a/packages/sdks/javascript/tsconfig.json
+++ b/packages/sdks/javascript/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "es2015",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": [
       "ES2015",
       "DOM"
@@ -16,6 +16,7 @@
     "removeComments": false,
     /* Strict Type-Checking Options */
     "strict": true,
+    "isolatedModules": true,
     "noImplicitAny": true,
     "noUnusedLocals": false,
     "strictNullChecks": true,


### PR DESCRIPTION
## Description of changes
- [x] Add unit coverage for `isTokenExpired` across valid, expired, missing, and malformed-token cases.
- [x] Replace the JWT payload decode path with a browser-safe implementation that fails closed on bad input.
- [x] Declare the SDK Node runtime floor explicitly so the use of `atob` is supported and documented.
- [x] Add a package-local `lint:fix` script and document the package-local lint workflow in `AGENTS.md`.
- [x] Add a patch changeset for the SDK runtime fix so the release note matches the user-facing behavior change.

## GitHub issues resolved by this PR
- N/A

## Quality Assurance
- [x] `npm test -- --runInBand tests/ApiBaseService.spec.ts tests/DevopnessApiClient.spec.ts`

## More info
- The browser-safe token decoding and malformed-token fallback are the only user-facing runtime changes here.