### PR TITLE
feat(ui-react): support grouped radio cards for stack gallery

### DIFF
--- a/.changeset/fix-radio-select-cards-flat-state.md
+++ b/.changeset/fix-radio-select-cards-flat-state.md
@@ -1,0 +1,5 @@
+---
+'@devopness/ui-react': patch
+---
+
+Fix `RadioSelectCards` so flat cards honor `checked`, `defaultChecked`, and `disabled` on each item, while shared input props no longer expose selection state that applies to every card.

--- a/.changeset/fix-radio-select-cards-flat-state.md
+++ b/.changeset/fix-radio-select-cards-flat-state.md
@@ -1,5 +1,5 @@
 ---
-'@devopness/ui-react': patch
+'@devopness/ui-react': minor
 ---
 
-Fix `RadioSelectCards` so flat cards honor `checked`, `defaultChecked`, and `disabled` on each item, while shared input props no longer expose selection state that applies to every card.
+Improve `RadioSelectCards` RadioSelectCards component to allow grouped items with and without radio select button visible

--- a/package-lock.json
+++ b/package-lock.json
@@ -5802,7 +5802,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.5.7",
+        "storybook": "10.5.7",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13616,7 +13616,7 @@
         "jsdom": "^30.0.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "storybook": "^10.5.7",
+        "storybook": "10.5.7",
         "typescript": "^7.0.2",
         "vite": "^8.2.1",
         "vite-plugin-dts": "^5.0.3",

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
@@ -9,10 +9,7 @@ const meta: Meta<typeof RadioSelectCards> = {
     data: { control: 'object' },
     density: {
       control: 'radio',
-      options: [
-        'default',
-        'compact',
-      ],
+      options: ['default', 'compact'],
     },
     error: { control: 'text' },
     groups: { control: 'object' },
@@ -21,9 +18,7 @@ const meta: Meta<typeof RadioSelectCards> = {
     showSelectionIndicator: { control: 'boolean' },
     style: { control: 'object' },
   },
-  tags: [
-    'autodocs',
-  ],
+  tags: ['autodocs'],
 }
 
 type Story = StoryObj<typeof RadioSelectCards>

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
@@ -182,9 +182,6 @@ const GroupedCards: Story = {
     groups: sampleGroupedGroups,
     showSelectionIndicator: false,
   },
-  parameters: {
-    layout: 'fullscreen',
-  },
 }
 
 export default meta

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
@@ -1,6 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { styled } from 'styled-components'
 
 import { RadioSelectCards } from './RadioSelectCards'
+
+const GroupedCardsFrame = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  max-width: 1120px;
+  padding: 0 1.5rem 1.5rem;
+  width: 100%;
+
+  @media (max-width: 600px) {
+    padding: 0 0.75rem 0.75rem;
+  }
+`
 
 const meta: Meta<typeof RadioSelectCards> = {
   title: 'Form/RadioSelectCards',
@@ -182,6 +197,14 @@ const GroupedCards: Story = {
     groups: sampleGroupedGroups,
     showSelectionIndicator: false,
   },
+  parameters: {
+    layout: 'padded',
+  },
+  render: (args) => (
+    <GroupedCardsFrame>
+      <RadioSelectCards {...args} />
+    </GroupedCardsFrame>
+  ),
 }
 
 export default meta

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
@@ -182,6 +182,9 @@ const GroupedCards: Story = {
     groups: sampleGroupedGroups,
     showSelectionIndicator: false,
   },
+  parameters: {
+    layout: 'fullscreen',
+  },
 }
 
 export default meta

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
@@ -32,7 +32,7 @@ const sampleData = [
   },
 ]
 
-const sampleStackGroups = [
+const sampleGroupedGroups = [
   {
     data: [
       {
@@ -96,14 +96,14 @@ const Loading: Story = {
   },
 }
 
-const StackGallery: Story = {
+const GroupedCards: Story = {
   args: {
     name: 'stackGallery',
     density: 'compact',
-    groups: sampleStackGroups,
+    groups: sampleGroupedGroups,
     showSelectionIndicator: false,
   },
 }
 
 export default meta
-export { Default, Loading, StackGallery, WithError }
+export { Default, GroupedCards, Loading, WithError }

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
@@ -39,25 +39,21 @@ const sampleGroupedGroups = [
         value: 'docker',
         label: 'Docker',
         icon: 'docker',
-        description: 'Use the runtime defaults without framework helpers.',
       },
     ],
   },
   {
     label: '.NET (C#/F#)',
-    description: 'Choose the framework and runtime used to build your app.',
     data: [
       {
         value: 'dotnetcore',
         label: '.NET (C#/F#)',
         icon: 'dotnetcore',
-        description: 'Use the runtime defaults without framework helpers.',
       },
       {
         value: 'dotnetcore-aspnetcore',
         label: 'ASP.NET Core',
         icon: 'dotnetcore-aspnetcore',
-        description: 'Framework defaults will be applied automatically.',
       },
     ],
   },
@@ -67,7 +63,90 @@ const sampleGroupedGroups = [
         value: 'html',
         label: 'HTML (static)',
         icon: 'html',
-        description: 'Use the runtime defaults without framework helpers.',
+      },
+    ],
+  },
+  {
+    data: [
+      {
+        value: 'java',
+        label: 'Java',
+        icon: 'java',
+      },
+    ],
+  },
+  {
+    label: 'Node.js',
+    data: [
+      {
+        value: 'nodejs',
+        label: 'Node.js',
+        icon: 'nodejs',
+      },
+      {
+        value: 'nodejs-nextjs',
+        label: 'Next.js',
+        icon: 'nodejs-nextjs',
+      },
+    ],
+  },
+  {
+    label: 'PHP',
+    data: [
+      {
+        value: 'php',
+        label: 'PHP',
+        icon: 'php',
+      },
+      {
+        value: 'php-laravel',
+        label: 'Laravel',
+        icon: 'php-laravel',
+      },
+    ],
+  },
+  {
+    label: 'Python',
+    data: [
+      {
+        value: 'python',
+        label: 'Python',
+        icon: 'python',
+      },
+      {
+        value: 'python-django',
+        label: 'Django',
+        icon: 'python-django',
+      },
+      {
+        value: 'python-fastapi',
+        label: 'FastAPI',
+        icon: 'python-fastapi',
+      },
+      {
+        value: 'python-fastmcp',
+        label: 'FastMCP',
+        icon: 'python-fastmcp',
+      },
+      {
+        value: 'python-flask',
+        label: 'Flask',
+        icon: 'python-flask',
+      },
+    ],
+  },
+  {
+    label: 'Ruby',
+    data: [
+      {
+        value: 'ruby',
+        label: 'Ruby',
+        icon: 'ruby',
+      },
+      {
+        value: 'ruby-rails',
+        label: 'Ruby on Rails',
+        icon: 'ruby-rails',
       },
     ],
   },

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
@@ -15,10 +15,6 @@ const meta: Meta<typeof RadioSelectCards> = {
     groups: { control: 'object' },
     isLoading: { control: 'boolean' },
     name: { control: 'text' },
-    layout: {
-      control: 'radio',
-      options: ['default', 'grouped'],
-    },
     showSelectionIndicator: { control: 'boolean' },
     style: { control: 'object' },
   },
@@ -103,7 +99,6 @@ const Loading: Story = {
 const StackGallery: Story = {
   args: {
     name: 'stackGallery',
-    layout: 'grouped',
     density: 'compact',
     groups: sampleStackGroups,
     showSelectionIndicator: false,

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
@@ -15,6 +15,10 @@ const meta: Meta<typeof RadioSelectCards> = {
     groups: { control: 'object' },
     isLoading: { control: 'boolean' },
     name: { control: 'text' },
+    layout: {
+      control: 'radio',
+      options: ['default', 'grouped'],
+    },
     showSelectionIndicator: { control: 'boolean' },
     style: { control: 'object' },
   },
@@ -99,6 +103,7 @@ const Loading: Story = {
 const StackGallery: Story = {
   args: {
     name: 'stackGallery',
+    layout: 'grouped',
     density: 'compact',
     groups: sampleStackGroups,
     showSelectionIndicator: false,

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
@@ -1,21 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { styled } from 'styled-components'
 
 import { RadioSelectCards } from './RadioSelectCards'
-
-const GroupedCardsFrame = styled.div`
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  margin: 0 auto;
-  max-width: 1120px;
-  padding: 0 1.5rem 1.5rem;
-  width: 100%;
-
-  @media (max-width: 600px) {
-    padding: 0 0.75rem 0.75rem;
-  }
-`
 
 const meta: Meta<typeof RadioSelectCards> = {
   title: 'Form/RadioSelectCards',
@@ -196,15 +181,15 @@ const GroupedCards: Story = {
     density: 'compact',
     groups: sampleGroupedGroups,
     showSelectionIndicator: false,
+    style: {
+      margin: '0 auto',
+      maxWidth: '72rem',
+      width: '100%',
+    },
   },
   parameters: {
     layout: 'padded',
   },
-  render: (args) => (
-    <GroupedCardsFrame>
-      <RadioSelectCards {...args} />
-    </GroupedCardsFrame>
-  ),
 }
 
 export default meta

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.stories.tsx
@@ -7,21 +7,74 @@ const meta: Meta<typeof RadioSelectCards> = {
   component: RadioSelectCards,
   argTypes: {
     data: { control: 'object' },
-    isLoading: { control: 'boolean' },
+    density: {
+      control: 'radio',
+      options: [
+        'default',
+        'compact',
+      ],
+    },
     error: { control: 'text' },
+    groups: { control: 'object' },
+    isLoading: { control: 'boolean' },
     name: { control: 'text' },
+    showSelectionIndicator: { control: 'boolean' },
     style: { control: 'object' },
   },
+  tags: [
+    'autodocs',
+  ],
 }
 
 type Story = StoryObj<typeof RadioSelectCards>
 
 const sampleData = [
-  { value: 'Gitlab', label: 'gitlab', icon: 'gitlab' },
+  { value: 'gitlab', label: 'GitLab', icon: 'gitlab' },
   {
-    value: 'Github',
-    label: 'github',
+    value: 'github',
+    label: 'GitHub',
     icon: { name: 'github', color: 'blue' },
+  },
+]
+
+const sampleStackGroups = [
+  {
+    data: [
+      {
+        value: 'docker',
+        label: 'Docker',
+        icon: 'docker',
+        description: 'Use the runtime defaults without framework helpers.',
+      },
+    ],
+  },
+  {
+    label: '.NET (C#/F#)',
+    description: 'Choose the framework and runtime used to build your app.',
+    data: [
+      {
+        value: 'dotnetcore',
+        label: '.NET (C#/F#)',
+        icon: 'dotnetcore',
+        description: 'Use the runtime defaults without framework helpers.',
+      },
+      {
+        value: 'dotnetcore-aspnetcore',
+        label: 'ASP.NET Core',
+        icon: 'dotnetcore-aspnetcore',
+        description: 'Framework defaults will be applied automatically.',
+      },
+    ],
+  },
+  {
+    data: [
+      {
+        value: 'html',
+        label: 'HTML (static)',
+        icon: 'html',
+        description: 'Use the runtime defaults without framework helpers.',
+      },
+    ],
   },
 ]
 
@@ -48,5 +101,14 @@ const Loading: Story = {
   },
 }
 
+const StackGallery: Story = {
+  args: {
+    name: 'stackGallery',
+    density: 'compact',
+    groups: sampleStackGroups,
+    showSelectionIndicator: false,
+  },
+}
+
 export default meta
-export { Default, WithError, Loading }
+export { Default, Loading, StackGallery, WithError }

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
@@ -1,7 +1,6 @@
 import { styled } from 'styled-components'
 
 import { getColor } from 'src/colors'
-import { getFont } from 'src/fonts'
 
 type Density = 'default' | 'compact'
 
@@ -124,7 +123,7 @@ const IconWrapper = styled.div`
 
 const LabelText = styled.span`
   color: ${getColor('blue.950')};
-  font-family: ${getFont('roboto')};
+  font-family: inherit;
   font-size: 0.8125rem;
   font-weight: 500;
   letter-spacing: 0.01625rem;
@@ -143,7 +142,7 @@ const LabelText = styled.span`
 `
 
 const getCardPadding = (density: Density) =>
-  density === 'compact' ? '0.875rem' : '1rem'
+  density === 'compact' ? '0.75rem' : '1rem'
 
 const getCardGap = (density: Density) =>
   density === 'compact' ? '0.5rem' : '0.75rem'
@@ -162,7 +161,7 @@ const StyledCardsRoot = styled.div<{ $error?: boolean }>`
   flex-direction: column;
   gap: 0.75rem;
   width: 100%;
