### PR TITLE
feat(js-sdk): add test case for case when too short access token is passed to DevopnessApiClient

### DIFF
--- a/packages/sdks/javascript/src/DevopnessApiClient.ts
+++ b/packages/sdks/javascript/src/DevopnessApiClient.ts
@@ -116,14 +116,14 @@ export class DevopnessApiClient {
   }
 
   public set accessToken(accessToken: string) {
-    const MIN_TOKEN_LENGHT = 100;
+    const MIN_TOKEN_LENGTH = 100;
 
     /**
      * As a complete access token validation rule might be too much to be implemented here, we
      * at least check for min length and return a substring of it to help users identify the
      * issue when first initializing this SDK from their apps
      */
-    if (accessToken && accessToken.length < MIN_TOKEN_LENGHT) {
+    if (accessToken && accessToken.length < MIN_TOKEN_LENGTH) {
       throw new Error(
         `"${accessToken.substring(0, 10)} ..." doesn't seem to be a valid access token issued by Devopness API.`,
       );

--- a/packages/sdks/javascript/tests/DevopnessApiClient.spec.ts
+++ b/packages/sdks/javascript/tests/DevopnessApiClient.spec.ts
@@ -67,3 +67,12 @@ test("expired access_token should trigger callback function", async () => {
   expect(mockRefreshTokenCallback).toHaveBeenCalled();
   expect(mockRefreshTokenCallback.mock.calls).toHaveLength(1);
 });
+
+test("too short access token should throw error", async () => {
+  const apiClient = new DevopnessApiClient();
+
+  const accessToken = "too_short_access_token";
+
+  expect(() => apiClient.accessToken = accessToken)
+    .toThrow(`"${accessToken.substring(0, 10)} ..." doesn't seem to be a valid access token issued by Devopness API.`);
+});

--- a/packages/sdks/javascript/tests/DevopnessApiClient.spec.ts
+++ b/packages/sdks/javascript/tests/DevopnessApiClient.spec.ts
@@ -73,6 +73,7 @@ test("too short access token should throw error", async () => {
 
   const accessToken = "too_short_access_token";
 
-  expect(() => apiClient.accessToken = accessToken)
-    .toThrow(`"${accessToken.substring(0, 10)} ..." doesn't seem to be a valid access token issued by Devopness API.`);
+  expect(() => (apiClient.accessToken = accessToken)).toThrow(
+    `"${accessToken.substring(0, 10)} ..." doesn't seem to be a valid access token issued by Devopness API.`,
+  );
 });

--- a/packages/sdks/javascript/tests/utils.spec.ts
+++ b/packages/sdks/javascript/tests/utils.spec.ts
@@ -10,6 +10,7 @@ test("parseQueryString keeps scalar values and omits empty ones", () => {
     boolean: true,
     falseValue: false,
     nullValue: null,
+    undefinedValue: undefined,
     emptyString: "",
     emptyArray: [],
     emptyObject: {},


### PR DESCRIPTION
## Description of changes
added test for case when too short access token is passed to `DevopnessApiClient` along with couple of small updates:
- fixed a small typo in `DevopnessApiClient` MIN_TOKEN_LENGHT -> MIN_TOKEN_LENGTH
- added test case for undefined value for `parseQueryString` function

## GitHub issues resolved by this PR
- N/A

## Quality Assurance

- Verified the test using `npm run test` locally
