### PR TITLE
fix: remove conflicting changesets token env from release workflow

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -64,10 +64,6 @@ jobs:
 
       - name: Create Release Pull Request or Publish Packages
         uses: changesets/action@v2
-        env:
-          # @changesets/changelog-github reads GITHUB_TOKEN from the environment while
-          # `npx changeset version` runs inside the custom version hook.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           github-token: ${{ secrets.DEVOPNESS_AUTOMATION_PAT }}
           pr-title: 'chore: version packages'

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 
 # Devopness
 
-TEMP
-
 Deploy apps and **provision cloud infrastructure from scratch** on AWS, Azure, GCP, DigitalOcean, and Hetzner: in accounts you control.
 
 One platform to replace many tools: Terraform + Ansible + Jenkins + PaaS (Vercel, Heroku, etc), and stack-specific server panels.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 # Devopness
 
+TEMP
+
 Deploy apps and **provision cloud infrastructure from scratch** on AWS, Azure, GCP, DigitalOcean, and Hetzner: in accounts you control.
 
 One platform to replace many tools: Terraform + Ansible + Jenkins + PaaS (Vercel, Heroku, etc), and stack-specific server panels.


### PR DESCRIPTION
## Description of changes
Fix CI error in https://github.com/devopness/devopness/actions/runs/31847474071/job/94916735382 

- [x] Remove the conflicting `GITHUB_TOKEN` env from `changesets/action@v2` in `.github/workflows/release-packages.yml`.
- [x] Keep the release job using `DEVOPNESS_AUTOMATION_PAT` via the `github-token` input so publishing and release PR creation continue to work.

## GitHub issues resolved by this PR
- N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: the release workflow runs without the `GITHUB_TOKEN` / `github-token` mismatch error and can create release PRs or publish packages.
