### PR TITLE
fix(sync-api-spec): auto-setup upstream branch

### DIFF
--- a/.github/workflows/sync-api-spec.yml
+++ b/.github/workflows/sync-api-spec.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           git config --global user.email "${{ vars.DEVOPNESS_AUTOMATIONS_EMAIL }}"
           git config --global user.name "${{ vars.DEVOPNESS_AUTOMATIONS_USERNAME }}"
+          git config --global push.autoSetupRemote true
           git remote set-url origin https://x-access-token:${{ secrets.DEVOPNESS_AUTOMATION_PAT }}@github.com/${{ github.repository }}
 
       - name: Setup Node Runtime


### PR DESCRIPTION
## Description of changes
- [x] Configure the API spec sync workflow to auto-create the upstream branch before `git-auto-commit-action` pushes.

## GitHub issues resolved by this PR
- [x] N/A

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: a fresh `feat/update-auto-generated-models` branch can push generated spec changes without failing on a missing upstream branch.

## More info
- Failed workflow run: https://github.com/devopness/devopness/actions/runs/33905493726