### PR TITLE
fix: add emptyContent prop to override ViewDetailsContent's empty-value fallback

### DIFF
--- a/.changeset/view-details-empty-content-override.md
+++ b/.changeset/view-details-empty-content-override.md
@@ -1,0 +1,7 @@
+---
+"@devopness/ui-react": minor
+---
+
+Add `emptyContent` prop to `ViewDetailsContent` to override the default empty-value fallback
+
+`ViewDetailsContent` previously hardcoded an em dash (`—`) as the fallback for an empty/undefined `value`, with no way for consumers to override it. A new optional `emptyContent` prop lets consumers pass their own fallback content (e.g. `-`, `N/A`) instead.

--- a/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetails.stories.tsx
+++ b/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetails.stories.tsx
@@ -130,5 +130,28 @@ const WithIcons: Story = {
   },
 }
 
+const EmptyContentOverride: Story = {
+  args: {
+    data: [
+      {
+        label: 'User Info',
+        items: [
+          {
+            label: 'Default fallback',
+            value: undefined,
+            navigationComponent: MockNavigationLink,
+          },
+          {
+            label: 'Custom fallback',
+            value: undefined,
+            emptyContent: 'N/A',
+            navigationComponent: MockNavigationLink,
+          },
+        ],
+      },
+    ],
+  },
+}
+
 export default meta
-export { Default, Loading, HiddenContent, WithIcons }
+export { Default, Loading, HiddenContent, WithIcons, EmptyContentOverride }

--- a/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetails.test.tsx
+++ b/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetails.test.tsx
@@ -285,4 +285,35 @@ describe('ViewDetails', () => {
     expect(screen.getByText('N/A')).toBeInTheDocument()
     expect(screen.queryByText('—')).not.toBeInTheDocument()
   })
+
+  it('renders emptyContent inside a link when the linked value is empty', () => {
+    const dataWithEmptyLinkValue: {
+      label: string
+      items: DetailsContentProps[]
+    }[] = [
+      {
+        label: 'Section',
+        items: [
+          {
+            label: 'Empty link',
+            value: undefined,
+            emptyContent: 'N/A',
+            url: 'https://example.com',
+            navigationComponent: MockNavigationLink,
+          },
+        ],
+      },
+    ]
+    render(
+      <ViewDetails
+        navigationComponent={MockNavigationLink}
+        data={dataWithEmptyLinkValue}
+      />
+    )
+
+    expect(screen.getByText('N/A').closest('a')).toHaveAttribute(
+      'href',
+      'https://example.com'
+    )
+  })
 })

--- a/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetails.test.tsx
+++ b/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetails.test.tsx
@@ -231,4 +231,58 @@ describe('ViewDetails', () => {
     expect(styles).toContain('max-width: 600px')
     expect(styles).toContain('display:none')
   })
+
+  it('renders an em dash for an empty value by default', () => {
+    const dataWithEmptyValue: {
+      label: string
+      items: DetailsContentProps[]
+    }[] = [
+      {
+        label: 'Section',
+        items: [
+          {
+            label: 'Empty field',
+            value: undefined,
+            navigationComponent: MockNavigationLink,
+          },
+        ],
+      },
+    ]
+    render(
+      <ViewDetails
+        navigationComponent={MockNavigationLink}
+        data={dataWithEmptyValue}
+      />
+    )
+
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('renders emptyContent instead of the default em dash when provided', () => {
+    const dataWithEmptyContent: {
+      label: string
+      items: DetailsContentProps[]
+    }[] = [
+      {
+        label: 'Section',
+        items: [
+          {
+            label: 'Empty field',
+            value: undefined,
+            emptyContent: 'N/A',
+            navigationComponent: MockNavigationLink,
+          },
+        ],
+      },
+    ]
+    render(
+      <ViewDetails
+        navigationComponent={MockNavigationLink}
+        data={dataWithEmptyContent}
+      />
+    )
+
+    expect(screen.getByText('N/A')).toBeInTheDocument()
+    expect(screen.queryByText('—')).not.toBeInTheDocument()
+  })
 })

--- a/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetailsContent.tsx
+++ b/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetailsContent.tsx
@@ -45,6 +45,11 @@ type DetailsContentProps = {
   label?: string
   /** Value for the detail item */
   value: ReactNode
+  /**
+   * Content to render when `value` is empty/undefined
+   * @default '—'
+   */
+  emptyContent?: ReactNode
   /** Icon to display alongside the label */
   icon?: DetailsIconProps
   /** URL string or props object for the navigation component */
@@ -91,6 +96,7 @@ type DetailsContentProps = {
 const ViewDetailsContent = ({
   label,
   value,
+  emptyContent = EMPTY_CONTENT,
   url,
   icon,
   isCopyToClipboard,
@@ -206,7 +212,7 @@ const ViewDetailsContent = ({
               )}
             >
               <Tooltip
-                title={getTextContent(formattedValue)}
+                title={getTextContent(formattedValue ?? emptyContent)}
                 enableOnlyWithEllipsisPoints
               >
                 <Text
@@ -221,7 +227,7 @@ const ViewDetailsContent = ({
                       : undefined
                   }
                 >
-                  {formattedValue ?? EMPTY_CONTENT}
+                  {formattedValue ?? emptyContent}
                 </Text>
               </Tooltip>
             </ConditionalWrapper>

--- a/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetailsContent.tsx
+++ b/packages/ui/react/src/components/Primitives/ViewDetails/ViewDetailsContent.tsx
@@ -200,7 +200,7 @@ const ViewDetailsContent = ({
               to={typeof url === 'string' ? url : undefined}
               {...(typeof url === 'object' ? url : undefined)}
             >
-              {value}
+              {formattedValue ?? emptyContent}
             </NavigationLink>
           ) : (
             <ConditionalWrapper


### PR DESCRIPTION
## Description of changes

- [x] Fixed `ViewDetailsContent` hardcoding an em dash (`—`) as the fallback for an empty/undefined `value`, with no way for consumers to override it
- [x] Added an optional `emptyContent` prop to `DetailsContentProps`, defaulting to the existing `—` fallback, so consumers can pass their own empty-value content
- [x] Fixed the tooltip title to reflect the actually-rendered content (`value` or the `emptyContent` fallback) instead of only the raw `value`, so a custom `emptyContent` isn't silently hidden when truncated
- [x] Added test coverage for the default fallback and the `emptyContent` override, and a new Storybook story

## GitHub issues resolved by this PR

- [x] closes #3324

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: consumers of `ViewDetailsContent` can pass an `emptyContent` prop to override the default `—` fallback for empty/undefined values; existing consumers that don't pass it see no behavior change; the tooltip correctly reflects whatever content is actually rendered (`value` or the `emptyContent` fallback).

## More info

https://jpsoaresxy-storybook.devopness.com/?path=/story/primitives-viewdetails--empty-content-override

### New Story
<img width="1918" height="966" alt="image" src="https://github.com/user-attachments/assets/7db372c7-dc68-4bf5-a608-06dcb4c872fb" />
