### PR TITLE
fix: changeset of sdk python

### DIFF
--- a/.changeset/add-filter-support-sdk-python.md
+++ b/.changeset/add-filter-support-sdk-python.md
@@ -1,5 +1,5 @@
 ---
-"devopness": minor
+"@devopness/sdk-python": minor
 ---
 
 Added support for `filter` query parameters in list endpoints for **Actions** and **Environment Actions**.


### PR DESCRIPTION
## Problem

https://github.com/devopness/devopness/actions/runs/31738952690
```ruby
HEAD is now at dd6955b feat: 2026-08-13 16:50 - Update API specification (#3451)
/tmp/cs-version.sh
🦋  error Error: Found changeset add-filter-support-sdk-python for package devopness which is not in the workspace
🦋  error     at mapGetOrThrow (/home/runner/work/devopness/devopness/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:105:11)
🦋  error     at getRelevantChangesets (/home/runner/work/devopness/devopness/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:589:29)
🦋  error     at Object.assembleReleasePlan [as default] (/home/runner/work/devopness/devopness/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:513:30)
🦋  error     at version (/home/runner/work/devopness/devopness/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1374:60)
🦋  error     at async run (/home/runner/work/devopness/devopness/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1573:11)
```

## Description of changes
<!-- 
Short description of how this PR's makes the world a better place for Devopness users or team members:
* Example: Click on element <X> on page/route <Y> will <some new behavior> [instead of <some old behavior>]

If the PR is still in draft state, please add a **Why draft?** section clarifying what's the help or feedback you need, or mention what needs to be done before the PR is ready to be reviewed.

- Keep PRs single-purpose and minimal; avoid unrelated cleanup.
-->
- [x] Fix the python sdk package name in changeset

## GitHub issues resolved by this PR
<!-- 
Check list box of GitHub issues completed by this PR.
Use `N/A` if this PR is not fixing any existing issue.
-->

- [x] N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: Changeset will be able to release the new version of the SDKs.

<!-- Use a concrete, verifiable, success criteria. Keep it short -->

## More info
<!-- 
More info to help repository maintainers when reviewing your PR: links, images, videos, ... 
-->