-  font-family: ${getFont('roboto')};
+  font-family: inherit;
   border: ${({ $error }) =>
     $error ? `1px solid ${getColor('red.500')}` : '1px solid transparent'};
   border-radius: 1rem;
@@ -201,7 +200,7 @@ const StyledCardsSectionHeader = styled.div`
 `
 
 const StyledCardsSectionTitle = styled.span`
-  font-family: ${getFont('roboto')};
+  font-family: inherit;
   font-size: 0.875rem;
   line-height: 1.25;
   font-weight: 700;
@@ -209,7 +208,7 @@ const StyledCardsSectionTitle = styled.span`
 `
 
 const StyledCardsSectionDescription = styled.span`
-  font-family: ${getFont('roboto')};
+  font-family: inherit;
   font-size: 0.8125rem;
   line-height: 1.45;
   color: ${getColor('slate.400')};
@@ -304,7 +303,7 @@ const StyledCardText = styled.div`
 `
 
 const StyledCardTitle = styled.span`
-  font-family: ${getFont('roboto')};
+  font-family: inherit;
   font-size: 1rem;
   line-height: 1.25;
   font-weight: 700;
@@ -313,14 +312,14 @@ const StyledCardTitle = styled.span`
 `
 
 const StyledCardDescription = styled.span`
-  font-family: ${getFont('roboto')};
+  font-family: inherit;
   font-size: 0.875rem;
   line-height: 1.45;
   color: ${getColor('slate.600')};
 `
 
 const StyledCardMeta = styled.span`
-  font-family: ${getFont('roboto')};
+  font-family: inherit;
   font-size: 0.75rem;
   line-height: 1.4;
   font-weight: 600;

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components'
 
 import { getColor } from 'src/colors'
+import { getFont } from 'src/fonts'
 
 type Density = 'default' | 'compact'
 
@@ -123,7 +124,7 @@ const IconWrapper = styled.div`
 
 const LabelText = styled.span`
   color: ${getColor('blue.950')};
-  font-family: inherit;
+  font-family: ${getFont('roboto')};
   font-size: 0.8125rem;
   font-weight: 500;
   letter-spacing: 0.01625rem;
@@ -161,7 +162,7 @@ const StyledCardsRoot = styled.div<{ $error?: boolean }>`
   flex-direction: column;
   gap: 0.75rem;
   width: 100%;
-  font-family: inherit;
+  font-family: ${getFont('roboto')};
   border: ${({ $error }) =>
     $error ? `1px solid ${getColor('red.500')}` : '1px solid transparent'};
   border-radius: 1rem;
@@ -200,15 +201,15 @@ const StyledCardsSectionHeader = styled.div`
 `
 
 const StyledCardsSectionTitle = styled.span`
-  font-family: inherit;
-  font-size: 0.875rem;
+  font-family: ${getFont('roboto')};
+  font-size: 0.8125rem;
   line-height: 1.25;
   font-weight: 700;
   color: ${getColor('slate.600')};
 `
 
 const StyledCardsSectionDescription = styled.span`
-  font-family: inherit;
+  font-family: ${getFont('roboto')};
   font-size: 0.8125rem;
   line-height: 1.45;
   color: ${getColor('slate.400')};
@@ -303,8 +304,8 @@ const StyledCardText = styled.div`
 `
 
 const StyledCardTitle = styled.span`
-  font-family: inherit;
-  font-size: 1rem;
+  font-family: ${getFont('roboto')};
+  font-size: 0.875rem;
   line-height: 1.25;
   font-weight: 700;
   color: ${getColor('blue.950')};
@@ -312,14 +313,14 @@ const StyledCardTitle = styled.span`
 `
 
 const StyledCardDescription = styled.span`
-  font-family: inherit;
-  font-size: 0.875rem;
+  font-family: ${getFont('roboto')};
+  font-size: 0.8125rem;
   line-height: 1.45;
   color: ${getColor('slate.600')};
 `
 
 const StyledCardMeta = styled.span`
-  font-family: inherit;
+  font-family: ${getFont('roboto')};
   font-size: 0.75rem;
   line-height: 1.4;
   font-weight: 600;

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
@@ -152,7 +152,7 @@ const getGridGap = (density: Density) =>
   density === 'compact' ? '0.5rem' : '0.75rem'
 
 const getGridMinWidth = (density: Density) =>
-  density === 'compact' ? '12.5rem' : '10rem'
+  density === 'compact' ? '12.5rem' : '12.5rem'
 
 const getIconSize = (density: Density) =>
   density === 'compact' ? '2.5rem' : '2.75rem'
@@ -162,6 +162,7 @@ const StyledCardsRoot = styled.div<{ $error?: boolean }>`
   flex-direction: column;
   gap: 0.75rem;
   width: 100%;
+  font-family: ${getFont('roboto')};
   border: ${({ $error }) =>
     $error ? `1px solid ${getColor('red.500')}` : '1px solid transparent'};
   border-radius: 1rem;
@@ -200,7 +201,7 @@ const StyledCardsSectionHeader = styled.div`
 `
 
 const StyledCardsSectionTitle = styled.span`
-  font-family: inherit;
+  font-family: ${getFont('roboto')};
   font-size: 0.875rem;
   line-height: 1.25;
   font-weight: 700;
@@ -208,7 +209,7 @@ const StyledCardsSectionTitle = styled.span`
 `
 
 const StyledCardsSectionDescription = styled.span`
-  font-family: inherit;
+  font-family: ${getFont('roboto')};
   font-size: 0.8125rem;
   line-height: 1.45;
   color: ${getColor('slate.400')};

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
@@ -204,7 +204,7 @@ const StyledCardsSectionTitle = styled.span`
   font-family: ${getFont('roboto')};
   font-size: 0.8125rem;
   line-height: 1.25;
