### PR TITLE
docs: refine README hero layout, header and cleanup unneeded references to copyright and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2023 Devopness
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1.  Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright 2023 Devopness
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Devopness
+Copyright 2023 Devopness
+
+This product includes software developed by Devopness (https://www.devopness.com).

--- a/README.md
+++ b/README.md
@@ -4,25 +4,25 @@
   </a>
 </p>
 
-<h1 align="center">Devopness</h1>
-
 <p align="center"><strong>Stop managing DevOps. Ship more, stress less.</strong></p>
 
 <p align="center"><em>DevOps Happiness for AI agents and humans.</em></p>
 
 <p align="center"><strong>One platform · Any cloud · Any stack · Free plan</strong></p>
 
-Deploy apps and **provision cloud infrastructure from scratch** on AWS, Azure, GCP, DigitalOcean, and Hetzner — in accounts you control.
+# Devopness
+
+Deploy apps and **provision cloud infrastructure from scratch** on AWS, Azure, GCP, DigitalOcean, and Hetzner: in accounts you control.
 
 One platform to replace many tools: Terraform + Ansible + Jenkins + PaaS (Vercel, Heroku, etc), and stack-specific server panels.
 
-Manage apps, Linux servers, and cloud infrastructure from anywhere — web, mobile, API, or natural language in your AI agent through MCP. No SSH or cloud console for routine work.
+Manage apps, Linux servers, and cloud infrastructure from anywhere: web, mobile, API, or natural language in your AI agent through MCP. No SSH or cloud console for routine work.
 
 <div align="center">
 
 [![npm](https://img.shields.io/npm/v/@devopness/sdk-js?label=npm)](https://www.npmjs.com/package/@devopness/sdk-js)
 [![PyPI](https://img.shields.io/pypi/v/devopness?label=pypi)](https://pypi.org/project/devopness/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/discord/1354644459031232655?label=discord&color=5865F2&logo=discord&logoColor=white)](https://discord.gg/WxKbZ3g37Q)
 [![GitHub stars](https://img.shields.io/github/stars/devopness/devopness?style=social)](https://github.com/devopness/devopness/stargazers)
 
@@ -32,7 +32,7 @@ Manage apps, Linux servers, and cloud infrastructure from anywhere — web, mobi
 
 ## For AI agents (MCP)
 
-Ask your AI agent to provision servers, deploy apps, migrate between clouds, and manage infrastructure through one MCP server — not a separate integration per cloud or stack.
+Ask your AI agent to provision servers, deploy apps, migrate between clouds, and manage infrastructure through one MCP server: not a separate integration per cloud or stack.
 
 **One-click install**
 
@@ -83,7 +83,7 @@ Instead of separate panels per stack, use one platform for all stacks. Devopness
 ## Quick start
 
 1. **[Create an account](https://app.devopness.com/)**: free, no credit card required
-2. **[Follow Getting Started](https://www.devopness.com/docs/)**: organization → project → environment → first deploy
+2. **[Follow Getting Started](https://www.devopness.com/docs/)**: organization -> project -> environment -> first deploy
 3. **[Connect MCP](https://www.devopness.com/docs/mcp/)**: optional; one-click in Cursor or VS Code above
 
 For developers, team leads, founders, and agencies shipping on cloud infrastructure they control.
@@ -118,4 +118,4 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md). If you use AI
 
 Like the project? **[Star this repo](https://github.com/devopness/devopness/stargazers)**: it helps others discover Devopness.
 
-Release notes: [GitHub Releases](https://github.com/devopness/devopness/releases). [MIT License](LICENSE) unless otherwise specified in a package `LICENSE` file.
+Release notes: [GitHub Releases](https://github.com/devopness/devopness/releases). Licensed under [Apache License 2.0](LICENSE).

--- a/examples/applications/README.md
+++ b/examples/applications/README.md
@@ -26,7 +26,3 @@ Improvements and contributions are highly encouraged! 🙏👊
 See the [contributing guide](../../CONTRIBUTING.md) for details on how to participate.
 
 All communication and contributions to Devopness projects are subject to the [Devopness Code of Conduct](../../CODE_OF_CONDUCT.md).
-
-## 📜 License
-
-All repository contents are licensed under the terms of the [MIT License](../../LICENSE) unless otherwise specified.

--- a/examples/applications/node-express/README.md
+++ b/examples/applications/node-express/README.md
@@ -61,7 +61,3 @@ Contributions are highly encouraged! 🙏👊
 See the [contributing guide](../../../CONTRIBUTING.md) for details on how to participate.
 
 All communication and contributions to Devopness projects are subject to the [Devopness Code of Conduct](../../../CODE_OF_CONDUCT.md).
-
-## 📜 License
-
-All repository contents are licensed under the terms of the [MIT License](../../../LICENSE) unless otherwise specified.

--- a/examples/applications/php-laravel/README.md
+++ b/examples/applications/php-laravel/README.md
@@ -63,7 +63,3 @@ Contributions are highly encouraged! 🙏👊
 See the [contributing guide](../../../CONTRIBUTING.md) for details on how to participate.
 
 All communication and contributions to Devopness projects are subject to the [Devopness Code of Conduct](../../../CODE_OF_CONDUCT.md).
-
-## 📜 License
-
-All repository contents are licensed under the terms of the [MIT License](../../../LICENSE) unless otherwise specified.

--- a/examples/applications/ruby-rails/README.md
+++ b/examples/applications/ruby-rails/README.md
@@ -59,7 +59,3 @@ Contributions are highly encouraged! 🙏👊
 See the [contributing guide](../../../CONTRIBUTING.md) for details on how to participate.
 
 All communication and contributions to Devopness projects are subject to the [Devopness Code of Conduct](../../../CODE_OF_CONDUCT.md).
-
-## 📜 License
-
-All repository contents are licensed under the terms of the [MIT License](../../../LICENSE) unless otherwise specified.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18732,7 +18732,7 @@
     "packages/sdks/javascript": {
       "name": "@devopness/sdk-js",
       "version": "3.5.2",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/parse-link-header": "^2.0.3",
         "axios": "^1.18.1",
@@ -18781,7 +18781,7 @@
     "packages/ui/react": {
       "name": "@devopness/ui-react",
       "version": "2.192.5",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mui/icons-material": "9.1.1",
         "@mui/material": "9.1.2",

--- a/packages/sdks/javascript/package-lock.json
+++ b/packages/sdks/javascript/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@devopness/sdk-js",
       "version": "3.5.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/parse-link-header": "^2.0.3",
         "axios": "^1.18.1",

--- a/packages/sdks/javascript/package.json
+++ b/packages/sdks/javascript/package.json
@@ -47,7 +47,7 @@
     "Server Management"
   ],
   "author": "Devopness (https://www.devopness.com)",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "release": {
     "branches": [
       "main"

--- a/packages/sdks/python/pyproject.toml
+++ b/packages/sdks/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 name = "devopness"
 version = "2.6.1"
 description = "Devopness API Python SDK - Painless essential DevOps to everyone"
-license = "MIT"
+license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "Devopness (https://www.devopness.com)" }]
@@ -33,7 +33,7 @@ classifiers = [
   "Framework :: Pydantic",
   "Intended Audience :: Developers",
   "Intended Audience :: System Administrators",
-  "License :: OSI Approved :: MIT License",
+  "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",

--- a/packages/ui/react/package.json
+++ b/packages/ui/react/package.json
@@ -55,7 +55,7 @@
     "Server Management"
   ],
   "author": "Devopness (https://www.devopness.com)",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "release": {
     "branches": [
       "main"


### PR DESCRIPTION
## Description of changes

Cleanup README and other .md files:
- [x] Remove redundant license sections from example application READMEs (root `LICENSE`/`NOTICE` remain the source of truth)
- [x] Update root `README.md` Apache badge/footer and move the title to a left-aligned `# Devopness` after the logo hero

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: README cleanup, root `LICENSE` contains Apache 2.0 text

## More info