### PR TITLE
fix: adjust the font size of select component description

### DIFF
--- a/.changeset/adjust-font-size-of-description-on-select.md
+++ b/.changeset/adjust-font-size-of-description-on-select.md
@@ -1,0 +1,5 @@
+---
+"@devopness/ui-react": patch
+---
+
+Adjust font size of description text in `Select` component to 13px from 12px.

--- a/packages/ui/react/src/components/Forms/Select/CustomComponents/styled.ts
+++ b/packages/ui/react/src/components/Forms/Select/CustomComponents/styled.ts
@@ -33,7 +33,7 @@ const NoOption = styled.div`
 `
 
 const OptionSelectedWrapper = styled.div<OptionProps>`
-  display: ${({ $hasDescription }) => ($hasDescription ? 'grid' : 'grid')};
+  display: grid;
   ${({ $hasDescription }) =>
     $hasDescription
       ? css`
@@ -101,7 +101,6 @@ const OptionLabel = styled.span<{ $hasDescription?: boolean }>`
 
 const OptionDescription = styled.span`
   padding-left: 6px;
-  font-size: 12px;
   ${ellipsisStyle}
 `
 


### PR DESCRIPTION
## Description of changes

Adjust the font size of description text in `Select` component
- [x] Updated font size from 12px to default 13px as Label text font size. Both Being inherited from [parent element](https://github.com/therealrinku/devopness/blob/6b0a4273a84e2b2d5cafe5a4fde4d3caa58f464e/packages/ui/react/src/components/Forms/Select/CustomComponents/styled.ts#L49) 

ℹ️ I checked other sizes like 14px as well, while it does look better than 13px. I'm sticking to 13px for now to keep same size as other element for eg `Button` component's text font size. I think we can rethink the size for these components as well later on (perhaps 14px) and update them altogether so everything remains consistent together.

## GitHub issues resolved by this PR

- [x] N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is:  No visual or functional regressions, only increase in font size of description text

## More info
Before:

<img width="492" height="278" alt="Screenshot 2026-09-07 at 13 51 00" src="https://github.com/user-attachments/assets/6547c2e9-27c3-4dc6-94e3-ab7974290e09" />


After:

<img width="492" height="278" alt="Screenshot 2026-09-07 at 13 52 15" src="https://github.com/user-attachments/assets/64232623-2a08-4409-b19a-27bd930ac8f3" />



https://github.com/user-attachments/assets/c38804b1-bb67-458c-aba4-411bd0d9700f