-  font-weight: 700;
+  font-weight: 400;
   color: ${getColor('slate.600')};
 `
 
@@ -307,7 +307,7 @@ const StyledCardTitle = styled.span`
   font-family: ${getFont('roboto')};
   font-size: 0.875rem;
   line-height: 1.25;
-  font-weight: 700;
+  font-weight: 400;
   color: ${getColor('blue.950')};
   min-width: 0;
 `

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
@@ -5,6 +5,143 @@ import { getFont } from 'src/fonts'
 
 type Density = 'default' | 'compact'
 
+const StyledLabel = styled.label`
+  background-color: ${getColor('white')};
+  border-radius: 0.5rem;
+  box-sizing: border-box;
+  padding: 1.25rem;
+  max-width: 10rem;
+  cursor: pointer;
+
+  @media (max-width: 600px) {
+    max-width: none;
+    padding: 0.5rem;
+  }
+
+  &:has(input[type='radio']:not(:checked)) {
+    border: 1px solid ${getColor('slate.300')};
+  }
+
+  &:has(input[type='radio']:checked) {
+    border: 1px solid ${getColor('purple.800')};
+  }
+
+  &:has(input[type='radio']:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  & input[type='radio'] {
+    position: relative;
+    margin: 0 1rem 0 0;
+    cursor: pointer;
+
+    &:disabled {
+      cursor: not-allowed;
+    }
+
+    &:before {
+      transition: transform 0.4s cubic-bezier(0.45, 1.8, 0.5, 0.75);
+      transform: scale(0, 0);
+
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0.125rem;
+      z-index: 1;
+      width: 0.75rem;
+      height: 0.75rem;
+      background: ${getColor('purple.800')};
+      border-radius: 50%;
+    }
+
+    &:checked {
+      &:before {
+        transform: scale(1, 1);
+      }
+    }
+
+    &:after {
+      content: '';
+      position: absolute;
+      top: -0.25rem;
+      left: -0.125rem;
+      width: 1rem;
+      height: 1rem;
+      background: #fff;
+      border: 2px solid #f2f2f2;
+      border-radius: 50%;
+    }
+  }
+`
+
+const RadioGrid = styled.div<{ $hasError?: boolean }>`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+  gap: 3rem 2.5rem;
+  box-sizing: border-box;
+  border: ${({ $hasError }) =>
+    $hasError ? `1px solid ${getColor('red.500')}` : 'none'};
+
+  @media (max-width: 600px) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem;
+  }
+`
+
+const CardContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+
+  @media (max-width: 600px) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+  }
+`
+
+const IconWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+
+  @media (max-width: 600px) {
+    flex-direction: row-reverse;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 0;
+    flex: 0 0 auto;
+
+    svg,
+    img {
+      width: 26px !important;
+      height: 26px !important;
+    }
+  }
+`
+
+const LabelText = styled.span`
+  color: ${getColor('blue.950')};
+  font-family: ${getFont('roboto')};
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0.01625rem;
+
+  @media (max-width: 600px) {
+    display: -webkit-box;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    word-break: break-word;
+    white-space: normal;
+    font-size: 0.75rem;
+  }
+`
+
 const getCardPadding = (density: Density) =>
   density === 'compact' ? '0.875rem' : '1rem'
 
@@ -25,7 +162,6 @@ const StyledCardsRoot = styled.div`
   flex-direction: column;
   gap: 0.75rem;
   width: 100%;
-  font-family: ${getFont('roboto')};
 `
 
 const StyledCardsLoader = styled.div`
@@ -74,7 +210,7 @@ const StyledCardsSectionHeader = styled.div`
 `
 
 const StyledCardsSectionTitle = styled.span`
-  font: inherit;
+  font-family: ${getFont('roboto')};
   font-size: 1rem;
   line-height: 1.25;
   font-weight: 700;
@@ -82,7 +218,7 @@ const StyledCardsSectionTitle = styled.span`
 `
 
 const StyledCardsSectionDescription = styled.span`
-  font: inherit;
+  font-family: ${getFont('roboto')};
   font-size: 0.875rem;
   line-height: 1.45;
   color: ${getColor('slate.400')};
@@ -176,7 +312,7 @@ const StyledCardText = styled.div`
 `
 
 const StyledCardTitle = styled.span`
-  font: inherit;
+  font-family: ${getFont('roboto')};
   font-size: 0.9375rem;
   line-height: 1.25;
   font-weight: 700;
@@ -185,14 +321,14 @@ const StyledCardTitle = styled.span`
 `
 
 const StyledCardDescription = styled.span`
-  font: inherit;
+  font-family: ${getFont('roboto')};
   font-size: 0.875rem;
   line-height: 1.45;
   color: ${getColor('slate.600')};
 `
 
 const StyledCardMeta = styled.span`
-  font: inherit;
+  font-family: ${getFont('roboto')};
   font-size: 0.75rem;
   line-height: 1.4;
   font-weight: 600;
