### PR TITLE
fix: rename ViewDetailsContent's IconProps to DetailsIconProps

### DIFF
--- a/.changeset/icon-props-naming-collision.md
+++ b/.changeset/icon-props-naming-collision.md
@@ -1,0 +1,7 @@
+---
+"@devopness/ui-react": patch
+---
+
+Fix `ViewDetailsContent`'s `IconProps` being silently shadowed by an unrelated same-named type
+
+The package exported two different types both named `IconProps` (one from `Icon`, one from `ViewDetailsContent`), and TypeScript's explicit named re-export for `Icon`'s `IconProps` always won over the wildcard re-export of `ViewDetailsContent`'s, with no compile error. `ViewDetailsContent`'s icon type is now exported as `DetailsIconProps` instead, resolving the ambiguity.

--- a/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetailsContent.tsx
+++ b/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetailsContent.tsx
@@ -15,7 +15,7 @@ import { QuestionIcon, getTextContent } from 'src/utils'
 const EMPTY_CONTENT = '—'
 
 /** Props for the icon component */
-type IconProps =
+type DetailsIconProps =
   | (Icon | Omit<string, Icon>)
   | {
       name: Omit<string, Icon>
@@ -46,7 +46,7 @@ type DetailsContentProps = {
   /** Value for the detail item */
   value: ReactNode
   /** Icon to display alongside the label */
-  icon?: IconProps
+  icon?: DetailsIconProps
   /** URL string or props object for the navigation component */
   url?: string | Partial<NavigationComponentProps>
   /** If true, the URL is a resource within the application */
@@ -69,7 +69,7 @@ type DetailsContentProps = {
         label?: string
         value?: string
       }
-  statusIcon?: IconProps
+  statusIcon?: DetailsIconProps
   /**
    * Component to use for navigation links
    */
@@ -284,4 +284,4 @@ const ViewDetailsContent = ({
   )
 }
 export { ViewDetailsContent }
-export type { IconProps, DetailsContentProps }
+export type { DetailsIconProps, DetailsContentProps }


### PR DESCRIPTION
## Description of changes

- [x] Fixed `ViewDetailsContent` exporting a type named `IconProps` that collided with a different, unrelated `IconProps` type from `Icon`
- [x] Renamed `ViewDetailsContent`'s icon type to `DetailsIconProps`, so both types are now reachable, unambiguously, under distinct names
- [x] No other internal consumer needed changes 

## GitHub issues resolved by this PR

- [x] closes #3323 

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is:  `import { IconProps } from '@devopness/ui-react'` unambiguously refers to `Icon`'s type, and consumers needing `ViewDetailsContent`'s icon shape (the `icon`/`statusIcon` fields on `DetailsContentProps`) can import `DetailsIconProps` instead, with no other observable behavior change.

## More info

No visual changes
