### PR TITLE
fix: resolve hasDescription prop warning on select component

### DIFF
--- a/.changeset/update-prop-name-to-resolve-console-warning.md
+++ b/.changeset/update-prop-name-to-resolve-console-warning.md
@@ -1,0 +1,5 @@
+---
+"@devopness/ui-react": patch
+---
+
+Update internal prop name of `Select` component's internal components to resolve console warnings

--- a/packages/ui/react/src/components/Forms/Select/CustomComponents/Option.tsx
+++ b/packages/ui/react/src/components/Forms/Select/CustomComponents/Option.tsx
@@ -45,7 +45,7 @@ const OptionBody = ({ optionConfiguration }: OptionBodyProps) => {
         {iconName &&
           typeof iconName === 'string' &&
           iconLoader(iconName as Icon, iconSize ?? 11, '', 0.5, '')}
-        <OptionLabel hasDescription={!!hasDescription}>{option}</OptionLabel>
+        <OptionLabel $hasDescription={!!hasDescription}>{option}</OptionLabel>
       </OptionRow>
 
       {/* Second row: description with icon (if provided) */}
@@ -91,7 +91,7 @@ const Option = ({
     >
       <OptionWrapper
         isCreateLink={data.isCreateLink}
-        hasDescription={!!hasDescription}
+        $hasDescription={!!hasDescription}
       >
         <OptionBody optionConfiguration={optionConfiguration} />
       </OptionWrapper>

--- a/packages/ui/react/src/components/Forms/Select/CustomComponents/SingleValue.tsx
+++ b/packages/ui/react/src/components/Forms/Select/CustomComponents/SingleValue.tsx
@@ -20,7 +20,7 @@ const SingleValue = ({
     data.labelDescription && data.labelDescription.trim() !== ''
 
   return (
-    <OptionSelectedWrapper hasDescription={!!hasDescription}>
+    <OptionSelectedWrapper $hasDescription={!!hasDescription}>
       <OptionBody optionConfiguration={optionConfiguration} />
     </OptionSelectedWrapper>
   )

--- a/packages/ui/react/src/components/Forms/Select/CustomComponents/styled.ts
+++ b/packages/ui/react/src/components/Forms/Select/CustomComponents/styled.ts
@@ -5,7 +5,7 @@ import { getColor } from 'src/colors'
 type OptionProps = {
   isOptionSelected?: boolean
   isCreateLink?: boolean
-  hasDescription?: boolean
+  $hasDescription?: boolean
 }
 
 const ellipsisStyle = css`
@@ -33,9 +33,9 @@ const NoOption = styled.div`
 `
 
 const OptionSelectedWrapper = styled.div<OptionProps>`
-  display: ${({ hasDescription }) => (hasDescription ? 'grid' : 'grid')};
-  ${({ hasDescription }) =>
-    hasDescription
+  display: ${({ $hasDescription }) => ($hasDescription ? 'grid' : 'grid')};
+  ${({ $hasDescription }) =>
+    $hasDescription
       ? css`
           grid-template-rows: auto auto;
           gap: 2px;
@@ -53,9 +53,9 @@ const OptionSelectedWrapper = styled.div<OptionProps>`
 `
 
 const OptionWrapper = styled.div<OptionProps>`
-  display: ${({ hasDescription }) => (hasDescription ? 'grid' : 'flex')};
-  ${({ hasDescription }) =>
-    hasDescription
+  display: ${({ $hasDescription }) => ($hasDescription ? 'grid' : 'flex')};
+  ${({ $hasDescription }) =>
+    $hasDescription
       ? css`
           grid-template-rows: auto auto;
           gap: 2px;
@@ -93,10 +93,10 @@ const OptionRow = styled.div`
   min-width: 0;
 `
 
-const OptionLabel = styled.span<{ hasDescription?: boolean }>`
+const OptionLabel = styled.span<{ $hasDescription?: boolean }>`
   padding-left: 6px;
   ${ellipsisStyle}
-  font-weight: ${({ hasDescription }) => (hasDescription ? 600 : 400)};
+  font-weight: ${({ $hasDescription }) => ($hasDescription ? 600 : 400)};
 `
 
 const OptionDescription = styled.span`


### PR DESCRIPTION
## Description of changes

Update the `hasDescription` prop passed to styled component in some components of `packages/ui/react/src/components/Forms/Select/CustomComponents` folder to `$hasDescription` to resolve the console warning.

- [x] update prop name `hasDescription` to `$hasDescription`


## GitHub issues resolved by this PR

- [x] N/A

## Quality Assurance

<!-- Please complete this checklist before requesting a review of your pull request. -->

- Once the changes in this PR are merged and deployed, success criteria is:  no visual or functional regression for `Select` component, validated locally.


## More info

<img width="655" height="455" alt="Screenshot 2026-09-04 at 16 29 56" src="https://github.com/user-attachments/assets/a2baac79-d0be-4b93-b3ca-4f5c45ba4b1e" />