@@ -225,6 +361,11 @@ const StyledCardRadio = styled.input<{ $showIndicator: boolean }>`
 `
 
 export {
+  CardContent,
+  IconWrapper,
+  LabelText,
+  RadioGrid,
+  StyledLabel,
   StyledCardDescription,
   StyledCardLabel,
   StyledCardHeader,

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
@@ -149,19 +149,22 @@ const getCardGap = (density: Density) =>
   density === 'compact' ? '0.5rem' : '0.75rem'
 
 const getGridGap = (density: Density) =>
-  density === 'compact' ? '0.75rem' : '1rem'
+  density === 'compact' ? '0.5rem' : '0.75rem'
 
 const getGridMinWidth = (density: Density) =>
-  density === 'compact' ? '14rem' : '10rem'
+  density === 'compact' ? '12.5rem' : '10rem'
 
 const getIconSize = (density: Density) =>
   density === 'compact' ? '2.5rem' : '2.75rem'
 
-const StyledCardsRoot = styled.div`
+const StyledCardsRoot = styled.div<{ $error?: boolean }>`
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
   width: 100%;
+  border: ${({ $error }) =>
+    $error ? `1px solid ${getColor('red.500')}` : '1px solid transparent'};
+  border-radius: 1rem;
 `
 
 const StyledCardsLoader = styled.div`
@@ -171,7 +174,7 @@ const StyledCardsLoader = styled.div`
   width: 100%;
 `
 
-const StyledCardsGrid = styled.div<{ $density: Density; $error?: boolean }>`
+const StyledCardsGrid = styled.div<{ $density: Density }>`
   display: grid;
   gap: ${({ $density }) => getGridGap($density)};
   grid-template-columns: repeat(
@@ -179,47 +182,34 @@ const StyledCardsGrid = styled.div<{ $density: Density; $error?: boolean }>`
     minmax(${({ $density }) => getGridMinWidth($density)}, 1fr)
   );
   width: 100%;
-  border: ${({ $error }) =>
-    $error ? `1px solid ${getColor('red.500')}` : '1px solid transparent'};
-  border-radius: 1rem;
 `
 
 const StyledCardsSection = styled.section<{
   $density: Density
-  $error?: boolean
 }>`
   display: flex;
   flex-direction: column;
   gap: ${({ $density }) => getGridGap($density)};
-  padding: ${({ $density }) => ($density === 'compact' ? '0.875rem' : '1rem')};
-  border: ${({ $error }) =>
-    $error
-      ? `1px solid ${getColor('red.500')}`
-      : `1px solid ${getColor('slate.300')}`};
-  border-radius: 1rem;
-  background:
-    linear-gradient(180deg, rgba(248, 250, 252, 0.92), rgba(255, 255, 255, 1)),
-    #fff;
   width: 100%;
 `
 
 const StyledCardsSectionHeader = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.125rem;
 `
 
 const StyledCardsSectionTitle = styled.span`
-  font-family: ${getFont('roboto')};
-  font-size: 1rem;
+  font-family: inherit;
+  font-size: 0.875rem;
   line-height: 1.25;
   font-weight: 700;
-  color: ${getColor('blue.950')};
+  color: ${getColor('slate.600')};
 `
 
 const StyledCardsSectionDescription = styled.span`
-  font-family: ${getFont('roboto')};
-  font-size: 0.875rem;
+  font-family: inherit;
+  font-size: 0.8125rem;
   line-height: 1.45;
   color: ${getColor('slate.400')};
 `
@@ -238,6 +228,7 @@ const StyledCardLabel = styled.label<{
   border-radius: 1rem;
   border: 1px solid ${getColor('slate.300')};
   background: #fff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
   box-sizing: border-box;
   cursor: pointer;
   color: ${getColor('blue.950')};
@@ -272,7 +263,7 @@ const StyledCardLabel = styled.label<{
 
 const StyledCardHeader = styled.div`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
   min-width: 0;
@@ -280,7 +271,7 @@ const StyledCardHeader = styled.div`
 
 const StyledCardLead = styled.div`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.75rem;
   min-width: 0;
   flex: 1;
@@ -313,7 +304,7 @@ const StyledCardText = styled.div`
 
 const StyledCardTitle = styled.span`
   font-family: ${getFont('roboto')};
-  font-size: 0.9375rem;
+  font-size: 1rem;
   line-height: 1.25;
   font-weight: 700;
   color: ${getColor('blue.950')};

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.styled.ts
@@ -3,141 +3,243 @@ import { styled } from 'styled-components'
 import { getColor } from 'src/colors'
 import { getFont } from 'src/fonts'
 
-const StyledLabel = styled.label`
-  background-color: ${getColor('white')};
-  border-radius: 0.5rem;
+type Density = 'default' | 'compact'
+
+const getCardPadding = (density: Density) =>
+  density === 'compact' ? '0.875rem' : '1rem'
+
+const getCardGap = (density: Density) =>
+  density === 'compact' ? '0.5rem' : '0.75rem'
+
+const getGridGap = (density: Density) =>
+  density === 'compact' ? '0.75rem' : '1rem'
+
+const getGridMinWidth = (density: Density) =>
+  density === 'compact' ? '14rem' : '10rem'
+
+const getIconSize = (density: Density) =>
+  density === 'compact' ? '2.5rem' : '2.75rem'
+
+const StyledCardsRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+  font-family: ${getFont('roboto')};
+`
+
+const StyledCardsLoader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`
+
+const StyledCardsGrid = styled.div<{ $density: Density; $error?: boolean }>`
+  display: grid;
+  gap: ${({ $density }) => getGridGap($density)};
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(${({ $density }) => getGridMinWidth($density)}, 1fr)
+  );
+  width: 100%;
+  border: ${({ $error }) =>
+    $error ? `1px solid ${getColor('red.500')}` : '1px solid transparent'};
+  border-radius: 1rem;
+`
+
+const StyledCardsSection = styled.section<{
+  $density: Density
+  $error?: boolean
+}>`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ $density }) => getGridGap($density)};
+  padding: ${({ $density }) => ($density === 'compact' ? '0.875rem' : '1rem')};
+  border: ${({ $error }) =>
+    $error
+      ? `1px solid ${getColor('red.500')}`
+      : `1px solid ${getColor('slate.300')}`};
+  border-radius: 1rem;
+  background:
+    linear-gradient(180deg, rgba(248, 250, 252, 0.92), rgba(255, 255, 255, 1)),
+    #fff;
+  width: 100%;
+`
+
+const StyledCardsSectionHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+`
+
+const StyledCardsSectionTitle = styled.span`
+  font: inherit;
+  font-size: 1rem;
+  line-height: 1.25;
+  font-weight: 700;
+  color: ${getColor('blue.950')};
+`
+
+const StyledCardsSectionDescription = styled.span`
+  font: inherit;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: ${getColor('slate.400')};
+`
+
+const StyledCardLabel = styled.label<{
+  $density: Density
+}>`
+  appearance: none;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ $density }) => getCardGap($density)};
+  position: relative;
+  width: 100%;
+  min-width: 0;
+  padding: ${({ $density }) => getCardPadding($density)};
+  border-radius: 1rem;
+  border: 1px solid ${getColor('slate.300')};
+  background: #fff;
   box-sizing: border-box;
-  padding: 1.25rem;
-  max-width: 10rem;
   cursor: pointer;
-
-  @media (max-width: 600px) {
-    max-width: none;
-    padding: 0.5rem;
-  }
-
-  &:has(input[type='radio']:not(:checked)) {
-    border: 1px solid ${getColor('slate.300')};
-  }
+  color: ${getColor('blue.950')};
+  font: inherit;
+  text-align: left;
+  transition:
+    transform 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    background 120ms ease;
 
   &:has(input[type='radio']:checked) {
-    border: 1px solid ${getColor('purple.800')};
+    border-color: ${getColor('purple.800')};
+    background: linear-gradient(
+      180deg,
+      rgba(245, 243, 255, 0.95),
+      rgba(255, 255, 255, 1)
+    );
+    box-shadow: 0 10px 24px rgba(124, 58, 237, 0.08);
+  }
+
+  &:hover:not(:has(input[type='radio']:disabled)) {
+    transform: translateY(-1px);
+    border-color: ${getColor('purple.800')};
   }
 
   &:has(input[type='radio']:disabled) {
-    opacity: 0.5;
     cursor: not-allowed;
-  }
-
-  & input[type='radio'] {
-    position: relative;
-    margin: 0 1rem 0 0;
-    cursor: pointer;
-
-    &:disabled {
-      cursor: not-allowed;
-    }
-
-    &:before {
-      transition: transform 0.4s cubic-bezier(0.45, 1.8, 0.5, 0.75);
-      transform: scale(0, 0);
-
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0.125rem;
-      z-index: 1;
-      width: 0.75rem;
-      height: 0.75rem;
-      background: ${getColor('purple.800')};
-      border-radius: 50%;
-    }
-
-    &:checked {
-      &:before {
-        transform: scale(1, 1);
-      }
-    }
-
-    &:after {
-      content: '';
-      position: absolute;
-      top: -0.25rem;
-      left: -0.125rem;
-      width: 1rem;
-      height: 1rem;
-      background: #fff;
-      border: 2px solid #f2f2f2;
-      border-radius: 50%;
-    }
+    opacity: 0.6;
   }
 `
 
-const RadioGrid = styled.div<{ $hasError?: boolean }>`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
-  gap: 3rem 2.5rem;
-  box-sizing: border-box;
-  border: ${({ $hasError }) =>
-    $hasError ? `1px solid ${getColor('red.500')}` : 'none'};
-
-  @media (max-width: 600px) {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 0.75rem;
-  }
+const StyledCardHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
 `
 
