### PR TITLE
fix(sdk-python): raise clear SDK errors instead of AttributeError and UnboundLocalError

### DIFF
--- a/.changeset/sdk-python-clear-initialization-and-payload-errors.md
+++ b/.changeset/sdk-python-clear-initialization-and-payload-errors.md
@@ -1,0 +1,5 @@
+---
+"@devopness/sdk-python": patch
+---
+
+Report Devopness SDK errors instead of `AttributeError` and `UnboundLocalError` when the SDK is used before a client is created, or when a request body has an unsupported type.

--- a/packages/sdks/python/src/devopness/base/base_service.py
+++ b/packages/sdks/python/src/devopness/base/base_service.py
@@ -43,7 +43,7 @@ class DevopnessBaseService:
         """
         Initializes the API base service with the provided configuration.
         """
-        if DevopnessBaseService._config is None:
+        if getattr(DevopnessBaseService, "_config", None) is None:
             raise DevopnessSdkError("DevopnessBaseService is not initialized")
 
         self._client = httpx.Client(
@@ -217,7 +217,7 @@ class DevopnessBaseServiceAsync:
         """
         Initializes the API base service with the provided configuration.
         """
-        if DevopnessBaseServiceAsync._config is None:
+        if getattr(DevopnessBaseServiceAsync, "_config", None) is None:
             raise DevopnessSdkError("DevopnessBaseServiceAsync is not initialized")
 
         self._client = httpx.AsyncClient(
@@ -435,15 +435,22 @@ def parse_payload(
                                                                 payload.
 
     Returns:
-        str: The payload as a string.
+        Optional[dict[str, Any]]: The payload for the request.
+
+    Raises:
+        DevopnessSdkError: If the payload type is not supported.
     """
     if data is None:
         return None
 
     if isinstance(data, DevopnessBaseModel):
-        payload = data.model_dump(exclude_unset=True)
+        return data.model_dump(exclude_unset=True)
 
     if isinstance(data, dict):
-        payload = data
+        return data
 
-    return payload
+    raise DevopnessSdkError(
+        "\nDevopness SDK Error: Invalid request body."
+        "\nExpected a dict or a DevopnessBaseModel subclass, but received: "
+        f"'{type(data).__name__}'."
+    )

--- a/packages/sdks/python/tests/unit/base/test_service.py
+++ b/packages/sdks/python/tests/unit/base/test_service.py
@@ -16,6 +16,8 @@ from devopness.base import (
     DevopnessBaseService,
     DevopnessBaseServiceAsync,
 )
+from devopness.base.base_service import parse_payload
+from devopness.core import DevopnessSdkError
 
 
 class DummyModel(DevopnessBaseModel):
@@ -518,3 +520,61 @@ class TestDevopnessBaseServiceAsync(unittest.IsolatedAsyncioTestCase):
             r"\(python/\d+\.\d+\.\d+ [A-Za-z0-9_\-]+\)"
         )
         self.assertRegex(user_agent, pattern)
+
+
+class TestDevopnessBaseServiceNotInitialized(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sync_config = getattr(DevopnessBaseService, "_config", None)
+        self.async_config = getattr(DevopnessBaseServiceAsync, "_config", None)
+
+        for service_cls in (DevopnessBaseService, DevopnessBaseServiceAsync):
+            if hasattr(service_cls, "_config"):
+                del service_cls._config
+
+    def tearDown(self) -> None:
+        if self.sync_config is not None:
+            DevopnessBaseService._config = self.sync_config
+
+        if self.async_config is not None:
+            DevopnessBaseServiceAsync._config = self.async_config
+
+    def test_service_without_config_raises_sdk_error(self) -> None:
+        with self.assertRaises(DevopnessSdkError) as ctx:
+            DevopnessBaseService()
+
+        self.assertIn("DevopnessBaseService is not initialized", str(ctx.exception))
+
+    def test_async_service_without_config_raises_sdk_error(self) -> None:
+        with self.assertRaises(DevopnessSdkError) as ctx:
+            DevopnessBaseServiceAsync()
+
+        self.assertIn(
+            "DevopnessBaseServiceAsync is not initialized",
+            str(ctx.exception),
+        )
+
+
+class TestParsePayload(unittest.TestCase):
+    def test_parse_payload_returns_none_for_empty_payload(self) -> None:
+        self.assertIsNone(parse_payload(None))
+
+    def test_parse_payload_keeps_dict_payload_unchanged(self) -> None:
+        payload = {"name": "dummy"}
+
+        self.assertEqual(parse_payload(payload), payload)
+
+    def test_parse_payload_omits_model_fields_that_were_not_set(self) -> None:
+        payload = DummyModel(name="dummy")
+
+        self.assertEqual(parse_payload(payload), {"name": "dummy"})
+
+    def test_parse_payload_raises_sdk_error_for_unsupported_payload(self) -> None:
+        for payload in ([1, 2, 3], "dummy", 42):
+            with self.assertRaises(DevopnessSdkError):
+                parse_payload(payload)  # type: ignore[arg-type]
+
+    def test_parse_payload_error_names_the_received_type(self) -> None:
+        with self.assertRaises(DevopnessSdkError) as ctx:
+            parse_payload([1, 2, 3])  # type: ignore[arg-type]
+
+        self.assertIn("'list'", str(ctx.exception))


### PR DESCRIPTION
## Description of changes

- [x] Fixed `DevopnessBaseService` and `DevopnessBaseServiceAsync` raising `AttributeError: type object 'DevopnessBaseService' has no attribute '_config'` instead of the intended `DevopnessSdkError`, since `_config` is a bare class annotation and does not exist until a client assigns it
- [x] Fixed `parse_payload` raising `UnboundLocalError` for unsupported payload types, now raising `DevopnessSdkError` naming the received type
- [x] Fixed `parse_payload` docstring, which documented a `str` return value instead of a dict
- [x] Added test coverage for both cases

## GitHub issues resolved by this PR

- [x] closes #3503

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is: using a service before a client is created, or passing an unsupported request body, raises `DevopnessSdkError` naming the problem instead of `AttributeError` / `UnboundLocalError`

## More info

Kept `_config` annotated as `DevopnessClientConfig` and used `getattr(..., "_config", None)`. Declaring it as `DevopnessClientConfig | None = None` reads better, but there are 22 `_config.` accesses in the package that would then fail `mypy`. Glad to go that way instead if you prefer.

Ran from `packages/sdks/python`: `ruff check`, `ruff format --check` and `mypy src tests` pass. Unit tests go from 62 to 69 passing, and the 4 new tests covering these two bugs fail on `main`.
