### PR TITLE
fix: update the arrow head color of breadcrumb component

### DIFF
--- a/.changeset/update-arrow-head-stroke-on-breadcrumbs.md
+++ b/.changeset/update-arrow-head-stroke-on-breadcrumbs.md
@@ -1,0 +1,5 @@
+---
+"@devopness/ui-react": patch
+---
+
+Update stroke color of `ArrowHead` in `BreadCrumbs` component

--- a/packages/ui/react/src/components/Primitives/BreadCrumbs/BreadCrumbs.tsx
+++ b/packages/ui/react/src/components/Primitives/BreadCrumbs/BreadCrumbs.tsx
@@ -34,6 +34,7 @@ import {
   NodeContent,
   NodeContentContainer,
 } from './BreadCrumbs.styled'
+import { getColor } from 'src/colors'
 
 const DROPDOWN_ICON_SIZE = 24
 
@@ -160,7 +161,7 @@ const CrumbLogo = ({
         </LogoContent>
         <ArrowHead
           fill="white"
-          stroke="#c7cedb"
+          stroke={getColor('slate.300')}
         />
       </LogoContainer>
     </Tooltip>
@@ -372,7 +373,7 @@ const Crumb = ({
             onClick={handleCrumbClick}
             aria-label={`Navigate to ${label}`}
             fill="white"
-            stroke="#c7cedb"
+            stroke={getColor('slate.300')}
           />
         </div>
       </CrumbWrapper>


### PR DESCRIPTION
## Description of changes
Update the color of `ArrowHead` to match with previously expected color

- [x] Updated stroke color of ArrowHead to `#e3e8f9` which is equivalent to `rgb(227, 232, 249)` as expected in the web app

## GitHub issues resolved by this PR

- [x] N/A

## Quality Assurance

- Once the changes in this PR are merged and deployed, success criteria is:  No visual or functional regression.

## More info

Before:
<img width="532" height="144" alt="Screenshot 2026-09-09 at 21 41 42" src="https://github.com/user-attachments/assets/5981d1f2-7216-431d-a21b-78a42bdad39b" />


After:
<img width="532" height="144" alt="Screenshot 2026-09-09 at 21 41 59" src="https://github.com/user-attachments/assets/59b0974f-99f4-45a1-9f54-0ace0c71d1df" />


Expected( app.devopness.com)
<img width="756" height="67" alt="Screenshot 2026-09-09 at 21 45 31" src="https://github.com/user-attachments/assets/a63c72c4-9140-43e5-849e-fdf9c0f7e42c" />
 