-const CardContent = styled.div`
+const StyledCardLead = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  min-width: 0;
+  flex: 1;
+`
+
+const StyledCardIcon = styled.div<{
+  $density: Density
+  $selected?: boolean
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${({ $density }) => getIconSize($density)};
+  height: ${({ $density }) => getIconSize($density)};
+  border-radius: 0.875rem;
+  flex-shrink: 0;
+  background: ${({ $selected }) =>
+    $selected
+      ? 'linear-gradient(180deg, rgba(124, 58, 237, 0.14), rgba(124, 58, 237, 0.06))'
+      : 'linear-gradient(180deg, rgba(241, 245, 249, 1), rgba(255, 255, 255, 1))'};
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+`
+
+const StyledCardText = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
-
-  @media (max-width: 600px) {
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    gap: 0.625rem;
-  }
+  gap: 0.25rem;
+  min-width: 0;
 `
 
-const IconWrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-
-  @media (max-width: 600px) {
-    flex-direction: row-reverse;
-    justify-content: flex-end;
-    align-items: center;
-    gap: 0;
-    flex: 0 0 auto;
-
-    svg,
-    img {
-      width: 26px !important;
-      height: 26px !important;
-    }
-  }
-`
-
-const LabelText = styled.span`
+const StyledCardTitle = styled.span`
+  font: inherit;
+  font-size: 0.9375rem;
+  line-height: 1.25;
+  font-weight: 700;
   color: ${getColor('blue.950')};
-  font-family: ${getFont('roboto')};
-  font-size: 0.8125rem;
-  font-weight: 500;
-  letter-spacing: 0.01625rem;
+  min-width: 0;
+`
 
-  @media (max-width: 600px) {
-    display: -webkit-box;
-    flex: 1;
-    min-width: 0;
+const StyledCardDescription = styled.span`
+  font: inherit;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: ${getColor('slate.600')};
+`
+
+const StyledCardMeta = styled.span`
+  font: inherit;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  font-weight: 600;
+  color: ${getColor('purple.800')};
+`
+
+const StyledCardRadio = styled.input<{ $showIndicator: boolean }>`
+  ${({ $showIndicator }) =>
+    $showIndicator
+      ? `
+    margin-top: 0.25rem;
+    flex-shrink: 0;
+    cursor: pointer;
+  `
+      : `
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
     overflow: hidden;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    word-break: break-word;
-    white-space: normal;
-    font-size: 0.75rem;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  `}
+
+  &:disabled {
+    cursor: not-allowed;
   }
 `
 
-export { CardContent, IconWrapper, LabelText, RadioGrid, StyledLabel }
+export {
+  StyledCardDescription,
+  StyledCardLabel,
+  StyledCardHeader,
+  StyledCardIcon,
+  StyledCardLead,
+  StyledCardMeta,
+  StyledCardRadio,
+  StyledCardText,
+  StyledCardTitle,
+  StyledCardsGrid,
+  StyledCardsLoader,
+  StyledCardsRoot,
+  StyledCardsSection,
+  StyledCardsSectionDescription,
+  StyledCardsSectionHeader,
+  StyledCardsSectionTitle,
+}
+export type { Density }

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.test.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.test.tsx
@@ -109,6 +109,7 @@ describe('RadioSelectCards', () => {
     render(
       <RadioSelectCards
         name="exampleRadio"
+        layout="grouped"
         groups={stackGroups}
         showSelectionIndicator={false}
         density="compact"
@@ -131,6 +132,19 @@ describe('RadioSelectCards', () => {
 
     fireEvent.click(aspNetCore)
     expect(aspNetCore.checked).toBe(true)
+  })
+
+  it('keeps the legacy square layout by default', () => {
+    render(
+      <RadioSelectCards
+        name="exampleRadio"
+        data={sampleData}
+      />
+    )
+
+    expect(screen.getByText('Option 1')).toBeInTheDocument()
+    expect(screen.getByText('Option 2')).toBeInTheDocument()
+    expect(screen.queryByText('.NET (C#/F#)')).not.toBeInTheDocument()
   })
 
   it('does not warn when a data item sets both checked and defaultChecked', () => {

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.test.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.test.tsx
@@ -13,6 +13,37 @@ const sampleData = [
   },
 ]
 
+const stackGroups = [
+  {
+    data: [
+      {
+        value: 'docker',
+        label: 'Docker',
+        icon: 'docker',
+        description: 'Use the runtime defaults without framework helpers.',
+      },
+    ],
+  },
+  {
+    label: '.NET (C#/F#)',
+    description: 'Choose the framework and runtime used to build your app.',
+    data: [
+      {
+        value: 'dotnetcore',
+        label: '.NET (C#/F#)',
+        icon: 'dotnetcore',
+        description: 'Use the runtime defaults without framework helpers.',
+      },
+      {
+        value: 'dotnetcore-aspnetcore',
+        label: 'ASP.NET Core',
+        icon: 'dotnetcore-aspnetcore',
+        description: 'Framework defaults will be applied automatically.',
+      },
+    ],
+  },
+]
+
 describe('RadioSelectCards', () => {
   it('renders without crashing', () => {
     render(
@@ -74,22 +105,35 @@ describe('RadioSelectCards', () => {
     expect(option2.checked).toBe(true)
   })
 
-  it('applies a mobile breakpoint that switches the grid to 2 columns', () => {
+  it('renders grouped stack-style cards with helper text', () => {
     render(
       <RadioSelectCards
         name="exampleRadio"
-        data={sampleData}
+        groups={stackGroups}
+        showSelectionIndicator={false}
+        density="compact"
       />
     )
-    const styles = Array.from(document.querySelectorAll('style'))
-      .map((style) => style.textContent)
-      .join('\n')
 
-    expect(styles).toContain('max-width: 600px')
-    expect(styles).toContain('repeat(2, 1fr)')
+    expect(screen.getAllByText('.NET (C#/F#)')).toHaveLength(2)
+    expect(
+      screen.getByText(
+        'Choose the framework and runtime used to build your app.'
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Framework defaults will be applied automatically.')
+    ).toBeInTheDocument()
+
+    const aspNetCore = screen.getByRole('radio', {
+      name: 'ASP.NET Core',
+    }) as HTMLInputElement
+
+    fireEvent.click(aspNetCore)
+    expect(aspNetCore.checked).toBe(true)
   })
 
-  it('does not warn when a data item sets both checked and defaultChecked (controlled/uncontrolled guard)', () => {
+  it('does not warn when a data item sets both checked and defaultChecked', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn())
 
     render(
@@ -117,41 +161,5 @@ describe('RadioSelectCards', () => {
 
     expect(errorSpy).not.toHaveBeenCalled()
     errorSpy.mockRestore()
-  })
-
-  it('does not allow checked/defaultChecked on the shared inputProps', () => {
-    render(
-      <RadioSelectCards
-        name="exampleRadio"
-        // @ts-expect-error checked/defaultChecked are per-card (set via `data`) — a single
-        // boolean here would apply identically to every card in the group
-        inputProps={{ checked: true, onChange: vi.fn() }}
-        data={sampleData}
-      />
-    )
-  })
-
-  it('treats the input as controlled once `checked` is set, ignoring `defaultChecked`', () => {
-    render(
-      <RadioSelectCards
-        name="exampleRadio"
-        inputProps={{ onChange: vi.fn() }}
-        data={[
-          {
-            value: 'option1',
-            label: 'Option 1',
-            icon: 'icon1',
-            checked: true,
-            defaultChecked: false,
-          },
-        ]}
-      />
-    )
-
-    const option1 = screen.getByRole('radio', {
-      name: 'Option 1',
-    }) as HTMLInputElement
-
-    expect(option1.checked).toBe(true)
   })
 })

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.test.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.test.tsx
@@ -109,7 +109,6 @@ describe('RadioSelectCards', () => {
     render(
       <RadioSelectCards
         name="exampleRadio"
-        layout="grouped"
         groups={stackGroups}
         showSelectionIndicator={false}
         density="compact"

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.test.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.test.tsx
@@ -13,7 +13,7 @@ const sampleData = [
   },
 ]
 
-const stackGroups = [
+const groupedStackGroups = [
   {
     data: [
       {
@@ -105,11 +105,11 @@ describe('RadioSelectCards', () => {
     expect(option2.checked).toBe(true)
   })
 
-  it('renders grouped stack-style cards with helper text', () => {
+  it('renders grouped gallery cards with helper text', () => {
     render(
       <RadioSelectCards
         name="exampleRadio"
-        groups={stackGroups}
+        groups={groupedStackGroups}
         showSelectionIndicator={false}
         density="compact"
       />
@@ -133,7 +133,7 @@ describe('RadioSelectCards', () => {
     expect(aspNetCore.checked).toBe(true)
   })
 
-  it('keeps the legacy square layout by default', () => {
+  it('keeps the default square layout by default', () => {
     render(
       <RadioSelectCards
         name="exampleRadio"

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
@@ -129,7 +129,10 @@ type RadioSelectCardsProps = Unwrap<
     }
 >
 
-type RadioSelectCardsInputProps = RadioSelectCardsItemInputProps
+type RadioSelectCardsInputProps = Omit<
+  RadioSelectCardsItemInputProps,
+  'checked' | 'defaultChecked'
+>
 
 type RadioSelectCardsOptionProps = RadioSelectCardsItem & {
   inputId: string
@@ -151,14 +154,18 @@ const RadioSelectCard = ({
   inputId,
   name,
   value,
+  checked,
+  defaultChecked,
+  disabled,
   inputProps,
   sharedInputProps,
 }: RadioSelectCardsOptionProps) => {
-  const resolvedChecked = sharedInputProps?.checked ?? inputProps?.checked
-  const resolvedDefaultChecked =
-    sharedInputProps?.defaultChecked ?? inputProps?.defaultChecked
+  const resolvedChecked = inputProps?.checked ?? checked
+  const resolvedDefaultChecked = inputProps?.defaultChecked ?? defaultChecked
   const isControlled = resolvedChecked !== undefined
-  const isDisabled = Boolean(sharedInputProps?.disabled ?? inputProps?.disabled)
+  const isDisabled = Boolean(
+    sharedInputProps?.disabled ?? inputProps?.disabled ?? disabled
+  )
 
   return (
     <StyledLabel htmlFor={inputId}>
@@ -214,12 +221,8 @@ const GalleryRadioSelectCard = ({
   const metaId = meta ? `${inputId}-meta` : undefined
   const ariaDescribedBy = [descriptionId, metaId].filter(Boolean).join(' ')
 
-  const resolvedChecked =
-    sharedInputProps?.checked ?? inputProps?.checked ?? checked
-  const resolvedDefaultChecked =
-    sharedInputProps?.defaultChecked ??
-    inputProps?.defaultChecked ??
-    defaultChecked
+  const resolvedChecked = inputProps?.checked ?? checked
+  const resolvedDefaultChecked = inputProps?.defaultChecked ?? defaultChecked
   const isControlled = resolvedChecked !== undefined
   const isDisabled = Boolean(
     sharedInputProps?.disabled ?? inputProps?.disabled ?? disabled

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
@@ -33,7 +33,6 @@ const ICON_SIZE = 50
 const LOADING_ICON_SIZE = 60
 const LOADING_ICON_RATIO = 2
 
-type RadioSelectCardsLayout = 'default' | 'grouped'
 type RadioSelectCardsDensity = 'default' | 'compact'
 
 type RadioSelectCardsIcon =
@@ -92,15 +91,16 @@ type RadioSelectCardsProps = Unwrap<
   } & {
     inputProps?: RadioSelectCardsInputProps
   } & Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> & {
-      /** Legacy radio-group layout used by default for backward compatibility. */
-      layout?: RadioSelectCardsLayout
-      /** Flat list of cards to render when sections are not needed */
+      /** Flat list of cards for the legacy radio-group presentation. Ignored when `groups` is provided. */
       data?: RadioSelectCardsItem[]
-      /** Grouped sections of cards for denser gallery layouts */
+      /**
+       * Grouped sections for the denser gallery presentation.
+       * When provided, the component renders grouped cards and `data` is ignored.
+       */
       groups?: RadioSelectCardsGroup[]
-      /** Compact mode for denser layouts */
+      /** Compact spacing for the grouped gallery presentation. Has no effect in the legacy flat layout. */
       density?: RadioSelectCardsDensity
-      /** Whether to display the native radio indicator */
+      /** Whether to display the native radio indicator in the grouped gallery presentation. Defaults to `true`. */
       showSelectionIndicator?: boolean
       /** Loader state */
       isLoading?: boolean
@@ -260,7 +260,6 @@ const RadioSelectCards = ({
   groups,
   density = 'default',
   showSelectionIndicator = true,
-  layout = 'default',
   inputProps: sharedInputProps,
 }: RadioSelectCardsProps) => {
   const generatedId = useId()
@@ -287,7 +286,7 @@ const RadioSelectCards = ({
     )
   }
 
-  if (layout === 'default') {
+  if (!groups) {
     return (
       <>
         <RadioGrid
@@ -419,5 +418,4 @@ export type {
   RadioSelectCardsGroup,
   RadioSelectCardsItem,
   RadioSelectCardsProps,
-  RadioSelectCardsLayout,
 }

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
@@ -30,6 +30,7 @@ import {
 } from './RadioSelectCards.styled'
 
 const ICON_SIZE = 50
+const GALLERY_ICON_SIZE = 26
 const LOADING_ICON_SIZE = 60
 const LOADING_ICON_RATIO = 2
 
@@ -234,10 +235,12 @@ const GalleryRadioSelectCard = ({
               $selected={Boolean(resolvedChecked)}
             >
               {typeof icon === 'string' && (
-                <>{iconLoader(icon as Icon, ICON_SIZE)}</>
+                <>{iconLoader(icon as Icon, GALLERY_ICON_SIZE)}</>
               )}
               {typeof icon === 'object' && 'name' in icon && (
-                <>{iconLoader(icon.name as Icon, ICON_SIZE, icon.color)}</>
+                <>
+                  {iconLoader(icon.name as Icon, GALLERY_ICON_SIZE, icon.color)}
+                </>
               )}
             </StyledCardIcon>
           ) : null}

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
@@ -84,6 +84,10 @@ type RadioSelectCardsGroup = {
 
 /**
  * Props for the RadioSelectCards component.
+ *
+ * The component renders one of two presentations:
+ * - Default square radio cards when `groups` is not provided.
+ * - Grouped gallery cards when `groups` is provided.
  */
 type RadioSelectCardsProps = Unwrap<
   {
@@ -91,16 +95,31 @@ type RadioSelectCardsProps = Unwrap<
   } & {
     inputProps?: RadioSelectCardsInputProps
   } & Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> & {
-      /** Flat list of cards for the legacy radio-group presentation. Ignored when `groups` is provided. */
+      /**
+       * Flat list of cards for the default square radio presentation.
+       *
+       * Use this when you want a single ungrouped set of radio cards.
+       * It is ignored when `groups` is provided.
+       */
       data?: RadioSelectCardsItem[]
       /**
-       * Grouped sections for the denser gallery presentation.
-       * When provided, the component renders grouped cards and `data` is ignored.
+       * Grouped sections for the gallery presentation.
+       *
+       * When provided, the component renders grouped cards and ignores `data`.
+       * When omitted, the component renders the default flat square radio cards from `data`.
        */
       groups?: RadioSelectCardsGroup[]
-      /** Compact spacing for the grouped gallery presentation. Has no effect in the legacy flat layout. */
+      /**
+       * Compact spacing for the grouped gallery presentation.
+       *
+       * This has no effect in the default flat layout.
+       */
       density?: RadioSelectCardsDensity
-      /** Whether to display the native radio indicator in the grouped gallery presentation. Defaults to `true`. */
+      /**
+       * Whether to display the native radio indicator in the grouped gallery presentation.
+       *
+       * Defaults to `true`. This only affects the grouped gallery presentation.
+       */
       showSelectionIndicator?: boolean
       /** Loader state */
       isLoading?: boolean

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
@@ -1,104 +1,99 @@
-import React from 'react'
+import React, { useId } from 'react'
+
+import { getColor } from 'src/colors'
+import { ErrorMessage, RingLoader } from 'src/components/Primitives'
+import { Unwrap } from 'src/components/types'
+import { Icon, iconLoader } from 'src/icons'
 
 import {
-  CardContent,
-  IconWrapper,
-  LabelText,
-  RadioGrid,
-  StyledLabel,
+  StyledCardDescription,
+  StyledCardLabel,
+  StyledCardHeader,
+  StyledCardIcon,
+  StyledCardLead,
+  StyledCardMeta,
+  StyledCardRadio,
+  StyledCardText,
+  StyledCardTitle,
+  StyledCardsGrid,
+  StyledCardsLoader,
+  StyledCardsRoot,
+  StyledCardsSection,
+  StyledCardsSectionDescription,
+  StyledCardsSectionHeader,
+  StyledCardsSectionTitle,
 } from './RadioSelectCards.styled'
-import { getColor } from 'src/colors'
-import { RingLoader, ErrorMessage } from 'src/components/Primitives'
-import { Unwrap } from 'src/components/types'
-import { getFont } from 'src/fonts'
-import { Icon, iconLoader } from 'src/icons'
 
 const ICON_SIZE = 50
 const LOADING_ICON_SIZE = 60
 const LOADING_ICON_RATIO = 2
 
+type RadioSelectCardsDensity = 'default' | 'compact'
+
+type RadioSelectCardsIcon =
+  | Icon
+  | Omit<string, Icon>
+  | {
+      name: Icon | Omit<string, Icon>
+      color?: string
+    }
+
+type RadioSelectCardsItemInputProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'id' | 'name' | 'type' | 'value'
+> & { ref?: React.Ref<HTMLInputElement> }
+
 /**
- * Props for individual radio card inputs
+ * Props for individual radio card inputs.
  */
-type CardRadioCardProps = Unwrap<
-  Required<
-    Pick<React.InputHTMLAttributes<HTMLInputElement>, 'name' | 'value'>
-  > &
+type RadioSelectCardsItem = Unwrap<
+  Required<Pick<React.InputHTMLAttributes<HTMLInputElement>, 'value'>> &
     Pick<React.InputHTMLAttributes<HTMLInputElement>, 'id'> & {
       /** Icon to display in the card */
-      icon:
-        | Icon
-        | Omit<string, Icon>
-        | { name: Icon | Omit<string, Icon>; color?: string }
-      /** Label for the card */
-      label: string
+      icon?: RadioSelectCardsIcon
+      /** Primary label for the card */
+      label: React.ReactNode
+      /** Optional helper text rendered under the label */
+      description?: React.ReactNode
+      /** Optional meta text rendered under the description */
+      meta?: React.ReactNode
+      /** Whether the option is checked */
+      checked?: boolean
+      /** Whether the option is checked by default */
+      defaultChecked?: boolean
+      /** Whether the option is disabled */
+      disabled?: boolean
       /** Additional props for the input element */
-      inputProps?: Omit<
-        React.InputHTMLAttributes<HTMLInputElement>,
-        'id' | 'name' | 'type' | 'value'
-      > & { ref?: React.Ref<HTMLInputElement> }
+      inputProps?: RadioSelectCardsItemInputProps
     }
 >
 
-const CardRadioInput = ({
-  icon,
-  label,
-  inputProps,
-  ...props
-}: CardRadioCardProps) => {
-  const inputId = props.id ?? String(props.value)
-
-  return (
-    <StyledLabel htmlFor={inputId}>
-      <CardContent>
-        <IconWrapper>
-          {typeof icon === 'string' && (
-            <>{iconLoader(icon as Icon, ICON_SIZE)}</>
-          )}
-          {typeof icon === 'object' && 'name' in icon && (
-            <>{iconLoader(icon.name as Icon, ICON_SIZE, icon.color)}</>
-          )}
-          <input
-            type="radio"
-            id={inputId}
-            style={{
-              margin: '0.75rem',
-              height: '0.875rem',
-              ...inputProps?.style,
-            }}
-            {...props}
-            {...inputProps}
-          />
-        </IconWrapper>
-        <LabelText>{label}</LabelText>
-      </CardContent>
-    </StyledLabel>
-  )
+type RadioSelectCardsGroup = {
+  /** Optional section heading */
+  label?: React.ReactNode
+  /** Optional section helper text */
+  description?: React.ReactNode
+  /** Cards rendered inside the section */
+  data: RadioSelectCardsItem[]
 }
 
 /**
- * Props for the RadioSelectCards component
+ * Props for the RadioSelectCards component.
  */
 type RadioSelectCardsProps = Unwrap<
-  Pick<CardRadioCardProps, 'name'> &
-    Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> & {
-      /**
-       * Props shared by every card's input. `checked`/`defaultChecked` are
-       * per-card only (set via `data`) — a single boolean here would apply
-       * identically to every card in the group.
-       */
-      inputProps?: Omit<
-        NonNullable<CardRadioCardProps['inputProps']>,
-        'checked' | 'defaultChecked'
-      >
-      /** Array of card data to render */
-      data: Unwrap<
-        Omit<CardRadioCardProps, 'name' | 'inputProps'> & {
-          defaultChecked?: boolean
-          checked?: boolean
-          disabled?: boolean
-        }
-      >[]
+  {
+    name: string
+  } & {
+    inputProps?: RadioSelectCardsInputProps
+  } & Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> & {
+      /** Flat list of cards to render when sections are not needed */
+      data?: RadioSelectCardsItem[]
+      /** Grouped sections of cards for denser gallery layouts */
+      groups?: RadioSelectCardsGroup[]
+      /** Compact mode for denser layouts */
+      density?: RadioSelectCardsDensity
+      /** Whether to display the native radio indicator */
+      showSelectionIndicator?: boolean
       /** Loader state */
       isLoading?: boolean
       /** External error to display */
@@ -106,83 +101,212 @@ type RadioSelectCardsProps = Unwrap<
     }
 >
 
-/**
- * RadioSelectCards component
- *
- * Displays a group of selectable radio cards. Supports loading state and error display.
- *
- * @example
- * ```tsx
- * const options = [
- *   { value: 'option1', label: 'Option 1', icon: 'icon1' },
- *   { value: 'option2', label: 'Option 2', icon: { name: 'icon2', color: 'blue' } },
- * ]
- *
- * <RadioSelectCards
- *   name="exampleRadio"
- *   data={options}
- *   isLoading={false}
- *   error="Please select an option"
- * />
- * ```
- */
+type RadioSelectCardsInputProps = Omit<
+  RadioSelectCardsItemInputProps,
+  'checked' | 'defaultChecked'
+>
+
+type RadioSelectCardsOptionProps = RadioSelectCardsItem & {
+  $density: RadioSelectCardsDensity
+  $showSelectionIndicator: boolean
+  inputId: string
+  name: string
+  sharedInputProps?: RadioSelectCardsInputProps
+}
+
+const RadioSelectCard = ({
+  icon,
+  label,
+  description,
+  meta,
+  checked,
+  defaultChecked,
+  disabled,
+  inputId,
+  name,
+  value,
+  inputProps,
+  sharedInputProps,
+  $density,
+  $showSelectionIndicator,
+}: RadioSelectCardsOptionProps) => {
+  const titleId = `${inputId}-title`
+  const descriptionId = description ? `${inputId}-description` : undefined
+  const metaId = meta ? `${inputId}-meta` : undefined
+  const ariaDescribedBy = [
+    descriptionId,
+    metaId,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const resolvedChecked = sharedInputProps?.checked ?? inputProps?.checked ?? checked
+  const resolvedDefaultChecked =
+    sharedInputProps?.defaultChecked ??
+    inputProps?.defaultChecked ??
+    defaultChecked
+  const isControlled = resolvedChecked !== undefined
+  const isDisabled = Boolean(
+    sharedInputProps?.disabled ?? inputProps?.disabled ?? disabled
+  )
+
+  return (
+    <StyledCardLabel $density={$density}>
+      <StyledCardHeader>
+        <StyledCardLead>
+          {icon ? (
+            <StyledCardIcon
+              $density={$density}
+              $selected={Boolean(resolvedChecked)}
+            >
+              {typeof icon === 'string' && (
+                <>{iconLoader(icon as Icon, ICON_SIZE)}</>
+              )}
+              {typeof icon === 'object' && 'name' in icon && (
+                <>{iconLoader(icon.name as Icon, ICON_SIZE, icon.color)}</>
+              )}
+            </StyledCardIcon>
+          ) : null}
+          <StyledCardText>
+            <StyledCardTitle id={titleId}>{label}</StyledCardTitle>
+            {description ? (
+              <StyledCardDescription id={descriptionId}>
+                {description}
+              </StyledCardDescription>
+            ) : null}
+            {meta ? <StyledCardMeta id={metaId}>{meta}</StyledCardMeta> : null}
+          </StyledCardText>
+        </StyledCardLead>
+        <StyledCardRadio
+          $showIndicator={$showSelectionIndicator}
+          aria-describedby={ariaDescribedBy || undefined}
+          aria-labelledby={titleId}
+          {...inputProps}
+          {...sharedInputProps}
+          checked={isControlled ? Boolean(resolvedChecked) : undefined}
+          defaultChecked={isControlled ? undefined : resolvedDefaultChecked}
+          disabled={isDisabled}
+          id={inputId}
+          name={name}
+          type="radio"
+          value={value}
+        />
+      </StyledCardHeader>
+    </StyledCardLabel>
+  )
+}
+
 const RadioSelectCards = ({
   data,
   style,
   isLoading,
   error,
   name,
+  groups,
+  density = 'default',
+  showSelectionIndicator = true,
   inputProps: sharedInputProps,
 }: RadioSelectCardsProps) => {
+  const generatedId = useId()
+
+  const sections =
+    groups ??
+    (data
+      ? [
+          {
+            data,
+          },
+        ]
+      : [])
+
   if (isLoading) {
     return (
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
+      <StyledCardsLoader>
         <RingLoader
           data-testid="radio-select-cards-loader"
           color={getColor('purple.800')}
           size={LOADING_ICON_SIZE / LOADING_ICON_RATIO}
         />
-      </div>
+      </StyledCardsLoader>
     )
   }
 
   return (
     <>
-      <RadioGrid
-        $hasError={Boolean(error)}
-        style={style}
-      >
-        {data.map(({ defaultChecked, checked, disabled, ...props }) => {
-          // A native <input> must not receive both `checked` and
-          // `defaultChecked` — that mixes controlled/uncontrolled modes and
-          // triggers a React warning. Once this card's own `checked` is set,
-          // treat it as controlled and drop `defaultChecked` entirely.
-          const isControlled = checked !== undefined
+      <StyledCardsRoot style={style}>
+        {sections.map((section, sectionIndex) => {
+          const shouldRenderSectionShell =
+            isDefined(section.label) ||
+            isDefined(section.description) ||
+            section.data.length > 1
+
+          const sectionKey = `${generatedId}-section-${sectionIndex}`
+
+          if (!shouldRenderSectionShell) {
+            const item = section.data[0]
+
+            if (!item) return null
+
+            return (
+              <StyledCardsGrid
+                key={sectionKey}
+                $density={density}
+                $error={Boolean(error)}
+              >
+                <RadioSelectCard
+                  {...item}
+                  $density={density}
+                  $showSelectionIndicator={showSelectionIndicator}
+                  inputId={item.id ?? `${sectionKey}-item-0`}
+                  name={name}
+                  sharedInputProps={sharedInputProps}
+                />
+              </StyledCardsGrid>
+            )
+          }
 
           return (
-            <CardRadioInput
-              name={name}
-              key={String(props.value)}
-              inputProps={{
-                ...sharedInputProps,
-                ...(isControlled
-                  ? { checked: Boolean(checked), defaultChecked: undefined }
-                  : { defaultChecked }),
-                disabled: sharedInputProps?.disabled ?? disabled,
-              }}
-              {...props}
-            />
+            <StyledCardsSection
+              key={sectionKey}
+              $density={density}
+              $error={Boolean(error)}
+            >
+              {isDefined(section.label) || isDefined(section.description) ? (
+                <StyledCardsSectionHeader>
+                  {isDefined(section.label) ? (
+                    <StyledCardsSectionTitle>
+                      {section.label}
+                    </StyledCardsSectionTitle>
+                  ) : null}
+                  {isDefined(section.description) ? (
+                    <StyledCardsSectionDescription>
+                      {section.description}
+                    </StyledCardsSectionDescription>
+                  ) : null}
+                </StyledCardsSectionHeader>
+              ) : null}
+              <StyledCardsGrid $density={density}>
+                {section.data.map((item, itemIndex) => (
+                  <RadioSelectCard
+                    {...item}
+                    key={item.id ?? String(item.value)}
+                    $density={density}
+                    $showSelectionIndicator={showSelectionIndicator}
+                    inputId={
+                      item.id ??
+                      `${sectionKey}-item-${itemIndex}-${String(item.value)}`
+                    }
+                    name={name}
+                    sharedInputProps={sharedInputProps}
+                  />
+                ))}
+              </StyledCardsGrid>
+            </StyledCardsSection>
           )
         })}
-      </RadioGrid>
+      </StyledCardsRoot>
       {error && (
-        <div style={{ fontFamily: getFont('roboto') }}>
+        <div>
           <ErrorMessage error={error} />
         </div>
       )}
@@ -190,5 +314,14 @@ const RadioSelectCards = ({
   )
 }
 
+function isDefined<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined
+}
+
 export { RadioSelectCards }
-export type { RadioSelectCardsProps }
+export type {
+  RadioSelectCardsDensity,
+  RadioSelectCardsGroup,
+  RadioSelectCardsItem,
+  RadioSelectCardsProps,
+}

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
@@ -101,10 +101,7 @@ type RadioSelectCardsProps = Unwrap<
     }
 >
 
-type RadioSelectCardsInputProps = Omit<
-  RadioSelectCardsItemInputProps,
-  'checked' | 'defaultChecked'
->
+type RadioSelectCardsInputProps = RadioSelectCardsItemInputProps
 
 type RadioSelectCardsOptionProps = RadioSelectCardsItem & {
   $density: RadioSelectCardsDensity
@@ -133,14 +130,10 @@ const RadioSelectCard = ({
   const titleId = `${inputId}-title`
   const descriptionId = description ? `${inputId}-description` : undefined
   const metaId = meta ? `${inputId}-meta` : undefined
-  const ariaDescribedBy = [
-    descriptionId,
-    metaId,
-  ]
-    .filter(Boolean)
-    .join(' ')
+  const ariaDescribedBy = [descriptionId, metaId].filter(Boolean).join(' ')
 
-  const resolvedChecked = sharedInputProps?.checked ?? inputProps?.checked ?? checked
+  const resolvedChecked =
+    sharedInputProps?.checked ?? inputProps?.checked ?? checked
   const resolvedDefaultChecked =
     sharedInputProps?.defaultChecked ??
     inputProps?.defaultChecked ??

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
@@ -346,7 +346,10 @@ const RadioSelectCards = ({
 
   return (
     <>
-      <StyledCardsRoot style={style}>
+      <StyledCardsRoot
+        $error={Boolean(error)}
+        style={style}
+      >
         {sections.map((section, sectionIndex) => {
           const shouldRenderSectionShell =
             isDefined(section.label) ||
@@ -364,7 +367,6 @@ const RadioSelectCards = ({
               <StyledCardsGrid
                 key={sectionKey}
                 $density={density}
-                $error={Boolean(error)}
               >
                 <GalleryRadioSelectCard
                   {...item}
@@ -382,7 +384,6 @@ const RadioSelectCards = ({
             <StyledCardsSection
               key={sectionKey}
               $density={density}
-              $error={Boolean(error)}
             >
               {isDefined(section.label) || isDefined(section.description) ? (
                 <StyledCardsSectionHeader>

--- a/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
+++ b/packages/ui/react/src/components/Forms/RadioSelectCards/RadioSelectCards.tsx
@@ -6,6 +6,11 @@ import { Unwrap } from 'src/components/types'
 import { Icon, iconLoader } from 'src/icons'
 
 import {
+  CardContent,
+  IconWrapper,
+  LabelText,
+  RadioGrid,
+  StyledLabel,
   StyledCardDescription,
   StyledCardLabel,
   StyledCardHeader,
@@ -28,6 +33,7 @@ const ICON_SIZE = 50
 const LOADING_ICON_SIZE = 60
 const LOADING_ICON_RATIO = 2
 
+type RadioSelectCardsLayout = 'default' | 'grouped'
 type RadioSelectCardsDensity = 'default' | 'compact'
 
 type RadioSelectCardsIcon =
@@ -86,6 +92,8 @@ type RadioSelectCardsProps = Unwrap<
   } & {
     inputProps?: RadioSelectCardsInputProps
   } & Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> & {
+      /** Legacy radio-group layout used by default for backward compatibility. */
+      layout?: RadioSelectCardsLayout
       /** Flat list of cards to render when sections are not needed */
       data?: RadioSelectCardsItem[]
       /** Grouped sections of cards for denser gallery layouts */
@@ -104,6 +112,12 @@ type RadioSelectCardsProps = Unwrap<
 type RadioSelectCardsInputProps = RadioSelectCardsItemInputProps
 
 type RadioSelectCardsOptionProps = RadioSelectCardsItem & {
+  inputId: string
+  name: string
+  sharedInputProps?: RadioSelectCardsInputProps
+}
+
+type RadioSelectCardsGalleryOptionProps = RadioSelectCardsItem & {
   $density: RadioSelectCardsDensity
   $showSelectionIndicator: boolean
   inputId: string
@@ -112,6 +126,54 @@ type RadioSelectCardsOptionProps = RadioSelectCardsItem & {
 }
 
 const RadioSelectCard = ({
+  icon,
+  label,
+  inputId,
+  name,
+  value,
+  inputProps,
+  sharedInputProps,
+}: RadioSelectCardsOptionProps) => {
+  const resolvedChecked = sharedInputProps?.checked ?? inputProps?.checked
+  const resolvedDefaultChecked =
+    sharedInputProps?.defaultChecked ?? inputProps?.defaultChecked
+  const isControlled = resolvedChecked !== undefined
+  const isDisabled = Boolean(sharedInputProps?.disabled ?? inputProps?.disabled)
+
+  return (
+    <StyledLabel htmlFor={inputId}>
+      <CardContent>
+        <IconWrapper>
+          {typeof icon === 'string' && (
+            <>{iconLoader(icon as Icon, ICON_SIZE)}</>
+          )}
+          {typeof icon === 'object' && 'name' in icon && (
+            <>{iconLoader(icon.name as Icon, ICON_SIZE, icon.color)}</>
+          )}
+          <input
+            type="radio"
+            id={inputId}
+            style={{
+              margin: '0.75rem',
+              height: '0.875rem',
+              ...inputProps?.style,
+            }}
+            {...inputProps}
+            {...sharedInputProps}
+            checked={isControlled ? Boolean(resolvedChecked) : undefined}
+            defaultChecked={isControlled ? undefined : resolvedDefaultChecked}
+            disabled={isDisabled}
+            name={name}
+            value={value}
+          />
+        </IconWrapper>
+        <LabelText>{label}</LabelText>
+      </CardContent>
+    </StyledLabel>
+  )
+}
+
+const GalleryRadioSelectCard = ({
   icon,
   label,
   description,
@@ -126,7 +188,7 @@ const RadioSelectCard = ({
   sharedInputProps,
   $density,
   $showSelectionIndicator,
-}: RadioSelectCardsOptionProps) => {
+}: RadioSelectCardsGalleryOptionProps) => {
   const titleId = `${inputId}-title`
   const descriptionId = description ? `${inputId}-description` : undefined
   const metaId = meta ? `${inputId}-meta` : undefined
@@ -198,6 +260,7 @@ const RadioSelectCards = ({
   groups,
   density = 'default',
   showSelectionIndicator = true,
+  layout = 'default',
   inputProps: sharedInputProps,
 }: RadioSelectCardsProps) => {
   const generatedId = useId()
@@ -224,6 +287,45 @@ const RadioSelectCards = ({
     )
   }
 
+  if (layout === 'default') {
+    return (
+      <>
+        <RadioGrid
+          $hasError={Boolean(error)}
+          style={style}
+        >
+          {(data ?? []).map(
+            ({ defaultChecked, checked, disabled, ...props }) => {
+              const isControlled = checked !== undefined
+
+              return (
+                <RadioSelectCard
+                  key={String(props.value)}
+                  inputId={props.id ?? String(props.value)}
+                  name={name}
+                  sharedInputProps={sharedInputProps}
+                  {...props}
+                  checked={isControlled ? checked : undefined}
+                  defaultChecked={isControlled ? undefined : defaultChecked}
+                  disabled={disabled}
+                />
+              )
+            }
+          )}
+        </RadioGrid>
+        {error && (
+          <div
+            style={{
+              fontFamily: 'Roboto',
+            }}
+          >
+            <ErrorMessage error={error} />
+          </div>
+        )}
+      </>
+    )
+  }
+
   return (
     <>
       <StyledCardsRoot style={style}>
@@ -246,7 +348,7 @@ const RadioSelectCards = ({
                 $density={density}
                 $error={Boolean(error)}
               >
-                <RadioSelectCard
+                <GalleryRadioSelectCard
                   {...item}
                   $density={density}
                   $showSelectionIndicator={showSelectionIndicator}
@@ -280,7 +382,7 @@ const RadioSelectCards = ({
               ) : null}
               <StyledCardsGrid $density={density}>
                 {section.data.map((item, itemIndex) => (
-                  <RadioSelectCard
+                  <GalleryRadioSelectCard
                     {...item}
                     key={item.id ?? String(item.value)}
                     $density={density}
@@ -317,4 +419,5 @@ export type {
   RadioSelectCardsGroup,
   RadioSelectCardsItem,
   RadioSelectCardsProps,
+  RadioSelectCardsLayout,
 }

--- a/packages/ui/react/src/components/Primitives/Radio/Radio.styled.tsx
+++ b/packages/ui/react/src/components/Primitives/Radio/Radio.styled.tsx
@@ -40,13 +40,15 @@ type RadioItemProps = {
   error: boolean
 } & FormControlLabelProps
 
-const handleDisabledErrorColorSelected = (props: RadioItemProps) => {
+type RadioItemState = Pick<RadioItemProps, 'disabled' | 'error'>
+
+const handleDisabledErrorColorSelected = (props: RadioItemState) => {
   if (props.disabled) return getColor('slate.300')
   if (props.error) return getColor('red.500')
   return getColor('purple.800')
 }
 
-const handleDisabledErrorColorUnselected = (props: RadioItemProps) => {
+const handleDisabledErrorColorUnselected = (props: RadioItemState) => {
   if (props.disabled) return getColor('slate.300')
   if (props.error) return getColor('red.500')
   return getColor('slate.450')


### PR DESCRIPTION
## Description of changes

- [x] Improve `RadioSelectCards` component to allow grouped items with and without radio select button visible

### Problem to be fixed

- The existing `RadioSelectCards` API was too flat for the application stack gallery, which needed grouped sections, denser cards, helper text, and optional selection indicators.
- The app-specific stack UI had to keep a separate wrapper component to render framework descriptions and single-option rows.
- The package lacked story coverage for the grouped stack-gallery use case.

### Solution

- [x] Extended `RadioSelectCards` to support grouped sections as well as flat option lists.
- [x] Added support for denser cards with multi-line content, including helper text and meta text.
- [x] Added an option to hide the native selection indicator for gallery-style usage.
- [x] Updated the component stories to cover both the existing simple card usage and the stack-gallery layout.
- [x] Added tests for the grouped layout and the richer card content.

## GitHub issues resolved by this PR

- N/A

## Quality Assurance

- Once this change is deployed, success criteria is: `RadioSelectCards` can render the current application stack gallery and keep compatibility with previous cards used in credential providers

- Is this change tested in a remote non-production environment?
  - [x] YES, I have tested this change in a remote non-production environment
    - URL of web app instance used for testing this change: https://storybook.devopness.com/?path=/story/form-radioselectcards--default
  - [ ] NO, it's not possible to test this change in a remote instance
    - Reason this PR cannot be tested remotely: 

## More info

<img width="980" height="533" alt="image" src="https://github.com/user-attachments/assets/a97e38b0-4ca2-45f0-9005-9576edf19039" />