### PR TITLE
feat(ui): update autocompleteProps type

### DIFF
--- a/.changeset/update-autocomplete-props.md
+++ b/.changeset/update-autocomplete-props.md
@@ -1,0 +1,5 @@
+---
+"@devopness/ui-react": patch
+---
+
+Update the type of `AutocompleteProps` for Autocomplete component for support of autoCompleteProps like getOptionLabel and renderOption

--- a/packages/ui/react/src/components/Forms/Autocomplete/Autocomplete.tsx
+++ b/packages/ui/react/src/components/Forms/Autocomplete/Autocomplete.tsx
@@ -13,8 +13,17 @@ type AutocompleteProps = {
   inputProps: Omit<ComponentPropsWithoutRef<typeof Input>, 'type'>
   /** Props passed directly to MUI Autocomplete component */
   autocompleteProps: Pick<
-    ComponentPropsWithoutRef<typeof MuiAutocomplete>,
-    'options' | 'onInputChange' | 'onChange' | 'onBlur' | 'value' | 'open'
+    ComponentPropsWithoutRef<
+      typeof MuiAutocomplete<unknown, undefined, undefined, true>
+    >,
+    | 'options'
+    | 'onInputChange'
+    | 'onChange'
+    | 'onBlur'
+    | 'value'
+    | 'open'
+    | 'getOptionLabel'
+    | 'renderOption'
   >
 }
 


### PR DESCRIPTION
## Description of changes

- Updated the type of `Autocomplete` component in `packages/ui/react/src/components/Forms/Autocomplete/Autocomplete.tsx` to match with usage in web app.

## GitHub issues resolved by this PR

- [x] N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: no new issue added

## More info
No visual or functional changes, only types