### PR TITLE
fix: CardList grid uses fluid auto-fill instead of fixed 1/2/3-column breakpoints

### DIFF
--- a/.changeset/cardlist-fluid-grid.md
+++ b/.changeset/cardlist-fluid-grid.md
@@ -1,0 +1,5 @@
+---
+"@devopness/ui-react": patch
+---
+
+Fix `CardList`'s grid to use a fluid `auto-fill`/`minmax(250px, 1fr)` layout instead of a fixed 1/2/3-column breakpoint grid. The fixed grid capped the desktop layout at 3 columns regardless of viewport width, wasting horizontal space and wrapping cards to a new row even on very wide screens.

--- a/packages/ui/react/src/components/CardList/CardList.styled.tsx
+++ b/packages/ui/react/src/components/CardList/CardList.styled.tsx
@@ -17,17 +17,13 @@ const StyledCardListContainer = styled.section`
 
 const StyledGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(1, 1fr);
+  grid-template-columns: 1fr;
   gap: 42px 30px;
   padding-bottom: 42px;
   width: 100%;
 
-  @media (min-width: 641px) {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  @media (min-width: 1025px) {
-    grid-template-columns: repeat(3, 1fr);
+  @media (min-width: 600px) {
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   }
 `
 


### PR DESCRIPTION
## Description of changes

- [x] `CardList`'s grid (`CardList.styled.tsx`) now uses `grid-template-columns: repeat(auto-fill, minmax(250px, 1fr))` at `min-width: 600px` instead of a fixed 1/2/3-column breakpoint grid. The old grid capped desktop layouts at 3 columns regardless of viewport width, wasting horizontal space and wrapping cards to a new row even on very wide screens.

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed (published to npm), success criteria is: `CardList` shows as many columns as fit the viewport width (min 250px per card), matching the original web-app grid behavior, instead of capping at 3 columns.

## More info

https://jpsoaresxy-storybook.devopness.com/?path=/story/components-cardlist--all-resources

<img width="1918" height="967" alt="image" src="https://github.com/user-attachments/assets/92b0a9ff-56bf-401d-be56-2792db277020" />

