### PR TITLE
fix: add react-table as peer dependency

### DIFF
--- a/.changeset/add-react-table-as-peer-dep.md
+++ b/.changeset/add-react-table-as-peer-dep.md
@@ -1,5 +1,5 @@
 ---
-"@devopness/ui-react": patch
+"@devopness/ui-react": major
 ---
 
 Add react-table as peer dependency

--- a/.changeset/add-react-table-as-peer-dep.md
+++ b/.changeset/add-react-table-as-peer-dep.md
@@ -1,0 +1,5 @@
+---
+"@devopness/ui-react": patch
+---
+
+Add react-table as peer dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -11378,6 +11378,7 @@
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
       "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -13222,7 +13223,6 @@
         "react-icons": "^5.7.0",
         "react-select": "^5.10.2",
         "react-spinners": "^0.17.1",
-        "react-table": "^7.8.0",
         "styled-components": "^6.5.3"
       },
       "devDependencies": {
@@ -13254,7 +13254,8 @@
       },
       "peerDependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-table": "^7.8.0"
       }
     },
     "packages/ui/react/node_modules/@oxc-project/types": {

--- a/packages/ui/react/package.json
+++ b/packages/ui/react/package.json
@@ -77,7 +77,6 @@
     "react-icons": "^5.7.0",
     "react-select": "^5.10.2",
     "react-spinners": "^0.17.1",
-    "react-table": "^7.8.0",
     "styled-components": "^6.5.3"
   },
   "devDependencies": {
@@ -109,7 +108,8 @@
   },
   "peerDependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-table": "^7.8.0"
   },
   "overrides": {
     "styled-components": "$styled-components",

--- a/packages/ui/react/src/components/Primitives/Table/Table.tsx
+++ b/packages/ui/react/src/components/Primitives/Table/Table.tsx
@@ -1,3 +1,7 @@
+// Note: This version of react-table is no longer maintained
+// Long term ideal solution would be to migrate to tanstack/react-table
+// Docs: https://tanstack.com/table/latest
+
 import type { ReactElement, ReactNode } from 'react'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import type {

--- a/packages/ui/react/src/components/Primitives/Table/TableRowDragDrop/TableRowDragDrop.tsx
+++ b/packages/ui/react/src/components/Primitives/Table/TableRowDragDrop/TableRowDragDrop.tsx
@@ -1,3 +1,7 @@
+// Note: This version of react-table is no longer maintained
+// Long term ideal solution would be to migrate to tanstack/react-table
+// Docs: https://tanstack.com/table/latest
+
 import type { ReactElement } from 'react'
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { DndProvider, useDrag, useDrop } from 'react-dnd'

--- a/packages/ui/react/vite.config.ts
+++ b/packages/ui/react/vite.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
         'react-dom',
         'react/jsx-runtime',
         'react/jsx-dev-runtime',
+        'react-table',
         /^react(\/.*)?$/,
       ],
       output: {


### PR DESCRIPTION
## Description of changes
- [x] Add `react-table` as peer dependency to prevent the `require` module error on the consumer app. screenshot below:
- [x] Added changeset

Long term ideal solution would be to migrate to `tanstack/react-table`

## GitHub issues resolved by this PR
- N/A

## Quality Assurance
- Once the changes in this PR are merged and deployed, success criteria is: no crash of the consumer app, validated locally.

## More info
Previous error screenshot:

<img width="1440" height="874" alt="649407408-835bc30c-7f12-4d69-97ff-e345da69654c" src="https://github.com/user-attachments/assets/1391a607-df7e-4d0a-a97e-e77440df8c69" />
