### PR TITLE
fix(ui-react): remove redundant segments from Storybook story titles

### DIFF
--- a/packages/ui/react/src/components/CardList/CardContent/CardContent.stories.tsx
+++ b/packages/ui/react/src/components/CardList/CardContent/CardContent.stories.tsx
@@ -36,7 +36,7 @@ const MockRouterLink = styled.a`
 `
 
 const meta = {
-  title: 'Components/CardList/CardContent/CardContent',
+  title: 'Components/CardList/CardContent',
   component: CardContent,
   args: {
     basePath: '/applications',

--- a/packages/ui/react/src/components/Primitives/CardGrid/CardGrid.stories.tsx
+++ b/packages/ui/react/src/components/Primitives/CardGrid/CardGrid.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/react-vite'
 import { CardGrid } from './CardGrid'
 
 const meta: Meta<typeof CardGrid> = {
-  title: 'Primitives/CardGrid/CardGrid',
+  title: 'Primitives/CardGrid',
   component: CardGrid,
   args: {
     gap: '1.5rem',

--- a/packages/ui/react/src/components/Primitives/CardLoading/CardLoading.stories.tsx
+++ b/packages/ui/react/src/components/Primitives/CardLoading/CardLoading.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { CardLoading } from '.'
 
 const meta = {
-  title: 'Primitives/CardLoading/CardLoading',
+  title: 'Primitives/CardLoading',
   component: CardLoading,
 } satisfies Meta<typeof CardLoading>
 

--- a/packages/ui/react/src/components/Primitives/Label/Label.stories.tsx
+++ b/packages/ui/react/src/components/Primitives/Label/Label.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Label } from './Label'
 
 const meta = {
-  title: 'Form/Label',
+  title: 'Primitives/Label',
   component: Label,
 } satisfies Meta<typeof Label>
 

--- a/packages/ui/react/src/components/Primitives/ResourceCard/ResourceCard.stories.tsx
+++ b/packages/ui/react/src/components/Primitives/ResourceCard/ResourceCard.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/react-vite'
 import { ResourceCard } from './ResourceCard'
 
 const meta: Meta<typeof ResourceCard> = {
-  title: 'Primitives/ResourceCard/ResourceCard',
+  title: 'Primitives/ResourceCard',
   component: ResourceCard,
   args: {
     name: 'production-api',

--- a/packages/ui/react/src/components/README.md
+++ b/packages/ui/react/src/components/README.md
@@ -92,10 +92,12 @@ Use the Storybook title to communicate the abstraction level of the component:
 
 Prefer nested titles that group related items by feature or family. For example:
 
-- `Primitives/ResourceCard/ResourceCard`
 - `Components/ResourceDataCard/ResourceDataCard`
 - `Components/ResourceDataCard/ResourceDataCardList`
-- `Templates/Card/Card`
+- `Components/CardList/CardList`
+- `Components/CardList/CardContent`
+
+When a folder holds a single component, don't repeat its name in the title: use `Primitives/ResourceCard`, not `Primitives/ResourceCard/ResourceCard`. Storybook derives the title from the file path when a story doesn't set one, and it already drops the repeated segment.
 
 Keep the category aligned with the component's role, not its visual appearance alone. A card that is mostly an atomic display surface belongs in `Primitives`; a card that includes list state, empty state, add/link actions, pagination, or resource-specific composition belongs in `Components`.
 

--- a/packages/ui/react/src/components/ResourceCardGrid/ResourceCardGrid.stories.tsx
+++ b/packages/ui/react/src/components/ResourceCardGrid/ResourceCardGrid.stories.tsx
@@ -23,7 +23,7 @@ const mockResources = [
 ]
 
 const meta = {
-  title: 'Components/ResourceCardGrid/ResourceCardGrid',
+  title: 'Components/ResourceCardGrid',
   component: ResourceCardGrid,
   args: {
     resourceType: 'application',

--- a/packages/ui/react/src/components/Templates/Card/Card.stories.tsx
+++ b/packages/ui/react/src/components/Templates/Card/Card.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Card } from './Card'
 
 const meta = {
-  title: 'Templates/Card/Card',
+  title: 'Templates/Card',
   component: Card,
   argTypes: {
     indicator: { control: 'number' },


### PR DESCRIPTION
## Description of changes

- [x] Removed the repeated component name from the title of 6 story files, so the sidebar shows `Primitives/CardGrid` instead of `Primitives/CardGrid/CardGrid`
- [x] Moved `Label` from `Form` to `Primitives`, matching the folder its source is in

Left `Components/CardList/CardList` and `Components/ResourceDataCard/ResourceDataCard` alone, those folders have more than one component so the second segment is a real group there.

## GitHub issues resolved by this PR

- [x] closes #3512

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is: the seven components show up once in the sidebar path and no story goes missing

## More info

Built the Storybook on `main` and on this branch and compared both `index.json`: same 257 entries, same 57 components, only the 7 titles differ. No duplicate titles and no title that is a prefix of another.

No changeset here, `vite.config.ts` excludes `src/**/*.stories.*` from the build so the published package is not affected.

One heads up: story ids come from the title, so 7 Storybook URLs change (`primitives-cardgrid-cardgrid--docs` becomes `primitives-cardgrid--docs`). The other 220 ids are untouched. If you would rather keep the old links working, setting an explicit `id` on the meta keeps the URL while showing the new title, happy to push that if you prefer.
